### PR TITLE
Ensure ExtendedCloud.namespaces is always an array

### DIFF
--- a/src/renderer/components/EnhancedTable/EnhancedTableRow.js
+++ b/src/renderer/components/EnhancedTable/EnhancedTableRow.js
@@ -221,7 +221,7 @@ export const EnhancedTableRow = ({ extendedCloud }) => {
         </EnhTableRowCell>
       </EnhTableRow>
       {isOpenFirstLevel &&
-        (actualNamespaces || []).map((namespace, index) => (
+        actualNamespaces.map((namespace, index) => (
           <EnhRowsWrapper key={namespace.name}>
             <EnhTableRow>
               <EnhTableRowCell isFirstLevel>

--- a/src/renderer/components/GlobalPage/AddCloudInstance.js
+++ b/src/renderer/components/GlobalPage/AddCloudInstance.js
@@ -67,17 +67,19 @@ export const AddCloudInstance = ({ onAdd, onCancel }) => {
         setExtCloud(extCl);
 
         extCl.removeEventListener(
-          EXTENDED_CLOUD_EVENTS.LOADING_CHANGE,
+          EXTENDED_CLOUD_EVENTS.LOADED,
+          loadingListener
+        );
+        extCl.removeEventListener(
+          EXTENDED_CLOUD_EVENTS.ERROR_CHANGE,
           loadingListener
         );
       }
       setLoading(extCl.loading);
     };
 
-    extCl.addEventListener(
-      EXTENDED_CLOUD_EVENTS.LOADING_CHANGE,
-      loadingListener
-    );
+    extCl.addEventListener(EXTENDED_CLOUD_EVENTS.LOADED, loadingListener);
+    extCl.addEventListener(EXTENDED_CLOUD_EVENTS.ERROR_CHANGE, loadingListener);
   }, [extCloud, cloud]);
 
   const cleanCloudsState = () => {


### PR DESCRIPTION
We were using the `namespaces` property with a double purpose:
- if it was null, then this indicated we hadn't loaded successfully
  for the first time yet
- if it was an array, then we had loaded, and we had data

This leads to "protective" code like `extCloud.namespaces || []` in
many places.

This change makes `namespaces` be always an array, and empty if we've
never loaded yet successfully at least once.

It changes `ExtendedCloud.loading` to `ExtendedCloud.loaded` which is
false until we've completed one successful data load. After that, it's
_always_ true. `ExtendedCloud.fetching` keeps flipping from true
when we're fetching, back to false when we aren't.

The `error` property also gets its own event, and AddCloudInstance
is made to listen for `ERROR_CHANGE` in case there's an error during
the initial load, since it only cares about the intial load.