### PR TITLE
Prevent non-ready and deleted clusters from being added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Fixed: When adding only one cluster, that being the Management Cluster, and this resulting in the creation of a new `mcc_default` workspace, the extension would crash because it failed to find the ID of the new workspace to activate.
 - Added namespace/name detail of cluster in console error if we fail to parse data for any discovered cluster(s) to make it easier to identify which cluster the extension can't load.
+- Fixed: Clusters that aren't ready (i.e. still being provisioned), which means a kubeConfig can't be generated for them yet, are now gracefully handled instead of resulting in a handled exception output to the console. They will still show-up in the list of clusters to add, but will now be disabled/un-selectable and will have a "(not ready)" label associated with them.
+- Fixed: Clusters being deleted will no longer show-up in the list of clusters to add.
 
 ## v2.1.1
 

--- a/src/cc/View.js
+++ b/src/cc/View.js
@@ -226,7 +226,8 @@ export const View = function ({ extension }) {
 
   const handleClusterSelectAll = useCallback(
     function ({ selected }) {
-      setSelectedClusters(selected ? clusters.concat() : []);
+      // shallow-clone by filtering for ready clusters
+      setSelectedClusters(selected ? clusters.filter((cl) => cl.ready) : []);
     },
     [clusters]
   );
@@ -454,9 +455,11 @@ export const View = function ({ extension }) {
         setSelectedClusters(null); // clear selection because we (re-)loading clusters
       } else if (clustersLoaded && !selectedClusters) {
         // set initial selection, skipping management clusters since they typically
-        //  are of less importance
+        //  are of less importance, as well as clusters that aren't ready yet
         // also, shallow clone the array to disassociate from source
-        setSelectedClusters(clusters.filter((cl) => !cl.isManagementCluster));
+        setSelectedClusters(
+          clusters.filter((cl) => cl.ready && !cl.isManagementCluster)
+        );
       } else if (clustersLoaded && activeEventType === EXT_EVENT_ADD_CLUSTERS) {
         setLoaderMessage(null); // don't show the loader again when user actually adds the clusters
       }

--- a/src/cc/store/ClustersProvider.js
+++ b/src/cc/store/ClustersProvider.js
@@ -21,8 +21,12 @@ class ClustersProviderStore extends ProviderStore {
     return {
       ...super.makeNew(),
       data: {
-        namespaces: [], // {Array<Namespace>}
-        clusters: [], // {Array<Cluster>} use `Cluster.namespace` to find groups
+        namespaces: [], // @type {Array<Namespace>}
+
+        // All clusters except any that are in progress of being deleted; use
+        //  `Cluster.namespace` to find groups
+        // @type {Array<Cluster>}
+        clusters: [],
       },
     };
   }
@@ -237,7 +241,9 @@ const _loadData = async function (cloudUrl, config, authAccess) {
     if (clResults.error) {
       pr.store.error = clResults.error;
     } else {
-      pr.store.data.clusters = clResults.clusters;
+      pr.store.data.clusters = clResults.clusters.filter(
+        (cluster) => !cluster.deleteInProgress
+      );
     }
   }
 

--- a/src/strings.ts
+++ b/src/strings.ts
@@ -108,6 +108,7 @@ export const login: Dict = {
 
 export const clusterList: Dict = {
   title: () => 'Select clusters',
+  notReady: () => '(not ready)',
   action: {
     selectAll: {
       label: () => 'Select all',


### PR DESCRIPTION
Fixes #95

The list of clusters to add will now omit any clusters being deleted,
and will show, but not allow to be selected, clusters that are still
being provisioned. Those will also have a "(not ready)" label on them.

<img width="645" alt="Screen Shot 2021-02-04 at 11 37 23 AM" src="https://user-images.githubusercontent.com/2855350/106934844-3e5e3180-66e0-11eb-9f61-097a14cb09b5.png">
