### PR TITLE
Optimize ExtendedCloud data fetches, fix bugs

### DIFF
--- a/src/common/ExtendedCloud.js
+++ b/src/common/ExtendedCloud.js
@@ -178,11 +178,13 @@ const _deserializeClustersList = function (body, cloud) {
         try {
           return new Cluster(item, cloud.username);
         } catch (err) {
-          logger.error(
+          logger.warn(
             'ExtendedCloud._deserializeClustersList()',
-            `Failed to deserialize cluster ${idx} (namespace/name="${
+            `Ignoring cluster ${idx} (namespace/name="${
               item?.metadata?.namespace ?? '<unknown>'
-            }/${item?.metadata?.name ?? '<unknown>'}"): ${err.message}`,
+            }/${
+              item?.metadata?.name ?? '<unknown>'
+            }") because it could not be deserialized: ${err.message}`,
             err
           );
           return undefined;
@@ -210,9 +212,9 @@ const _deserializeNamespacesList = function (body) {
         try {
           return new Namespace(item);
         } catch (err) {
-          logger.error(
+          logger.warn(
             'ExtendedCloud._deserializeNamespacesList()',
-            `Failed to deserialize namespace ${idx}: ${err.message}`,
+            `Ignoring namespace ${idx} because it could not be deserialized: ${err.message}`,
             err
           );
           return undefined;

--- a/src/renderer/auth/authUtil.js
+++ b/src/renderer/auth/authUtil.js
@@ -51,39 +51,57 @@ export function extractJwtPayload(token) {
 }
 
 /**
- * [ASYNC] Refreshes the auth tokens.
- * @param {string} baseUrl MCC URL. Must NOT end with a slash.
- * @param {Object} config MCC Configuration object.
- * @param {Cloud} cloud An Cloud object.
- * @returns {string|undefined} On success, the `cloud` object is updated with new tokens
- *  and expiries, and `undefined` is returned. On error, `cloud` remains unchanged,
- *  and an error message is returned.
+ * [ASYNC] Refreshes a Cloud's auth tokens.
+ * @param {Cloud} cloud A Cloud object.
+ * @returns {boolean} On success, the `cloud` object is updated with new tokens and
+ *  `true` is returned. On error, `cloud.connectError` is updated with an error message,
+ *  and `false` is returned.
  */
-export async function refreshToken(baseUrl, config, cloud) {
-  const authClient = new AuthClient({ baseUrl, config });
+export async function cloudRefresh(cloud) {
+  console.log(
+    `@@@@@@@ authUtil.cloudRefresh(): refreshing tokens for cloud=${cloud}`
+  ); // DEBUG LOG
+
+  const authClient = new AuthClient({
+    baseUrl: cloud.cloudUrl,
+    config: cloud.config,
+  });
   const { response, body, error } = await authClient.refreshToken(
     cloud.refreshToken
   );
 
   if (response && response.status === 400) {
-    return strings.authUtil.error.sessionExpired();
+    cloud.connectError = strings.authUtil.error.sessionExpired();
   } else if (error) {
-    return error;
+    cloud.connectError = error;
   }
 
+  if (cloud.connectError) {
+    console.error(
+      `@@@@@@@ authUtil.cloudRefresh(): ERROR refreshing tokens for cloud=${cloud}`
+    ); // DEBUG LOG
+    return false;
+  }
+
+  console.log(
+    `@@@@@@@ authUtil.cloudRefresh(): updating tokens on cloud=${cloud}`
+  ); // DEBUG LOG
   // token was refreshed
   cloud.updateTokens(body);
+
+  return true;
 }
 
 /**
- * Terminates the session.
- * @param {string} baseUrl MCC URL. Must NOT end with a slash.
- * @param {Object} config MCC Configuration object.
+ * Terminates a Cloud session.
  * @param {Cloud} cloud An Cloud object.
  * @returns {string|undefined} `undefined` if successful; error message otherwise.
  */
-export async function logout(baseUrl, config, cloud) {
-  const authClient = new AuthClient({ baseUrl, config });
+export async function cloudLogout(cloud) {
+  const authClient = new AuthClient({
+    baseUrl: cloud.cloudUrl,
+    config: cloud.config,
+  });
   const { error: refreshError } = await authClient.logout(cloud.refreshToken);
 
   if (refreshError) {
@@ -94,60 +112,66 @@ export async function logout(baseUrl, config, cloud) {
 }
 
 /**
- * Makes an authenticated request using the tokens in the `cloud` object.
+ * Makes an authenticated request using the given Cloud.
  * @param {Object} options
- * @param {string} options.baseUrl MCC URL. Must NOT end with a slash.
- * @param {Object} options.config MCC Configuration object.
  * @param {Cloud} options.cloud An Cloud object. NOTE: This instance will be UPDATED
  *  with new tokens if the token is expired and successfully refreshed.
  * @param {string} options.method Name of the method to call on the `entity`.
  * @param {string} options.entity One of the keys from `entityToClient`, the API entity
  *  on which to call the `method`.
  * @param {Object} [options.args] Optional arguments for the `method` on the `entity`.
- * @returns {Object} If successful, `{body: Object}`; otherwise, `{error: string, status: number}`.
+ * @returns {Object} If successful, `{body: Object, tokensRefreshed: boolean, cloud: Cloud}`;
+ *  otherwise, `{error: string, status: number, cloud: Cloud}`. `tokensRefreshed` is true if
+ *  the cloud's access token had expired and was successfully refreshed during the process
+ *  of making the request. In either case, `cloud` is a reference to the original `cloud`
+ *  given to make the request.
  */
-export async function authedRequest({
-  baseUrl,
-  config,
-  cloud,
-  method,
-  entity,
-  args,
-}) {
+export async function cloudRequest({ cloud, method, entity, args }) {
   // NOTE: it's useless to fetch if we don't have a token, or we can't refresh it
-  if (!cloud.token || cloud.isRefreshTokenExpired()) {
+  if (!cloud.isConnected()) {
     cloud.resetTokens();
-    return { error: strings.authUtil.error.invalidCredentials(), status: 401 };
+    return {
+      cloud,
+      error: strings.authUtil.error.invalidCredentials(),
+      status: 401,
+    };
   }
 
   const Client = entityToClient[entity];
+  let tokensRefreshed = false;
 
   // the first attempt to fetch
-  let k8sClient = new Client(baseUrl, cloud.token, entity);
-  const { response, error, body } = await k8sClient[method](entity, args);
+  const now = Date.now();
+  console.log(
+    `@@@@@@@ authUtil.cloudRequest(): method=${method}, entity=${entity}, args=${JSON.stringify(
+      args
+    )}, ID=${now}, cloud=${cloud}`
+  ); // DEBUG LOG
+  let k8sClient = new Client(cloud.cloudUrl, cloud.token, entity);
+  let { response, error, body } = await k8sClient[method](entity, args);
 
   if (response && response.status === 401) {
+    console.log(
+      `@@@@@@@ authUtil.cloudRequest(): got 401 response, refreshing tokens, ID=${now}, cloud=${cloud}`
+    ); // DEBUG LOG
+
     // assume token is expired, try to refresh
-    const refreshError = await refreshToken(baseUrl, config, cloud);
-    if (refreshError) {
-      return { error: refreshError, status: 401 };
+    tokensRefreshed = await cloudRefresh(cloud);
+    if (!tokensRefreshed) {
+      return { cloud, error: cloud.connectError, status: 401 };
     }
 
     // try to fetch again with updated token
-    k8sClient = new Client(baseUrl, cloud.token, entity);
-    const {
-      response: newResponse,
-      error: newError,
-      body: newBody,
-    } = await k8sClient[method](entity, args);
-
-    return newError
-      ? { error: newError, status: newResponse.status }
-      : { body: newBody };
+    console.log(
+      `@@@@@@@ authUtil.cloudRequest(): TOKENS REFRESHED, retrying: method=${method}, entity=${entity}, args=${JSON.stringify(
+        args
+      )}, ID=${now}, cloud=${cloud}`
+    ); // DEBUG LOG
+    k8sClient = new Client(cloud.cloudUrl, cloud.token, entity);
+    ({ response, error, body } = await k8sClient[method](entity, args));
   }
-  // else, either success with current tokens, or non-auth error
 
   return error
-    ? { error, status: (response && response.status) || 0 }
-    : { body };
+    ? { cloud, error, status: (response && response.status) || 0 }
+    : { cloud, body, tokensRefreshed };
 }

--- a/src/renderer/components/GlobalPage/AddCloudInstance.js
+++ b/src/renderer/components/GlobalPage/AddCloudInstance.js
@@ -82,6 +82,8 @@ export const AddCloudInstance = ({ onAdd, onCancel }) => {
 
   const cleanCloudsState = () => {
     setCloud(null);
+
+    extCloud?.destroy();
     setExtCloud(null);
   };
 
@@ -90,6 +92,11 @@ export const AddCloudInstance = ({ onAdd, onCancel }) => {
       makeExtCloud();
     }
   }, [cloud, loading, extCloud, makeExtCloud]);
+
+  // propertly destroy the ExtendedCloud object on unmount
+  useEffect(() => {
+    return () => extCloud?.destroy();
+  }, [extCloud]);
 
   return (
     <PageContainer>

--- a/src/renderer/store/ExtendedCloudProvider.js
+++ b/src/renderer/store/ExtendedCloudProvider.js
@@ -125,13 +125,6 @@ const _updateStore = function ({
 
     // if extendedCloud exists - update extendedCloud.cloud
     if (pr.store.extendedClouds[url]) {
-      console.log(
-        `******* ExtendedCloudProvider._updateStore(): updating cloud on ${
-          pr.store.extendedClouds[url]
-        }, (${
-          pr.store.extendedClouds[url].cloud === cloud ? 'same' : 'new'
-        }) cloud=${cloud}`
-      ); // DEBUG LOG
       // NOTE: updating the EC's Cloud instance will cause the EC to fetch new data,
       //  IIF the `cloud` is actually a new instance at the same URL; it's not always
       //  new as the CloudStore listens for changes on each Cloud and triggers the
@@ -187,8 +180,6 @@ export const ExtendedCloudProvider = function (props) {
   pr.setState = setState;
   // autorun calls on any cloudStore update (to often)
   autorun(() => {
-    // DEBUG REMOVE? const cloudUrlsToUpdate = [];
-
     // @type {{ [index: string]: string }} Map of Cloud URL to token for
     //   the new (current) set of known Clouds stored on disk.
     const cloudStoreTokens = Object.values(cloudStore.clouds).reduce(
@@ -198,30 +189,12 @@ export const ExtendedCloudProvider = function (props) {
       },
       {}
     );
-    // DEBUG REMOVE no longer necessary because of _triageCloudUrls()
-    // compare Cloud tokens between what's in CloudStore and what's in our current state
-    // Cloud tokens get refreshed every ~5 minutes, so the tokens will change, and we'll
-    //  know that the Cloud was updated
-    // const cloudStoreTokens = Object.values(cloudStore.clouds).reduce((acc, cloud) => {
-    //   const { cloudUrl, token } = cloud;
-    //   acc[cloudUrl] = token;
-    //   if (token !== pr?.store?.tokens?.[cloudUrl]) { // cloud be totally new Cloud, or existing one
-    //     cloudUrlsToUpdate.push(cloudUrl);
-    //   }
-    //   return acc;
-    // }, {});
 
     // compare tokens from cloudStore.clouds and tokens in ExtendedCloudProvider state
     //  at previous change in context
     if (!isEqual(pr.store.tokens, cloudStoreTokens)) {
       const { cloudUrlsToAdd, cloudUrlsToUpdate, cloudUrlsToRemove } =
         _triageCloudUrls(cloudStoreTokens);
-      console.log(
-        '******* ExtendedCloudProvider.autorun(): cloudUrlsToAdd=[%s], cloudUrlsToUpdate=[%s], cloudUrlsToRemove=[%s]',
-        cloudUrlsToAdd.join(', '),
-        cloudUrlsToUpdate.join(', '),
-        cloudUrlsToRemove.join(', ')
-      ); // DEBUG LOG
       _updateStore({
         cloudStoreTokens,
         cloudUrlsToAdd,

--- a/src/store/CloudStore.js
+++ b/src/store/CloudStore.js
@@ -60,8 +60,6 @@ export class CloudStore extends Common.Store.ExtensionStore {
 
     const json = result.valid ? store : CloudStore.getDefaults();
 
-    console.log('+++++++ CloudStore.fromStore()'); // DEBUG LOG
-
     Object.keys(json).forEach((key) => {
       if (key === 'clouds') {
         // restore from a map of cloudUrl to JSON object -> into a map of cloudUrl
@@ -73,15 +71,9 @@ export class CloudStore extends Common.Store.ExtensionStore {
             if (existingClouds[cloudUrl]) {
               // update existing Cloud with new data instead of creating a new instance
               //  so that currently-bound objects don't leak
-              console.log(
-                `+++++++ CloudStore.fromStore(): Updating existing cloud=${existingClouds[cloudUrl]}`
-              ); // DEBUG LOG
               cloud = existingClouds[cloudUrl].update(cloudJson);
             } else {
               // add new Cloud we don't know about yet
-              console.log(
-                `+++++++ CloudStore.fromStore(): Adding new cloud for cloudUrl=${cloudUrl}`
-              ); // DEBUG LOG
               cloud = new Cloud(cloudJson);
               this.listenForChanges(cloud);
               cloudMap[cloudUrl] = cloud;
@@ -95,9 +87,6 @@ export class CloudStore extends Common.Store.ExtensionStore {
         // make sure we properly remove any old/deleted Clouds
         Object.keys(existingClouds).forEach((cloudUrl) => {
           if (!newClouds[cloudUrl]) {
-            console.log(
-              `+++++++ CloudStore.fromStore(): Removing old cloud=${existingClouds[cloudUrl]}`
-            ); // DEBUG LOG
             this.stopListeningForChanges(existingClouds[cloudUrl]);
           }
         });
@@ -129,8 +118,6 @@ export class CloudStore extends Common.Store.ExtensionStore {
       return obj;
     }, {});
 
-    console.log('+++++++ CloudStore.toJSON()'); // DEBUG LOG
-
     // return a deep-clone that is no longer observable
     return toJS(observableThis);
   }
@@ -145,10 +132,6 @@ export class CloudStore extends Common.Store.ExtensionStore {
     //  one or more properties of the Cloud object were changed, and by using
     //  `extendObservable()` here, we'll trigger the Store to persist to disk,
     //  thereby capturing the Cloud's latest data in case the user quits Lens
-    console.log(
-      '+++++++ CloudStore.onCloudUpdate(): cloud=%s',
-      cloud.toString()
-    ); // DEBUG LOG
     extendObservable(this.clouds, { [cloud.cloudUrl]: cloud });
   };
 

--- a/src/store/ClusterStore.js
+++ b/src/store/ClusterStore.js
@@ -2,7 +2,7 @@
 // Cluster storage to persist clusters added to the Catalog by this extension
 //
 
-import { observable, toJS, makeObservable } from 'mobx';
+import { observable, action, toJS, makeObservable } from 'mobx';
 import { Common } from '@k8slens/extensions';
 import * as rtv from 'rtvjs';
 import { logger } from '../util/logger';
@@ -52,6 +52,10 @@ export class ClusterStore extends Common.Store.ExtensionStore {
     Object.keys(this).forEach((key) => (this[key] = defaults[key]));
   }
 
+  // NOTE: this method is not just called when reading from disk; it's also called in the
+  //  sync process between the Main and Renderer threads should code on either thread
+  //  update any of the store's properties
+  @action // prevent mobx from emitting a change event until the function returns
   fromStore(store) {
     const result = rtv.check({ store }, { store: storeTs });
 

--- a/src/strings.ts
+++ b/src/strings.ts
@@ -305,9 +305,14 @@ export const cloud: Dict = {
 
 export const extendedCloud: Dict = {
   error: {
-    credentials: () =>
+    invalidClusterPayload: () =>
+      'Failed to parse Clusters payload: Unexpected data format.',
+    invalidNamespacePayload: () =>
+      'Failed to parse Namespaces payload: Unexpected data format.',
+    invalidCredentialsPayload: () =>
       'Failed to parse Credentials payload: Unexpected data format.',
-    sshKeys: () => 'Failed to parse SSH Keys payload: Unexpected data format.',
+    invalidSshKeysPayload: () =>
+      'Failed to parse SSH Keys payload: Unexpected data format.',
   },
 };
 

--- a/src/util/ssoUtil.js
+++ b/src/util/ssoUtil.js
@@ -62,6 +62,9 @@ export const finishAuthorization = async function ({ oAuth, config, cloud }) {
   } else {
     const jwt = extractJwtPayload(body.id_token);
     if (jwt.preferred_username) {
+      console.log(
+        `^^^^^^^ ssoUtil.finishAuthorization(): updating tokens and username on cloud=${cloud}`
+      ); // DEBUG LOG
       cloud.updateTokens(body);
       cloud.username = jwt.preferred_username;
     } else {

--- a/src/util/ssoUtil.js
+++ b/src/util/ssoUtil.js
@@ -62,9 +62,6 @@ export const finishAuthorization = async function ({ oAuth, config, cloud }) {
   } else {
     const jwt = extractJwtPayload(body.id_token);
     if (jwt.preferred_username) {
-      console.log(
-        `^^^^^^^ ssoUtil.finishAuthorization(): updating tokens and username on cloud=${cloud}`
-      ); // DEBUG LOG
       cloud.updateTokens(body);
       cloud.username = jwt.preferred_username;
     } else {

--- a/test/mocks/mockExtCloud.js
+++ b/test/mocks/mockExtCloud.js
@@ -6,8 +6,6 @@ export const mockExtCloud = {
     refresh_token:
       'refresh-token-1',
     refresh_expires_in: 200,
-    expiresAt: 1234,
-    refreshExpiresAt: 5678,
     idpClientId: null,
     username: 'user@test.com',
     cloudUrl: 'https://cloud-url.com',
@@ -109,8 +107,6 @@ export const mockExtCloud2 = {
     refresh_token:
       'refresh-token-1',
     refresh_expires_in: 200,
-    expiresAt: 1234,
-    refreshExpiresAt: 5678,
     idpClientId: null,
     username: 'anotheruser@test.com',
     cloudUrl: 'https://cloud-url-2.com',


### PR DESCRIPTION
There was too much churn when fetching data for an ExtendedCloud:
Duplicated requests, multiple parallel data fetches for the same
EC, and too much back and forth between the CloudStore and the
ExtendedCloudProvider whenever a Cloud would get updated with
new tokens after they would get refreshed.

I fixed and changed a number of things. Here's a list of the most
prominent issues I addressed:

- addEventListener() in Cloud and EC was immediately calling the event
  handler instead of adding it to the list of handlers.
- Cloud didn't have enough events. Just having the one DATA_UPDATED
  event for all property changes was resulting in the EC using that
  Cloud to get notified (and trigger a data fetch) much too often.
  The EC only needs to fetch new data if the Cloud's sync-related
  properties change. Nothing else.
- Only the CloudStore is interested in all possible Cloud property
  changes so it can persist it to disk.
- When the EC's `cloud` property is updated from the
  ExtendedCloudProvider, the Cloud object actually isn't new, so
  there's no need to trigger a data fetch whenever the property
  is set. Now we check to see if the new value is actually
  different.
- When updating the EC's `cloud` property to a new Cloud, we
  weren't checking to see if we already had a Cloud object
  and removing listeners.
- Delaying the data fetch internally within the EC using the
  event dispatching mechanism is a good way to de-duplicate
  data fetch requests, rather than imperatively making them.
- Cloud.idpClientId was not needed, removed.
- The AddCloudInstance component was not properly destroying
  the temporary EC instance it was creating, which created a memory
  leak, and a random EC that kept fetching data after the
  component was unmounted ("destroyed" meaning event listeners
  on the Cloud removed, and interval stopped).
- In EC.fetchData(), we were continuing with requests to load
  clusters and ssh keys even though a previous request had
  failed, which would ultimately result in discarding the data
  and setting EC.error instead, so now we don't pursue additional
  unnecessary requests.
- authUtil module now returns an additional `tokensRefreshed`
  property in its payload, indicating whether tokens were
  refreshed as part of making the request. Turns out there's
  no optimization to make with this now that the EC doesn't
  care if the Cloud's tokens get updated, but this is handy
  nonetheless, so I left it in place.
- CloudStore was leaking Clouds when it would get reloaded
  from disk (Lens does sync to the disk every now and then,
  so even while Lens is running, we can get a random read
  from disk, causing us to overwrite the existing `clouds`
  map). We don't support this, so now we just skip resetting
  the `clouds` map when it's already set. If you want to
  mess with the JSON file on disk, quit Lens, mess with
  it, and then restart Lens.