### PR TITLE
[PRODX-19642] Fix crash on load from missing cloudUrl

### DIFF
--- a/src/renderer/auth/Cloud.js
+++ b/src/renderer/auth/Cloud.js
@@ -370,6 +370,7 @@ export class Cloud {
       idpClientId: this.idpClientId,
 
       username: this.username,
+      cloudUrl: this.cloudUrl,
     };
   }
 }


### PR DESCRIPTION
After #622, we weren't serializing the new property to JSON, so
it was undefined when cloning the Cloud object.