### PR TITLE
Consolidate Cloud.isConnected() and Cloud.status, fix connected notion

### DIFF
--- a/src/renderer/auth/authUtil.js
+++ b/src/renderer/auth/authUtil.js
@@ -120,7 +120,7 @@ export async function cloudLogout(cloud) {
  */
 export async function cloudRequest({ cloud, method, entity, args }) {
   // NOTE: it's useless to fetch if we don't have a token, or we can't refresh it
-  if (!cloud.isConnected()) {
+  if (!cloud.connected) {
     cloud.resetTokens();
     return {
       cloud,

--- a/src/strings.ts
+++ b/src/strings.ts
@@ -324,6 +324,7 @@ export const extendedCloud: Dict = {
 export const connectionStatuses: Dict = {
   cloud: {
     connected: () => 'Connected',
+    connecting: () => 'Connecting',
     disconnected: () => 'Disconnected',
   },
   namespace: {


### PR DESCRIPTION
I noticed that we ended-up with 2 ways of determining if a Cloud is
"connected" (which will lead to bugs down the line), and also an
incorrect notion of what "connected" means.

Now, we have a single way, `Cloud.status`, and a helper with
`Cloud.connected` (a boolean getter instead of a function, which
is true if status === CONNECTED, false otherwise, for cases where
the binary state is all we care about). Both properties are now
derived from the same set of logic in the `Cloud.status` getter,
so they won't diverge.

Also, "connected" really means the Cloud has all the necessary info
in order to make an API request. Without the `config` loaded, we're
technically not connected yet. So now, if we have everything except
the config, we consider this "connecting" because we have tokens,
but we just haven't gotten the config yet.

This covers the case where the Cloud is restored from disk with valid
tokens as the Cloud doesn't auto-fetch its config. The ExtendedCloud
will fetch the config when it does its initial data fetch. Then the
Cloud will become fully "connected".

I also tested some error scenarios in `Cloud.connect()` and ended-up
tweaking how `ExtendedCloud.fetchData()` reacts as a result. I think
things are more robust now than they were before.

### Preview

Here's what it looks like now when opening Lens and we already have a Cloud with valid tokens and the ExtendedCloud does its initial data fetch automatically:

![lex-connecting-status](https://user-images.githubusercontent.com/2855350/153281799-c3adbc63-a937-4d5a-8ddd-8228e5f0cd26.gif)

And here's what it looks like, in terms of status, when we load Lens and we have a disconnected Cloud, and we "reconnect" to it:

![lex-reconnect-with-status](https://user-images.githubusercontent.com/2855350/153281883-58bd9dc4-1dc1-4731-b443-73007e024d17.gif)
