### PR TITLE
Add lint rule for class member styling

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,6 +26,7 @@ const rules = {
     },
   ],
   'no-use-before-define': 'error',
+  'lines-between-class-members': 'error',
 
   //// react plugin
 

--- a/src/catalog/CredentialEntity.ts
+++ b/src/catalog/CredentialEntity.ts
@@ -35,9 +35,11 @@ export class CredentialEntity extends Common.Catalog.CatalogEntity<
   CredentialSpec
 > {
   public static readonly apiVersion = `${consts.catalog.entities.credential.group}/${consts.catalog.entities.credential.versions.v1alpha1}`;
+
   public static readonly kind = consts.catalog.entities.credential.kind;
 
   public readonly apiVersion = CredentialEntity.apiVersion;
+
   public readonly kind = CredentialEntity.kind;
 
   // "runs" the entity; called when the user just clicks on the item in the Catalog
@@ -78,6 +80,7 @@ export class CredentialEntity extends Common.Catalog.CatalogEntity<
 
 export class CredentialCategory extends Common.Catalog.CatalogCategory {
   public readonly apiVersion = `${consts.catalog.category.group}/${consts.catalog.category.versions.v1alpha1}`;
+
   public readonly kind = consts.catalog.category.kind;
 
   public metadata = {

--- a/src/catalog/ProxyEntity.ts
+++ b/src/catalog/ProxyEntity.ts
@@ -34,9 +34,11 @@ export class ProxyEntity extends Common.Catalog.CatalogEntity<
   ProxySpec
 > {
   public static readonly apiVersion = `${consts.catalog.entities.proxy.group}/${consts.catalog.entities.proxy.versions.v1alpha1}`;
+
   public static readonly kind = consts.catalog.entities.proxy.kind;
 
   public readonly apiVersion = ProxyEntity.apiVersion;
+
   public readonly kind = ProxyEntity.kind;
 
   // "runs" the entity; called when the user just clicks on the item in the Catalog
@@ -76,6 +78,7 @@ export class ProxyEntity extends Common.Catalog.CatalogEntity<
 
 export class ProxyCategory extends Common.Catalog.CatalogCategory {
   public readonly apiVersion = `${consts.catalog.category.group}/${consts.catalog.category.versions.v1alpha1}`;
+
   public readonly kind = consts.catalog.category.kind;
 
   public metadata = {

--- a/src/catalog/SshKeyEntity.ts
+++ b/src/catalog/SshKeyEntity.ts
@@ -32,9 +32,11 @@ export class SshKeyEntity extends Common.Catalog.CatalogEntity<
   SshKeySpec
 > {
   public static readonly apiVersion = `${consts.catalog.entities.sshKey.group}/${consts.catalog.entities.sshKey.versions.v1alpha1}`;
+
   public static readonly kind = consts.catalog.entities.sshKey.kind;
 
   public readonly apiVersion = SshKeyEntity.apiVersion;
+
   public readonly kind = SshKeyEntity.kind;
 
   // "runs" the entity; called when the user just clicks on the item in the Catalog
@@ -74,6 +76,7 @@ export class SshKeyEntity extends Common.Catalog.CatalogEntity<
 
 export class SshKeyCategory extends Common.Catalog.CatalogCategory {
   public readonly apiVersion = `${consts.catalog.category.group}/${consts.catalog.category.versions.v1alpha1}`;
+
   public readonly kind = consts.catalog.category.kind;
 
   public metadata = {

--- a/src/renderer/store/ProviderStore.js
+++ b/src/renderer/store/ProviderStore.js
@@ -30,6 +30,7 @@ export class ProviderStore {
   get loading() {
     return this.store.loading;
   }
+
   set loading(newValue) {
     this.store.loading = !!newValue;
   }
@@ -39,6 +40,7 @@ export class ProviderStore {
   get loaded() {
     return this.store.loaded;
   }
+
   set loaded(newValue) {
     this.store.loaded = !!newValue;
   }
@@ -51,6 +53,7 @@ export class ProviderStore {
   get error() {
     return this.store.error;
   }
+
   set error(newValue) {
     this.store.error = newValue || undefined; // empty string is NOT an error
   }


### PR DESCRIPTION
So far, Prettier doesn't style class members in any specific way,
so this won't conflict with Prettier styling.