### PR TITLE
Fix CloudStore serialization of clouds property

### DIFF
--- a/src/renderer/components/GlobalPage/ConnectionBlock.js
+++ b/src/renderer/components/GlobalPage/ConnectionBlock.js
@@ -61,7 +61,7 @@ export const ConnectionBlock = () => {
         setLoading(true);
       } else if (status === CONNECTION_STATUSES.CONNECTED) {
         newCloud.cleanStatusListener('statusListener'); // it's not necessary to clean this. But just in case
-        cloudStore.clouds[normUrl] = newCloud.toJSON();
+        cloudStore.clouds[normUrl] = newCloud;
         setLoading(false);
       } else if (status === CONNECTION_STATUSES.DISCONNECTED) {
         checkError(newCloud);

--- a/src/renderer/eventBus.ts
+++ b/src/renderer/eventBus.ts
@@ -60,6 +60,7 @@ export const extEventOauthCodeTs = {
   state: [rtv.OPTIONAL, rtv.STRING],
   data: {
     code: rtv.STRING,
+    state: [rtv.OPTIONAL, rtv.STRING],
     error: [rtv.OPTIONAL, rtv.STRING],
     error_description: [rtv.OPTIONAL, rtv.STRING],
   },

--- a/src/renderer/renderer.tsx
+++ b/src/renderer/renderer.tsx
@@ -179,12 +179,10 @@ export default class ExtensionRenderer extends LensExtension {
   protected handleProtocolOauthCode = ({ search }) => {
     this.navigate(ROUTE_GLOBAL_PAGE);
 
-    const { state, ...data } = search;
-
     dispatchExtEvent({
       type: EXT_EVENT_OAUTH_CODE,
-      data,
-      state,
+      state: search.state,
+      data: search,
     });
   };
 


### PR DESCRIPTION
Now we can store Cloud instances directly inside CloudStore.clouds.

I also fixed an issue with passing the data to the OAuth event:
We shouldn't remove `state` from the data when dispatching
the event so that the data payload remains intact for any
handlers.