### PR TITLE
Enable opening clusters in Lens based on context instead of UID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # ChangeLog
 
+## UNRELEASED
+
+### Minor
+
+- Added ability to open clusters from the MCC browser UI using kubeconfig context name so that even clusters added by downloading the kubeconfig from MCC and pasting into Lens can be opened from the browser by choosing the "Open in Lens" feature.
+
 ## v3.0.4
 
 ### Patch

--- a/src/renderer/components/GlobalPage/ClusterList.js
+++ b/src/renderer/components/GlobalPage/ClusterList.js
@@ -131,7 +131,7 @@ export const ClusterList = function ({
             cluster // list ALL clusters
           ) => {
             const inLens = lensClusters.find(
-              (lc) => lc.metadata.uid === cluster.id
+              (lc) => lc.spec.kubeconfigContext === cluster.contextName
             );
             return (
               <Component.Checkbox

--- a/src/renderer/eventBus.ts
+++ b/src/renderer/eventBus.ts
@@ -43,6 +43,7 @@ type EventQueue = Array<ExtensionEvent>;
  *
  * `event.data` is an object with the following properties:
  * - cloudUrl {string} MCC instance base URL.
+ * - username {string} Username of a user with access to the cluster.
  * - namespace {string} Name of the namespace that contains the cluster.
  * - clusterName (string) Name of the cluster being activated.
  * - clusterId {string} ID of the cluster being activated.
@@ -54,6 +55,7 @@ export const extEventActivateClusterTs = {
   type: [rtv.STRING, { exact: EXT_EVENT_ACTIVATE_CLUSTER }],
   data: {
     cloudUrl: rtv.STRING,
+    username: [rtv.OPTIONAL, rtv.STRING], // optional since older version of MCC will not send it, and we'll fallback to using clusterId in that case
     namespace: rtv.STRING,
     clusterName: rtv.STRING,
     clusterId: rtv.STRING,

--- a/src/renderer/renderer.tsx
+++ b/src/renderer/renderer.tsx
@@ -95,6 +95,7 @@ export default class ExtensionRenderer extends LensExtension {
       type: EXT_EVENT_ACTIVATE_CLUSTER,
       data: {
         cloudUrl: search.cloudUrl,
+        username: search.username,
         namespace: search.namespace,
         clusterName: search.clusterName,
         clusterId: search.clusterId,

--- a/src/renderer/store/Cluster.js
+++ b/src/renderer/store/Cluster.js
@@ -15,13 +15,15 @@ const getServerUrl = function (data) {
  * MCC cluster.
  * @class Cluster
  * @param {Object} data Raw cluster data payload from the API.
+ * @param {string} username Username used to access the cluster.
  */
 export class Cluster {
-  constructor(data) {
+  constructor(data, username) {
     DEV_ENV &&
       rtv.verify(
-        { data },
+        { username, data },
         {
+          username: rtv.STRING,
           data: {
             metadata: {
               name: rtv.STRING,
@@ -75,6 +77,9 @@ export class Cluster {
       );
 
     // NOTE: regardless of `ready`, we assume `data.metadata` is always available
+
+    /** @member {string} */
+    this.username = username;
 
     /** @member {string} */
     this.id = data.metadata.uid;
@@ -155,5 +160,11 @@ export class Cluster {
 
     /** @member {sting|null} */
     this.awsRegion = this.ready ? data.spec.providerSpec.region : null;
+  }
+
+  /** @member {string} contextName Kubeconfig context name for this cluster. */
+  get contextName() {
+    // NOTE: this mirrors how MCC generates kubeconfig context names
+    return `${this.username}@${this.namespace}@${this.name}`;
   }
 }

--- a/src/renderer/store/ClusterDataProvider.js
+++ b/src/renderer/store/ClusterDataProvider.js
@@ -136,9 +136,10 @@ const _fetchNamespaces = async function (
 /**
  * Deserialize the raw list of cluster data from the API into Cluster objects.
  * @param {Object} body Data response from /list/cluster API.
+ * @param {AuthAccess} authAccess The AuthAccess object used to access the clusters.
  * @returns {Array<Cluster>} Array of Cluster objects.
  */
-const _deserializeClustersList = function (body) {
+const _deserializeClustersList = function (body, authAccess) {
   if (!body || !Array.isArray(body.items)) {
     return { error: strings.clusterDataProvider.error.invalidClusterPayload() };
   }
@@ -147,7 +148,7 @@ const _deserializeClustersList = function (body) {
     data: body.items
       .map((item, idx) => {
         try {
-          return new Cluster(item);
+          return new Cluster(item, authAccess.username);
         } catch (err) {
           logger.error(
             'ClusterDataProvider._deserializeClustersList()',
@@ -206,7 +207,7 @@ const _fetchClusters = async function (
   let dsError;
 
   results.every((result) => {
-    const { data, error } = _deserializeClustersList(result.body);
+    const { data, error } = _deserializeClustersList(result.body, authAccess);
     if (error) {
       dsError = { error };
       return false; // break

--- a/src/util/templates.js
+++ b/src/util/templates.js
@@ -3,6 +3,19 @@
 //
 
 /**
+ * Generates a kubeconfig context name for a cluster in the same way that MCC does
+ *  when it generates cluster-specific kubeconfig files.
+ * @returns {string} Context name.
+ */
+export const mkClusterContextName = function ({
+  username,
+  namespace,
+  clusterName,
+}) {
+  return `${username}@${namespace}@${clusterName}`;
+};
+
+/**
  * Generates a KubeConfig for a specific cluster.
  * @param {Object} config Configuration parameters for the template.
  * @param {string} config.username Username for authentication.
@@ -34,10 +47,10 @@ export const kubeConfigTemplate = function ({
           cluster: cluster.name,
           user: username,
         },
-        name: `${username}@${cluster.name}`,
+        name: cluster.contextName,
       },
     ],
-    'current-context': `${username}@${cluster.name}`,
+    'current-context': cluster.contextName,
     kind: 'Config',
     preferences: {},
     users: [


### PR DESCRIPTION
When manually adding a cluster from MCC into Lens via downloaded
kubeconfig, Lens generates its own UID for the cluster since the
UID isn't given in the kubeconfig. That means we can't search
by UID when opening a cluster from MCC in the browser that
wasn't added via the extension.

This changes to searching by the same context name that MCC generates
in its kubeconfigs. So now we can find any cluster, whether it was
manually added, or added via the extension.

Note, however, we still fall back to using the cluster UID if we
don't get a username in the "activate cluster" event, as that
would be triggered by an older version of MCC that doesn't have
the fix to send over the username.