### PR TITLE
[PRODX-21176] Enable opening clusters in Lens based on context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # ChangeLog
 
-## UNRELEASED
+## v3.0.4
 
 ### Patch
 

--- a/src/common/Cloud.js
+++ b/src/common/Cloud.js
@@ -4,11 +4,11 @@ import { logger } from '../util/logger';
 import * as strings from '../strings';
 import * as ssoUtil from '../util/ssoUtil';
 import {
+  EXT_EVENT_OAUTH_CODE,
   extEventOauthCodeTs,
   addExtEventHandler,
   removeExtEventHandler,
 } from '../renderer/eventBus';
-import { EXT_EVENT_OAUTH_CODE } from '../constants';
 
 /**
  * Determines if a date has passed.

--- a/src/constants.js
+++ b/src/constants.js
@@ -89,8 +89,6 @@ export const ipcEvents = deepFreeze({
   },
 });
 
-export const EXT_EVENT_OAUTH_CODE = 'oauth/code';
-
 /** Welcome Page */
 export const welcomePage = deepFreeze({
   /** And more! button */

--- a/src/renderer/auth/clients/AuthClient.js
+++ b/src/renderer/auth/clients/AuthClient.js
@@ -1,7 +1,7 @@
 import queryString from 'query-string';
 import { request } from '../../../util/netUtil';
 import * as strings from '../../../strings';
-import { EXT_EVENT_OAUTH_CODE } from '../../../constants';
+import { EXT_EVENT_OAUTH_CODE } from '../../eventBus';
 import pkg from '../../../../package.json';
 
 const redirectUri = `lens://extension/${pkg.name}/${EXT_EVENT_OAUTH_CODE}`;

--- a/src/renderer/components/GlobalPage/ClusterList.js
+++ b/src/renderer/components/GlobalPage/ClusterList.js
@@ -131,7 +131,7 @@ export const ClusterList = function ({
             cluster // list ALL clusters
           ) => {
             const inLens = lensClusters.find(
-              (lc) => lc.metadata.uid === cluster.id
+              (lc) => lc.spec.kubeconfigContext === cluster.contextName
             );
             return (
               <Component.Checkbox

--- a/src/renderer/components/GlobalPage/SyncView.js
+++ b/src/renderer/components/GlobalPage/SyncView.js
@@ -23,12 +23,10 @@ import { Loader } from '../Loader';
 import { ErrorPanel } from '../ErrorPanel';
 import { PreferencesPanel } from './PreferencesPanel';
 import * as strings from '../../../strings';
-import {
-  catalog as catalogConsts,
-  EXT_EVENT_OAUTH_CODE,
-} from '../../../constants';
+import { catalog as catalogConsts } from '../../../constants';
 import { layout, mixinColumnStyles, mixinPageStyles } from '../styles';
 import {
+  EXT_EVENT_OAUTH_CODE,
   addExtEventHandler,
   removeExtEventHandler,
   extEventOauthCodeTs,

--- a/src/renderer/eventBus.ts
+++ b/src/renderer/eventBus.ts
@@ -5,7 +5,6 @@
 //
 
 import * as rtv from 'rtvjs';
-import { EXT_EVENT_OAUTH_CODE } from '../constants';
 
 //
 // TYPES
@@ -46,6 +45,30 @@ type EventQueue = Array<ExtensionEvent>;
 //
 
 /**
+ * Activates an existing cluster in Lens.
+ *
+ * `event.data` is an object with the following properties:
+ * - cloudUrl {string} MCC instance base URL.
+ * - username {string} Username of a user with access to the cluster.
+ * - namespace {string} Name of the namespace that contains the cluster.
+ * - clusterName (string) Name of the cluster being activated.
+ * - clusterId {string} ID of the cluster being activated.
+ */
+export const EXT_EVENT_ACTIVATE_CLUSTER = 'activateCluster';
+
+/** RTV Typeset to validate the event object for an `EXT_EVENT_ACTIVATE_CLUSTER` event. */
+export const extEventActivateClusterTs = {
+  type: [rtv.STRING, { exact: EXT_EVENT_ACTIVATE_CLUSTER }],
+  data: {
+    cloudUrl: rtv.STRING,
+    username: rtv.STRING,
+    namespace: rtv.STRING,
+    clusterName: rtv.STRING,
+    clusterId: rtv.STRING,
+  },
+};
+
+/**
  * OAuth (SSO) redirect route after user gives Lens access permission.
  *
  * `event.data` is an object with the following properties:
@@ -54,6 +77,8 @@ type EventQueue = Array<ExtensionEvent>;
  * - [error] (string} Optional error message.
  * - [error_description] {string} Optional error description.
  */
+export const EXT_EVENT_OAUTH_CODE = 'oauth/code';
+
 /** RTV Typeset to validate the event object for an `EXT_EVENT_OAUTH_CODE` event. */
 export const extEventOauthCodeTs = {
   type: [rtv.STRING, { exact: EXT_EVENT_OAUTH_CODE }],

--- a/src/renderer/store/Cluster.js
+++ b/src/renderer/store/Cluster.js
@@ -15,13 +15,15 @@ const getServerUrl = function (data) {
  * MCC cluster.
  * @class Cluster
  * @param {Object} data Raw cluster data payload from the API.
+ * @param {string} username Username used to access the cluster.
  */
 export class Cluster {
-  constructor(data) {
+  constructor(data, username) {
     DEV_ENV &&
       rtv.verify(
-        { data },
+        { username, data },
         {
+          username: rtv.STRING,
           data: {
             metadata: {
               name: rtv.STRING,
@@ -75,6 +77,9 @@ export class Cluster {
       );
 
     // NOTE: regardless of `ready`, we assume `data.metadata` is always available
+
+    /** @member {string} */
+    this.username = username;
 
     /** @member {string} */
     this.id = data.metadata.uid;
@@ -155,5 +160,11 @@ export class Cluster {
 
     /** @member {sting|null} */
     this.awsRegion = this.ready ? data.spec.providerSpec.region : null;
+  }
+
+  /** @member {string} contextName Kubeconfig context name for this cluster. */
+  get contextName() {
+    // NOTE: this mirrors how MCC generates kubeconfig context names
+    return `${this.username}@${this.namespace}@${this.name}`;
   }
 }

--- a/src/renderer/store/ClusterDataProvider.js
+++ b/src/renderer/store/ClusterDataProvider.js
@@ -136,9 +136,10 @@ const _fetchNamespaces = async function (
 /**
  * Deserialize the raw list of cluster data from the API into Cluster objects.
  * @param {Object} body Data response from /list/cluster API.
+ * @param {Cloud} cloud The Cloud object used to access the clusters.
  * @returns {Array<Cluster>} Array of Cluster objects.
  */
-const _deserializeClustersList = function (body) {
+const _deserializeClustersList = function (body, cloud) {
   if (!body || !Array.isArray(body.items)) {
     return { error: strings.clusterDataProvider.error.invalidClusterPayload() };
   }
@@ -147,7 +148,7 @@ const _deserializeClustersList = function (body) {
     data: body.items
       .map((item, idx) => {
         try {
-          return new Cluster(item);
+          return new Cluster(item, cloud.username);
         } catch (err) {
           logger.error(
             'ClusterDataProvider._deserializeClustersList()',
@@ -201,7 +202,7 @@ const _fetchClusters = async function (cloudUrl, config, cloud, namespaces) {
   let dsError;
 
   results.every((result) => {
-    const { data, error } = _deserializeClustersList(result.body);
+    const { data, error } = _deserializeClustersList(result.body, cloud);
     if (error) {
       dsError = { error };
       return false; // break

--- a/src/util/templates.js
+++ b/src/util/templates.js
@@ -3,6 +3,19 @@
 //
 
 /**
+ * Generates a kubeconfig context name for a cluster in the same way that MCC does
+ *  when it generates cluster-specific kubeconfig files.
+ * @returns {string} Context name.
+ */
+export const mkClusterContextName = function ({
+  username,
+  namespace,
+  clusterName,
+}) {
+  return `${username}@${namespace}@${clusterName}`;
+};
+
+/**
  * Generates a KubeConfig for a specific cluster.
  * @param {Object} config Configuration parameters for the template.
  * @param {string} config.username Username for authentication.
@@ -34,10 +47,10 @@ export const kubeConfigTemplate = function ({
           cluster: cluster.name,
           user: username,
         },
-        name: `${username}@${cluster.name}`,
+        name: cluster.contextName,
       },
     ],
-    'current-context': `${username}@${cluster.name}`,
+    'current-context': cluster.contextName,
     kind: 'Config',
     preferences: {},
     users: [


### PR DESCRIPTION
When manually adding a cluster from MCC into Lens via downloaded
kubeconfig, Lens generates its own UID for the cluster since the
UID isn't given in the kubeconfig. That means we can't search
by UID when opening a cluster from MCC in the browser that
wasn't added via the extension.

This changes to searching by the same context name that MCC generates
in its kubeconfigs. So now we can find any cluster, whether it was
manually added, or added via the extension.