### PR TITLE
Wrapping emotion instance into CacheProvider

### DIFF
--- a/src/page.tsx
+++ b/src/page.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { ThemeProvider } from '@emotion/react';
+import { ThemeProvider, CacheProvider } from '@emotion/react';
 import { View } from './cc/View';
 import { ExtStateProvider } from './cc/store/ExtStateProvider';
 import { ConfigProvider } from './cc/store/ConfigProvider';
@@ -8,6 +8,7 @@ import { ClustersProvider } from './cc/store/ClustersProvider';
 import { ClusterActionsProvider } from './cc/store/ClusterActionsProvider';
 import { lightThemeClassName, lightTheme, darkTheme } from './cc/theme';
 import ExtensionRenderer from './renderer';
+import createCache from "@emotion/cache";
 
 export { ContainerCloudIcon } from './cc/ContainerCloudIcon';
 
@@ -72,18 +73,20 @@ export const AddClusterPage = function ({ extension }: Props) {
   //
 
   return (
-    <ThemeProvider theme={theme}>
-      <ExtStateProvider extension={extension}>
-        <ConfigProvider>
-          <AuthProvider>
-            <ClustersProvider>
-              <ClusterActionsProvider extension={extension}>
-                <View extension={extension} />
-              </ClusterActionsProvider>
-            </ClustersProvider>
-          </AuthProvider>
-        </ConfigProvider>
-      </ExtStateProvider>
-    </ThemeProvider>
+    <CacheProvider value={createCache({ key: "lens-extension-cc" })}>
+      <ThemeProvider theme={theme}>
+        <ExtStateProvider extension={extension}>
+          <ConfigProvider>
+            <AuthProvider>
+              <ClustersProvider>
+                <ClusterActionsProvider extension={extension}>
+                  <View extension={extension} />
+                </ClusterActionsProvider>
+              </ClustersProvider>
+            </AuthProvider>
+          </ConfigProvider>
+        </ExtStateProvider>
+      </ThemeProvider>
+    </CacheProvider>
   );
 };

--- a/src/page.tsx
+++ b/src/page.tsx
@@ -8,7 +8,7 @@ import { ClustersProvider } from './cc/store/ClustersProvider';
 import { ClusterActionsProvider } from './cc/store/ClusterActionsProvider';
 import { lightThemeClassName, lightTheme, darkTheme } from './cc/theme';
 import ExtensionRenderer from './renderer';
-import createCache from "@emotion/cache";
+import createCache from '@emotion/cache';
 
 export { ContainerCloudIcon } from './cc/ContainerCloudIcon';
 
@@ -73,7 +73,7 @@ export const AddClusterPage = function ({ extension }: Props) {
   //
 
   return (
-    <CacheProvider value={createCache({ key: "lens-extension-cc" })}>
+    <CacheProvider value={createCache({ key: 'lens-extension-cc' })}>
       <ThemeProvider theme={theme}>
         <ExtStateProvider extension={extension}>
           <ConfigProvider>


### PR DESCRIPTION
Lens is using architecture when multiple emotion instances can be activated. Currently, all of them shares same `<style>` tag causing dropping all of the styles inside of it. Original bug: https://github.com/lensapp/lens/issues/2219.

This PR wraps all `emotion` contents into `<CacheProvider/>` which helps to isolate MCC Extension styles and prevents other emotion styles to be removed.

Part of https://github.com/lensapp/lens/pull/2365

Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>