### PR TITLE
Use existing Namespace class in ExtededCloud instead of anonymous object

### DIFF
--- a/src/renderer/components/EnhancedTable/AdditionalInfoRows.js
+++ b/src/renderer/components/EnhancedTable/AdditionalInfoRows.js
@@ -36,11 +36,11 @@ export const AdditionalInfoRows = ({ namespace }) => {
   const listOfInfo = [
     {
       infoName: managementClusters.table.tbodyDetailedInfo.clusters(),
-      infoCount: namespace.clustersCount,
+      infoCount: namespace.clusterCount,
     },
     {
       infoName: managementClusters.table.tbodyDetailedInfo.sshKeys(),
-      infoCount: namespace.sshKeysCount,
+      infoCount: namespace.sshKeyCount,
     },
     {
       infoName: managementClusters.table.tbodyDetailedInfo.credentials(),

--- a/src/renderer/components/EnhancedTable/EnhancedTableRow.js
+++ b/src/renderer/components/EnhancedTable/EnhancedTableRow.js
@@ -147,14 +147,14 @@ export const EnhancedTableRow = ({ extendedCloud }) => {
   const [onOpen, toggleMenu] = useState(false);
   const [isOpenFirstLevel, setIsOpenFirstLevel] = useState(false);
   const [actualNamespaces, setActualNamespaces] = useState(
-    extendedCloud.namespaces
+    extendedCloud.syncedNamespaces
   );
   const [openedSecondLevelListIndex, setOpenedSecondLevelListIndex] = useState(
     []
   );
   const updateNamespaces = (updatedRow) => {
     if (updatedRow) {
-      setActualNamespaces(updatedRow.namespaces);
+      setActualNamespaces(updatedRow.syncedNamespaces);
     }
   };
   useEffect(() => {

--- a/src/renderer/components/GlobalPage/SynchronizeBlock.js
+++ b/src/renderer/components/GlobalPage/SynchronizeBlock.js
@@ -256,13 +256,13 @@ export const SynchronizeBlock = ({ extCloud, onAdd }) => {
                     <li>
                       <p>
                         {synchronizeBlock.checkboxesDropdownLabels.clusters()} (
-                        {namespace.clustersCount})
+                        {namespace.clusterCount})
                       </p>
                     </li>
                     <li>
                       <p>
                         {synchronizeBlock.checkboxesDropdownLabels.sshKeys()} (
-                        {namespace.sshKeysCount})
+                        {namespace.sshKeyCount})
                       </p>
                     </li>
                     <li>

--- a/src/renderer/store/Namespace.js
+++ b/src/renderer/store/Namespace.js
@@ -1,4 +1,5 @@
 import * as rtv from 'rtvjs';
+import { Cluster } from './Cluster';
 
 /**
  * MCC project/namespace.
@@ -25,6 +26,10 @@ export class Namespace {
         }
       );
 
+    let _clusters = null;
+    let _sshKeys = null;
+    let _credentials = null;
+
     /** @member {string} */
     this.id = data.metadata.uid;
 
@@ -36,5 +41,96 @@ export class Namespace {
 
     /** @member {string} */
     this.phase = data.status.phase;
+
+    /**
+     * @member {Array<Cluster>|null} clusters Clusters in this namespace. `null` if unknown.
+     *  Empty if none.
+     */
+    Object.defineProperty(this, 'clusters', {
+      enumerable: true,
+      get() {
+        return _clusters;
+      },
+      set(newValue) {
+        rtv.verify(
+          { clusters: newValue },
+          {
+            clusters: [
+              rtv.EXPECTED,
+              rtv.ARRAY,
+              { $: [rtv.CLASS_OBJECT, { ctor: Cluster }] },
+            ],
+          }
+        );
+        if (newValue !== _clusters) {
+          _clusters = newValue || null;
+        }
+      },
+    });
+
+    /**
+     * @member {Array<Object>|null} sshKeys SSH keys in this namespace. `null` if unknown.
+     *  Empty if none.
+     */
+    Object.defineProperty(this, 'sshKeys', {
+      enumerable: true,
+      get() {
+        return _sshKeys;
+      },
+      set(newValue) {
+        // TODO: update the shape to check for an SshKey class instance
+        rtv.verify(
+          { sshKeys: newValue },
+          { sshKeys: [rtv.EXPECTED, rtv.ARRAY, { $: [rtv.OBJECT] }] }
+        );
+        if (newValue !== _sshKeys) {
+          _sshKeys = newValue || null;
+        }
+      },
+    });
+
+    /**
+     * @member {Array<Object>|null} credentials Credentials in this namespace. `null` if unknown.
+     *  Empty if none.
+     */
+    Object.defineProperty(this, 'credentials', {
+      enumerable: true,
+      get() {
+        return _credentials;
+      },
+      set(newValue) {
+        // TODO: update the shape to check for an Credential class instance
+        rtv.verify(
+          { credentials: newValue },
+          {
+            credentials: [
+              rtv.EXPECTED,
+              {
+                awscredential: [[rtv.OBJECT]],
+                byocredential: [[rtv.OBJECT]],
+                openstackcredential: [[rtv.OBJECT]],
+              },
+            ],
+          }
+        );
+        if (newValue !== _credentials) {
+          _credentials = newValue || null;
+        }
+      },
+    });
+  }
+
+  /**
+   * @member {number} clusterCount Number of clusters in this namespace.
+   */
+  get clusterCount() {
+    return this.clusters?.length || 0;
+  }
+
+  /**
+   * @member {number} clusterCount Number of SSH keys in this namespace.
+   */
+  get sshKeyCount() {
+    return this.sshKeys?.length || 0;
   }
 }

--- a/test/mocks/mockExtCloud.js
+++ b/test/mocks/mockExtCloud.js
@@ -18,9 +18,7 @@ export const mockExtCloud = {
     {
       name: 'namespaces-1',
       clusters: [],
-      clustersCount: 0,
       sshKeys: [],
-      sshKeysCount: 0,
       credentials: {
         awscredential: [],
         allCredentialsCount: 1,
@@ -52,9 +50,7 @@ export const mockExtCloud = {
           region: 'region-eu',
         },
       ],
-      clustersCount: 1,
       sshKeys: [],
-      sshKeysCount: 0,
       credentials: {
         awscredential: [],
         allCredentialsCount: 1,
@@ -86,9 +82,7 @@ export const mockExtCloud = {
           region: 'region-eu',
         },
       ],
-      clustersCount: 1,
       sshKeys: [],
-      sshKeysCount: 0,
       credentials: {
         awscredential: [],
         allCredentialsCount: 1,
@@ -119,9 +113,7 @@ export const mockExtCloud2 = {
     {
       name: 'namespaces-1',
       clusters: [],
-      clustersCount: 0,
       sshKeys: [],
-      sshKeysCount: 0,
       credentials: {
         awscredential: [],
         allCredentialsCount: 1,
@@ -153,9 +145,7 @@ export const mockExtCloud2 = {
           region: 'region-eu',
         },
       ],
-      clustersCount: 1,
       sshKeys: [],
-      sshKeysCount: 0,
       credentials: {
         awscredential: [],
         allCredentialsCount: 1,
@@ -187,9 +177,7 @@ export const mockExtCloud2 = {
           region: 'region-eu',
         },
       ],
-      clustersCount: 1,
       sshKeys: [],
-      sshKeysCount: 0,
       credentials: {
         awscredential: [],
         allCredentialsCount: 1,


### PR DESCRIPTION
We have a Namespace, and a Cluster class, yet `ExtendedCloud.namespaces`
was a list of anonymous objects with properties.

This moves it to being a list of Namespace objects using the existing
Namespace class, adding necessary properties to the class for clusters,
credentials, and SSH keys.

We're currently missing classes for Credentials and SSH keys. We'll need
to add those in a future PR. I will create a ticket for that. We should
propagate the use of raw API objects throughout the code.

This also changes the ExtendedCloud to always fetch ALL namespaces instead
of just the synced ones since we need to know what all exists at all times,
and adds a convenience `syncedNamespaces` getter that filters that list
to just what the Cloud is configured to sync for purposes of UI display
and (future) SyncManager.