### PR TITLE
Fix CVE-2022-0484

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ This is an early alpha build and is not fully functional. Use at your own risk.
 - No syncing actually takes place yet
 - Selective Sync button is not functional
 
+## v3.1.1
+
+### Patch
+
+- Fix `CVE-2022-0484` security issue allowing remote code execution by an attacker providing a spoofed MCC management cluster URL that has a `config.js` with a malicious value for the Keycloak URL (e.g. `file:/...` which could run code on the local system).
+    - Going forward, only `http/s:` Keycloak URLs are permitted.
+
+## v3.1.0
+
+### Minor
+
+- Added ability to open clusters from the MCC browser UI using kubeconfig context name so that even clusters added by downloading the kubeconfig from MCC and pasting into Lens can be opened from the browser by choosing the "Open in Lens" feature.
+    - This change is backward-compatible with older versions of MCC that still only send the cluster UID to Lens to use for finding a cluster and opening it. For these versions of MCC, manually-added clusters will not be found (as before). Only clusters added via the extension (whether by choosing "Add to Lens" in MCC, or by loading the extension and selecting a cluster from the list) will be found by cluster UID.
+
 ## v3.0.4
 
 ### Patch

--- a/src/strings.ts
+++ b/src/strings.ts
@@ -92,13 +92,6 @@ export const managementClusters = {
   },
 };
 
-export const configProvider: Dict = {
-  error: {
-    unexpectedToken: () =>
-      "A problem occurred while retrieving the instance's configuration details. Make sure the instance URL is correct.",
-  },
-};
-
 export const authUtil: Dict = {
   error: {
     sessionExpired: () => 'Session expired',
@@ -114,6 +107,8 @@ export const netUtil: Dict = {
     reason: (message = '') => `Reason: "${message}"`,
     serverResponse: (statusText = '') => `Server response: "${statusText}".`,
     responseCode: (status = -1) => `Server response code: ${status}`,
+    invalidBrowserUrl: (url) =>
+      `Cannot open URL in browser (must be http/s): "${url}"`,
   },
 };
 
@@ -292,6 +287,22 @@ export const welcome: Dict = {
   },
 };
 
+export const ssoUtil: Dict = {
+  error: {
+    ssoNotSupported: () =>
+      'The management cluster does not support SSO authorization.',
+    invalidSsoUrl: (url) =>
+      `The management cluster's Keycloak URL cannot be opened in a browser (must be http/s): "${url}"`,
+  },
+};
+
+export const cloud: Dict = {
+  error: {
+    unexpectedToken: () =>
+      "A problem occurred while retrieving the management cluster's configuration details. Make sure the management cluster URL is correct.",
+  },
+};
+
 export const extendedCloud: Dict = {
   error: {
     credentials: () =>
@@ -299,6 +310,7 @@ export const extendedCloud: Dict = {
     sshKeys: () => 'Failed to parse SSH Keys payload: Unexpected data format.',
   },
 };
+
 export const connectionStatuses = {
   cloud: {
     connected: () => 'Connected',

--- a/src/util/netUtil.js
+++ b/src/util/netUtil.js
@@ -1,7 +1,10 @@
 import { get } from 'lodash';
 import nodeFetch from 'node-fetch';
 import https from 'https';
+import { Common } from '@k8slens/extensions';
 import * as strings from '../strings';
+
+const { Util } = Common;
 
 // SECURITY: get around any MCC instance certificate issues
 const httpsAgent = DEV_UNSAFE_NO_CERT
@@ -36,6 +39,23 @@ function splitOnWords(key) {
  */
 export function normalizeUrl(url) {
   return url.replace(/\/$/, ''); // remove end slash if any
+}
+
+/**
+ * Opens the given URL in the native operating system. Permits only http/s URLs.
+ * @param {string} url Must be http/s.
+ * @throws {Error} If `url` does not use a permitted protocol: http or https.
+ */
+export function openBrowser(url) {
+  // SECURITY: This addresses CVE-2022-0484 where `openExternal()` provided by
+  //  Lens is designed to open _anything_, which means even file: protocols
+  //  that would result in local code execution (if MCC URL is spoofed and has
+  //  a config.js that provides a file: URL for Keycloak, for example)
+  if (!url.match(/^https?:/)) {
+    throw new Error(strings.netUtil.error.invalidBrowserUrl(url));
+  }
+
+  Util.openExternal(url); // open in default browser
 }
 
 /**


### PR DESCRIPTION
This addresses CVE-2022-0484 where `openExternal()` provided by
Lens is designed to open _anything_, which means even `file:` protocols
that would result in local code execution (if MCC URL is spoofed and has
a config.js that provides a `file:` URL for Keycloak, for example).

NOTE: This ports commit 23330ad9181022157ee51fedbdfb4d45b848cf49 on
`v3-maint` branch to `master`.