### PR TITLE
Default save path pref to safe directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # ChangeLog
 
+## UNRELEASED
+
+### Changed
+
+- The default save path for kubeConfig files is now a Lens-generated, extension-specific data directory that will survive even if the extension is uninstalled. This means any kubeConfig files saved to the default directory will not also be deleted, effectively/unintentionally removing those clusters from Lens.
+    - __NOTE about previous versions:__ If you are using the default directory from a previous version, we highly recommend you relocate any kubeConfig files it contains to a new directory of your choice, and update the directory in the extension's preferences to also be a directory of your choice, other than the current setting. Note that relocating the kubeConfig files will mean that the associated clusters will need to be re-added manually in Lens. (Another option would be to remove the clusters in Lens, update the directory, and then re-add them to Lens using the extension.)
+
 ## 2.0.3
 
 Supports Lens `>= 4.0.6`.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "2.0.3",
   "description": "Lens extension that loads Mirantis Container Cloud clusters.",
   "engines": {
-    "lens": ">= 4.0.0"
+    "lens": ">= 4.0.4"
   },
   "main": "dist/main.js",
   "renderer": "dist/renderer.js",

--- a/src/cc/store/ExtStateProvider.js
+++ b/src/cc/store/ExtStateProvider.js
@@ -228,26 +228,32 @@ export const useExtState = function () {
   };
 };
 
-export const ExtStateProvider = function ({ extension: lensExtension, ...props }) {
+export const ExtStateProvider = function ({
+  extension: lensExtension,
+  ...props
+}) {
   extension = lensExtension;
   if (!extFileFolder) {
-    extension.getExtensionFileFolder().then((folder) => {
-      extFileFolder = folder;
-      if (!pr.store.savePath) { // only use it if we didn't get a path on pr.load()
-        pr.store.savePath = extFileFolder;
-        pr.onChange();
-      }
-    })
-    .catch(() => {
-      if (!pr.store.savePath) {
-        // use the extension's installation directory as a fallback, though
-        //  this is not safe because if the extension is uninstalled, this
-        //  directory is removed by Lens, and would result in any Kubeconfig
-        //  files also being deleted, and therefore clusters lost in Lens
-        pr.store.savePath = __dirname;
-        pr.onChange();
-      }
-    });
+    extension
+      .getExtensionFileFolder()
+      .then((folder) => {
+        extFileFolder = folder;
+        if (!pr.store.savePath) {
+          // only use it if we didn't get a path on pr.load()
+          pr.store.savePath = extFileFolder;
+          pr.onChange();
+        }
+      })
+      .catch(() => {
+        if (!pr.store.savePath) {
+          // use the extension's installation directory as a fallback, though
+          //  this is not safe because if the extension is uninstalled, this
+          //  directory is removed by Lens, and would result in any Kubeconfig
+          //  files also being deleted, and therefore clusters lost in Lens
+          pr.store.savePath = __dirname;
+          pr.onChange();
+        }
+      });
   }
 
   // load state from storage only once

--- a/src/cc/store/ExtStateProvider.js
+++ b/src/cc/store/ExtStateProvider.js
@@ -3,6 +3,7 @@
 //
 
 import React, { createContext, useContext, useState, useMemo } from 'react';
+import propTypes from 'prop-types';
 import rtv from 'rtvjs';
 import { cloneDeep, cloneDeepWith } from 'lodash';
 import { AuthAccess } from '../auth/AuthAccess';
@@ -28,7 +29,9 @@ const extStateTs = {
   addToNew: [rtv.EXPECTED, rtv.BOOLEAN], // if workspaces should be created to match cluster namespaces
 };
 
+let extension; // {LensErendererExtension} instance reference
 let storeLoaded = false; // {boolean} true if the store has been loaded from storage
+let extFileFolder = null; // {string|undefined} Undefined until the folder path is loaded async from Lens
 
 //
 // Store
@@ -42,7 +45,7 @@ class ExtStateProviderStore extends ProviderStore {
       cloudUrl: null,
       username: null,
       authAccess: new AuthAccess(),
-      savePath: __dirname, // extension's `./dist` directory by default
+      savePath: extFileFolder || null,
       offline: true,
       addToNew: true,
     };
@@ -106,7 +109,7 @@ class ExtStateProviderStore extends ProviderStore {
       } catch (err) {
         // eslint-disable-next-line no-console -- OK to show errors
         console.error(
-          `[${pkg.name}/ExtStateProviderStore.load()] ERROR: ${err.message}`,
+          `[${pkg.name}/ExtStateProviderStore.load()] ERROR: Invalid state, reverting to defaults: ${err.message}`,
           err
         );
         useInitialState = true;
@@ -225,8 +228,30 @@ export const useExtState = function () {
   };
 };
 
-export const ExtStateProvider = function (props) {
+export const ExtStateProvider = function ({ extension: lensExtension, ...props }) {
+  extension = lensExtension;
+  if (!extFileFolder) {
+    extension.getExtensionFileFolder().then((folder) => {
+      extFileFolder = folder;
+      if (!pr.store.savePath) { // only use it if we didn't get a path on pr.load()
+        pr.store.savePath = extFileFolder;
+        pr.onChange();
+      }
+    })
+    .catch(() => {
+      if (!pr.store.savePath) {
+        // use the extension's installation directory as a fallback, though
+        //  this is not safe because if the extension is uninstalled, this
+        //  directory is removed by Lens, and would result in any Kubeconfig
+        //  files also being deleted, and therefore clusters lost in Lens
+        pr.store.savePath = __dirname;
+        pr.onChange();
+      }
+    });
+  }
+
   // load state from storage only once
+  // NOTE: this is sync while `extension.getExtensionFileFolder()` is async
   if (!storeLoaded) {
     pr.load();
     storeLoaded = true;
@@ -242,4 +267,8 @@ export const ExtStateProvider = function (props) {
   pr.setState = setState;
 
   return <ExtStateContext.Provider value={value} {...props} />;
+};
+
+ExtStateProvider.propTypes = {
+  extension: propTypes.object.isRequired,
 };

--- a/src/page.tsx
+++ b/src/page.tsx
@@ -73,7 +73,7 @@ export const AddClusterPage = function ({ extension }: Props) {
 
   return (
     <ThemeProvider theme={theme}>
-      <ExtStateProvider>
+      <ExtStateProvider extension={extension}>
         <ConfigProvider>
           <AuthProvider>
             <ClustersProvider>


### PR DESCRIPTION
Relies on https://github.com/lensapp/lens/pull/1785 to work, which is in Lens 4.0.4.

Lens now generates data directories for extensions that are safe,
even if the extension gets uninstalled. This commit uses that
generated directory as the new default save path.