### PR TITLE
Fetch all entity types from ExtendedCloud (and more)

### DIFF
--- a/src/api/apiConstants.js
+++ b/src/api/apiConstants.js
@@ -1,0 +1,50 @@
+//
+// MCC API constants
+//
+
+import { pick } from 'lodash';
+
+/**
+ * Map of API entity type to name/endpoint used in MCC API calls.
+ * @type {{ [index: string], string }}
+ */
+export const apiEntities = Object.freeze({
+  CLUSTER: 'clusters',
+  MACHINE: 'machines',
+  PUBLIC_KEY: 'publickeys', // "SSH keys"
+  NAMESPACE: 'namespaces',
+  OPENSTACK_CREDENTIAL: 'openstackcredentials',
+  AWS_CREDENTIAL: 'awscredentials',
+  EQUINIX_CREDENTIAL: 'equinixmetalcredentials',
+  VSPHERE_CREDENTIAL: 'vspherecredentials',
+  AZURE_CREDENTIAL: 'azurecredentials',
+  BYO_CREDENTIAL: 'byocredentials',
+  METAL_CREDENTIAL: 'secrets',
+  EVENT: 'events',
+  CLUSTER_RELEASE: 'clusterreleases',
+  KAAS_RELEASE: 'kaasreleases',
+  OPENSTACK_RESOURCE: 'openstackresources',
+  AWS_RESOURCE: 'awsresources',
+  AUTHORIZATION: 'authorizations',
+  METAL_HOST: 'baremetalhosts',
+  CEPH_CLUSTER: 'kaascephclusters',
+  RHEL_LICENSE: 'rhellicenses',
+  PROXY: 'proxies',
+});
+
+/**
+ * Map of credential entity type to name/endpoint used in MCC API calls.
+ * @type {{ [index: string], string }}
+ */
+export const apiCredentialEntities = Object.freeze(
+  pick(apiEntities, [
+    // NOTE: these are KEYS from the apiEntities map
+    'OPENSTACK_CREDENTIAL',
+    'AWS_CREDENTIAL',
+    'EQUINIX_CREDENTIAL',
+    'VSPHERE_CREDENTIAL',
+    'AZURE_CREDENTIAL',
+    'BYO_CREDENTIAL',
+    'METAL_CREDENTIAL',
+  ])
+);

--- a/src/api/apiUtil.js
+++ b/src/api/apiUtil.js
@@ -8,24 +8,31 @@ import { KubernetesAuthorizationClient } from './clients/KubernetesAuthorization
 import { KubernetesClient } from './clients/KubernetesClient';
 import { KubernetesEntityClient } from './clients/KubernetesEntityClient';
 import { logger } from '../util/logger';
+import { apiEntities } from './apiConstants';
 
 const entityToClient = {
-  cluster: KubernetesEntityClient,
-  machine: KubernetesEntityClient,
-  namespace: KubernetesClient,
-  credential: KubernetesClient,
-  openstackcredential: KubernetesEntityClient,
-  awscredential: KubernetesEntityClient,
-  byocredential: KubernetesEntityClient,
-  event: KubernetesClient,
-  publickey: KubernetesEntityClient,
-  clusterrelease: KubernetesEntityClient,
-  kaasrelease: KubernetesEntityClient,
-  openstackresource: KubernetesEntityClient,
-  awsresource: KubernetesEntityClient,
-  authorization: KubernetesAuthorizationClient,
-  baremetalhost: KubernetesEntityClient,
-  kaascephcluster: KubernetesEntityClient,
+  [apiEntities.CLUSTER]: KubernetesEntityClient,
+  [apiEntities.MACHINE]: KubernetesEntityClient,
+  [apiEntities.PUBLIC_KEY]: KubernetesEntityClient, // SSH keys
+  [apiEntities.NAMESPACE]: KubernetesClient,
+  [apiEntities.CREDENTIAL]: KubernetesClient,
+  [apiEntities.OPENSTACK_CREDENTIAL]: KubernetesEntityClient,
+  [apiEntities.AWS_CREDENTIAL]: KubernetesEntityClient,
+  [apiEntities.EQUINIX_CREDENTIAL]: KubernetesEntityClient,
+  [apiEntities.VSPHERE_CREDENTIAL]: KubernetesEntityClient,
+  [apiEntities.AZURE_CREDENTIAL]: KubernetesEntityClient,
+  [apiEntities.BYO_CREDENTIAL]: KubernetesEntityClient,
+  [apiEntities.METAL_CREDENTIAL]: KubernetesClient,
+  [apiEntities.EVENT]: KubernetesClient,
+  [apiEntities.CLUSTER_RELEASE]: KubernetesEntityClient,
+  [apiEntities.KAAS_RELEASE]: KubernetesEntityClient,
+  [apiEntities.OPENSTACK_RESOURCE]: KubernetesEntityClient,
+  [apiEntities.AWS_RESOURCE]: KubernetesEntityClient,
+  [apiEntities.AUTHORIZATION]: KubernetesAuthorizationClient,
+  [apiEntities.METAL_HOST]: KubernetesEntityClient,
+  [apiEntities.CEPH_CLUSTER]: KubernetesEntityClient,
+  [apiEntities.RHEL_LICENSE]: KubernetesEntityClient,
+  [apiEntities.PROXY]: KubernetesEntityClient,
 };
 
 /**
@@ -134,6 +141,16 @@ export async function cloudRequest({ cloud, method, entity, args }) {
   }
 
   const Client = entityToClient[entity];
+  if (!Client) {
+    return {
+      cloud,
+      error: `Unknown or unmapped entity ${
+        typeof entity === 'string' ? `"${entity}"` : entity
+      }`,
+      status: 0,
+    };
+  }
+
   let tokensRefreshed = false;
 
   // the first attempt to fetch

--- a/src/api/clients/KubernetesClient.js
+++ b/src/api/clients/KubernetesClient.js
@@ -1,5 +1,6 @@
 import { request } from '../../util/netUtil';
 import * as strings from '../../strings';
+import { apiEntities } from '../apiConstants';
 
 /**
  * @param {string} baseUrl The MCC base URL (i.e. the URL to the MCC UI). Expected to
@@ -39,9 +40,9 @@ export class KubernetesClient {
 
   list(entity, { namespaceName, entityDescriptionName } = {}) {
     const url = {
-      namespace: 'namespaces',
-      credential: `namespaces/${namespaceName}/secrets`,
-      event: `namespaces/${namespaceName}/events`,
+      [apiEntities.NAMESPACE]: entity,
+      [apiEntities.METAL_CREDENTIAL]: `${apiEntities.NAMESPACE}/${namespaceName}/${entity}`,
+      [apiEntities.EVENT]: `${apiEntities.NAMESPACE}/${namespaceName}/${entity}`,
     };
     return this.request(url[entity], {
       errorMessage: strings.apiClient.error.failedToGet(
@@ -52,8 +53,8 @@ export class KubernetesClient {
 
   create(entity, { namespaceName, config, entityDescriptionName } = {}) {
     const url = {
-      namespace: 'namespaces',
-      credential: `namespaces/${namespaceName}/secrets`,
+      [apiEntities.NAMESPACE]: entity,
+      [apiEntities.METAL_CREDENTIAL]: `${apiEntities.NAMESPACE}/${namespaceName}/${entity}`,
     };
     return this.request(url[entity], {
       options: { method: 'POST', body: JSON.stringify(config) },
@@ -66,8 +67,8 @@ export class KubernetesClient {
 
   delete(entity, { namespaceName, name, entityDescriptionName } = {}) {
     const url = {
-      namespace: `namespaces/${name}`,
-      credential: `namespaces/${namespaceName}/secrets/${name}`,
+      [apiEntities.NAMESPACE]: `${entity}/${name}`,
+      [apiEntities.METAL_CREDENTIAL]: `${apiEntities.NAMESPACE}/${namespaceName}/${entity}/${name}`,
     };
     return this.request(url[entity], {
       options: { method: 'DELETE' },

--- a/src/api/types/ApiObject.js
+++ b/src/api/types/ApiObject.js
@@ -1,15 +1,72 @@
+import * as rtv from 'rtvjs';
+
+/**
+ * Typeset for a basic MCC API Object.
+ */
+export const apiObjectTs = {
+  // NOTE: this is not intended to be fully-representative; we only list the properties
+  //  related to what we expect to find in order to create a `Credential` class instance
+
+  metadata: {
+    uid: rtv.STRING,
+    name: rtv.STRING,
+    creationTimestamp: rtv.STRING, // ISO8601 timestamp
+    deletionTimestamp: [rtv.OPTIONAL, rtv.STRING], // ISO8601 timestamp; only exists if being deleted
+  },
+};
+
+/**
+ * MCC generic API object. This is essentially a standard kube object spec with some
+ *  MCC-specific extensions.
+ * @class ApiObject
+ * @param {Object} data Raw cluster data payload from the API.
+ */
 export class ApiObject {
   constructor(data) {
-    /** @member {string} */
-    this.id = data.metadata.uid;
+    DEV_ENV && rtv.verify({ data }, { data: apiObjectTs });
 
     /** @member {string} */
-    this.name = data.metadata.name;
+    Object.defineProperty(this, 'id', {
+      enumerable: true,
+      get() {
+        return data.metadata.uid;
+      },
+    });
+
+    /** @member {string} */
+    Object.defineProperty(this, 'name', {
+      enumerable: true,
+      get() {
+        return data.metadata.name;
+      },
+    });
 
     /** @member {Date} */
-    this.creationDate = new Date(data.metadata.creationTimestamp);
+    Object.defineProperty(this, 'creationDate', {
+      enumerable: true,
+      get() {
+        return new Date(data.metadata.creationTimestamp);
+      },
+    });
 
     /** @member {boolean|null} */
-    this.deleteInProgress = !!data.metadata.deletionTimestamp;
+    Object.defineProperty(this, 'deleteInProgress', {
+      enumerable: true,
+      get() {
+        return !!data.metadata.deletionTimestamp;
+      },
+    });
+  }
+
+  /** @returns {string} A string representation of this instance for logging/debugging. */
+  toString() {
+    const propStr = `name: "${this.name}", id: "${this.id}"`;
+
+    if (Object.getPrototypeOf(this).constructor === ApiObject) {
+      return `{ApiObject ${propStr}}`;
+    }
+
+    // this is actually an extended class instance, so return only the properties
+    return propStr;
   }
 }

--- a/src/api/types/Cluster.js
+++ b/src/api/types/Cluster.js
@@ -1,6 +1,7 @@
 import * as rtv from 'rtvjs';
 import { get } from 'lodash';
-import { ApiObject } from './ApiObject';
+import { mergeRtvShapes } from '../../util/mergeRtvShapes';
+import { ApiObject, apiObjectTs } from './ApiObject';
 import { Namespace } from './Namespace';
 
 const isManagementCluster = function (data) {
@@ -14,149 +15,229 @@ const getServerUrl = function (data) {
 };
 
 /**
+ * Typeset for an MCC Cluster object.
+ */
+export const apiClusterTs = mergeRtvShapes({}, apiObjectTs, {
+  // NOTE: this is not intended to be fully-representative; we only list the properties
+  //  related to what we expect to find in order to create a `Credential` class instance
+
+  metadata: {
+    labels: [
+      rtv.OPTIONAL,
+      {
+        // if we have labels, these are important
+        'kaas.mirantis.com/provider': [rtv.OPTIONAL, rtv.STRING],
+        'kaas.mirantis.com/region': [rtv.OPTIONAL, rtv.STRING],
+      },
+    ],
+  },
+  spec: {
+    providerSpec: {
+      value: {
+        kaas: [
+          rtv.OPTIONAL,
+          {
+            management: [
+              rtv.OPTIONAL,
+              {
+                enabled: rtv.BOOLEAN,
+              },
+            ],
+            regional: [rtv.OPTIONAL, rtv.ARRAY],
+          },
+        ],
+        region: [rtv.OPTIONAL, rtv.STRING],
+      },
+    },
+  },
+  status: {
+    providerStatus: {
+      oidc: {
+        certificate: rtv.STRING,
+        clientId: rtv.STRING,
+        groupsClaim: rtv.STRING,
+        issuerUrl: rtv.STRING,
+        ready: rtv.BOOLEAN,
+      },
+      apiServerCertificate: rtv.STRING,
+      ucpDashboard: [rtv.OPTIONAL, rtv.STRING], // if managed by UCP, the URL
+      loadBalancerHost: [rtv.OPTIONAL, rtv.STRING],
+    },
+  },
+});
+
+/**
  * MCC cluster.
  * @class Cluster
  * @param {Object} data Raw cluster data payload from the API.
+ * @param {Namespace} namespace Namespace to which this object belongs.
  * @param {string} username Username used to access the cluster.
  */
 export class Cluster extends ApiObject {
-  constructor(data, username, namespace) {
+  constructor(data, namespace, username) {
     super(data);
+
+    // just testing for what is Cluster-specific
     DEV_ENV &&
       rtv.verify(
         { username, data, namespace },
         {
           username: rtv.STRING,
           namespace: [rtv.CLASS_OBJECT, { ctor: Namespace }],
-          data: {
-            metadata: {
-              name: rtv.STRING,
-              namespace: rtv.STRING,
-              uid: rtv.STRING,
-              creationTimestamp: rtv.STRING, // ISO8601 timestamp
-              deletionTimestamp: [rtv.OPTIONAL, rtv.STRING], // ISO8601 timestamp; only exists if being deleted
-              labels: [
-                rtv.OPTIONAL,
-                {
-                  'kaas.mirantis.com/provider': [rtv.OPTIONAL, rtv.STRING],
-                  'kaas.mirantis.com/region': [rtv.OPTIONAL, rtv.STRING],
-                },
-              ],
-            },
-            spec: {
-              providerSpec: {
-                value: {
-                  kaas: [
-                    rtv.OPTIONAL,
-                    {
-                      management: [
-                        rtv.OPTIONAL,
-                        {
-                          enabled: rtv.BOOLEAN,
-                        },
-                      ],
-                      regional: [rtv.OPTIONAL, rtv.ARRAY],
-                    },
-                  ],
-                  region: [rtv.OPTIONAL, rtv.STRING],
-                },
-              },
-            },
-            status: {
-              providerStatus: {
-                oidc: {
-                  certificate: rtv.STRING,
-                  clientId: rtv.STRING,
-                  groupsClaim: rtv.STRING,
-                  issuerUrl: rtv.STRING,
-                  ready: rtv.BOOLEAN,
-                },
-                apiServerCertificate: rtv.STRING,
-                ucpDashboard: [rtv.OPTIONAL, rtv.STRING], // if managed by UCP, the URL
-                loadBalancerHost: [rtv.OPTIONAL, rtv.STRING],
-              },
-            },
-          },
+          data: apiClusterTs,
         }
       );
 
     // NOTE: regardless of `ready`, we assume `data.metadata` is always available
 
     /** @member {Namespace} */
-    this.namespace = namespace;
+    Object.defineProperty(this, 'namespace', {
+      enumerable: true,
+      get() {
+        return namespace;
+      },
+    });
 
     /** @member {string} */
-    this.username = username;
+    Object.defineProperty(this, 'username', {
+      enumerable: true,
+      get() {
+        return username;
+      },
+    });
 
     /** @member {boolean} */
-    this.isManagementCluster = isManagementCluster(data);
+    Object.defineProperty(this, 'isManagementCluster', {
+      enumerable: true,
+      get() {
+        return isManagementCluster(data);
+      },
+    });
 
     // NOTE: cluster is ready/provisioned (and we can generate a kubeConfig for it) if
     //  these fields are all available and defined, and cluster isn't being deleted
-    this.ready = !!(
-      !this.deleteInProgress &&
-      data.status?.providerStatus?.loadBalancerHost &&
-      data.status?.providerStatus?.apiServerCertificate &&
-      data.status?.providerStatus?.oidc?.certificate &&
-      data.status?.providerStatus?.oidc?.clientId &&
-      data.status?.providerStatus?.oidc?.ready
-    );
+    Object.defineProperty(this, 'ready', {
+      enumerable: true,
+      get() {
+        return !!(
+          !this.deleteInProgress &&
+          data.status?.providerStatus?.loadBalancerHost &&
+          data.status?.providerStatus?.apiServerCertificate &&
+          data.status?.providerStatus?.oidc?.certificate &&
+          data.status?.providerStatus?.oidc?.clientId &&
+          data.status?.providerStatus?.oidc?.ready
+        );
+      },
+    });
 
     /** @member {string|null} */
-    this.serverUrl = this.ready ? getServerUrl(data) : null;
+    Object.defineProperty(this, 'serverUrl', {
+      enumerable: true,
+      get() {
+        return this.ready ? getServerUrl(data) : null;
+      },
+    });
 
     /**
      * IDP Certificate Authority Data (OIDC)
      * @member {string|null}
      */
-    this.idpIssuerUrl = this.ready
-      ? data.status.providerStatus.oidc.issuerUrl
-      : null;
+    Object.defineProperty(this, 'idpIssuerUrl', {
+      enumerable: true,
+      get() {
+        return this.ready ? data.status.providerStatus.oidc.issuerUrl : null;
+      },
+    });
 
     /** @member {string|null} */
-    this.idpCertificate = this.ready
-      ? data.status.providerStatus.oidc.certificate
-      : null;
+    Object.defineProperty(this, 'idpCertificate', {
+      enumerable: true,
+      get() {
+        return this.ready ? data.status.providerStatus.oidc.certificate : null;
+      },
+    });
 
     /** @member {string|null} */
-    this.idpClientId = this.ready
-      ? data.status.providerStatus.oidc.clientId
-      : null;
+    Object.defineProperty(this, 'idpClientId', {
+      enumerable: true,
+      get() {
+        return this.ready ? data.status.providerStatus.oidc.clientId : null;
+      },
+    });
 
     /** @member {string|null} */
-    this.apiCertificate = this.ready
-      ? data.status.providerStatus.apiServerCertificate
-      : null;
+    Object.defineProperty(this, 'apiCertificate', {
+      enumerable: true,
+      get() {
+        return this.ready
+          ? data.status.providerStatus.apiServerCertificate
+          : null;
+      },
+    });
 
     /**
      * e.g. 'aws'
      * @member {string|null}
      */
-    this.ucpUrl = this.ready ? data.status.providerStatus.ucpDashboard : null;
+    Object.defineProperty(this, 'ucpUrl', {
+      enumerable: true,
+      get() {
+        return this.ready ? data.status.providerStatus.ucpDashboard : null;
+      },
+    });
 
     /**
      * e.g. 'region-one'
      * @member {string|null}
      */
-    this.provider = this.ready
-      ? get(data.metadata, 'labels["kaas.mirantis.com/provider"]', null)
-      : null;
+    Object.defineProperty(this, 'provider', {
+      enumerable: true,
+      get() {
+        return this.ready
+          ? get(data.metadata, 'labels["kaas.mirantis.com/provider"]', null)
+          : null;
+      },
+    });
 
     /**
      * e.g. 'us-west-2'
      * @member {string|null}
      */
-    this.region = this.ready
-      ? get(data.metadata, 'labels["kaas.mirantis.com/region"]', null)
-      : null;
+    Object.defineProperty(this, 'region', {
+      enumerable: true,
+      get() {
+        return this.ready
+          ? get(data.metadata, 'labels["kaas.mirantis.com/region"]', null)
+          : null;
+      },
+    });
 
     /** @member {sting|null} */
-    this.awsRegion = this.ready ? data.spec.providerSpec.region : null;
+    Object.defineProperty(this, 'awsRegion', {
+      enumerable: true,
+      get() {
+        return this.ready ? data.spec.providerSpec.region : null;
+      },
+    });
   }
 
   /** @member {string} contextName Kubeconfig context name for this cluster. */
   get contextName() {
     // NOTE: this mirrors how MCC generates kubeconfig context names
     return `${this.username}@${this.namespace.name}@${this.name}`;
+  }
+
+  /** @returns {string} A string representation of this instance for logging/debugging. */
+  toString() {
+    const propStr = `${super.toString()}, ready: ${this.ready}, region: ${
+      typeof this.region === 'string' ? `"${this.region}"` : this.region
+    }`;
+
+    if (Object.getPrototypeOf(this).constructor === Cluster) {
+      return `{Cluster ${propStr}}`;
+    }
+
+    // this is actually an extended class instance, so return only the properties
+    return propStr;
   }
 }

--- a/src/api/types/License.js
+++ b/src/api/types/License.js
@@ -1,40 +1,65 @@
-import { ApiObject } from './ApiObject';
 import * as rtv from 'rtvjs';
+import { mergeRtvShapes } from '../../util/mergeRtvShapes';
+import { ApiObject, apiObjectTs } from './ApiObject';
 import { Namespace } from './Namespace';
 
-const licenseSpec = {
-  apiVersion: rtv.STRING,
-  kind: [rtv.REQUIRED, rtv.STRING],
-  metadata: {
-    name: [rtv.REQUIRED, rtv.STRING],
-    namespace: [rtv.REQUIRED, rtv.STRING],
-    uid: [rtv.REQUIRED, rtv.STRING],
-    creationTimestamp: rtv.STRING, // ISO8601 timestamp
-    resourceVersion: rtv.STRING,
-    finalizers: [rtv.OPTIONAL, rtv.ARRAY, rtv.OBJECT],
-    managedFields: [rtv.ARRAY, { $: [rtv.OBJECT] }], // complex nested object
-  },
-  spec: {
-    password: rtv.OBJECT,
-    username: rtv.STRING,
-  },
-};
+/**
+ * Typeset for an MCC License object.
+ */
+export const apiLicenseTs = mergeRtvShapes({}, apiObjectTs, {
+  // NOTE: this is not intended to be fully-representative; we only list the properties
+  //  related to what we expect to find in order to create a `Credential` class instance
+
+  kind: [rtv.STRING, { oneOf: 'RHELLicense' }],
+});
+
+/**
+ * MCC license.
+ * @class License
+ * @param {Object} data Raw cluster data payload from the API.
+ * @param {Namespace} namespace Namespace to which this object belongs.
+ */
 export class License extends ApiObject {
   constructor(data, namespace) {
     super(data);
+
     DEV_ENV &&
       rtv.verify(
         { data, namespace },
         {
-          data: licenseSpec,
+          data: apiLicenseTs,
           namespace: [rtv.CLASS_OBJECT, { ctor: Namespace }],
         }
       );
 
     /** @member {Namespace} */
-    this.namespace = namespace;
+    Object.defineProperty(this, 'namespace', {
+      enumerable: true,
+      get() {
+        return namespace;
+      },
+    });
 
     /** @member {string} */
-    this.kind = data.kind;
+    Object.defineProperty(this, 'kind', {
+      enumerable: true,
+      get() {
+        return data.kind;
+      },
+    });
+  }
+
+  /** @returns {string} A string representation of this instance for logging/debugging. */
+  toString() {
+    const propStr = `${super.toString()}, kind: "${this.kind}", namespace: "${
+      this.namespace.name
+    }"`;
+
+    if (Object.getPrototypeOf(this).constructor === License) {
+      return `{License ${propStr}}`;
+    }
+
+    // this is actually an extended class instance, so return only the properties
+    return propStr;
   }
 }

--- a/src/api/types/Proxy.js
+++ b/src/api/types/Proxy.js
@@ -1,20 +1,18 @@
 import * as rtv from 'rtvjs';
-import { ApiObject } from './ApiObject';
+import { mergeRtvShapes } from '../../util/mergeRtvShapes';
+import { ApiObject, apiObjectTs } from './ApiObject';
 import { get } from 'lodash';
 import { Namespace } from './Namespace';
 
-const proxySpec = {
-  apiVersion: rtv.STRING,
-  kind: [rtv.REQUIRED, rtv.STRING],
-  metadata: {
-    name: [rtv.REQUIRED, rtv.STRING],
-    namespace: [rtv.REQUIRED, rtv.STRING],
-    uid: [rtv.REQUIRED, rtv.STRING],
-    creationTimestamp: rtv.STRING, // ISO8601 timestamp
-    resourceVersion: rtv.STRING,
-    finalizers: [rtv.OPTIONAL, rtv.ARRAY, rtv.OBJECT],
-    managedFields: [rtv.ARRAY, { $: [rtv.OBJECT] }], // complex nested object
+/**
+ * Typeset for an MCC Proxy object.
+ */
+export const apiProxyTs = mergeRtvShapes({}, apiObjectTs, {
+  // NOTE: this is not intended to be fully-representative; we only list the properties
+  //  related to what we expect to find in order to create a `Credential` class instance
 
+  kind: [rtv.STRING, { oneOf: 'Proxy' }],
+  metadata: {
     labels: [
       rtv.OPTIONAL,
       {
@@ -26,34 +24,76 @@ const proxySpec = {
     httpProxy: rtv.STRING,
     httpsProxy: rtv.STRING,
   },
-};
+});
 
+/**
+ * MCC proxy.
+ * @class Proxy
+ * @param {Object} data Raw cluster data payload from the API.
+ * @param {Namespace} namespace Namespace to which this object belongs.
+ */
 export class Proxy extends ApiObject {
   constructor(data, namespace) {
     super(data);
+
     DEV_ENV &&
       rtv.verify(
         { data, namespace },
-        { data: proxySpec, namespace: [rtv.CLASS_OBJECT, { ctor: Namespace }] }
+        { data: apiProxyTs, namespace: [rtv.CLASS_OBJECT, { ctor: Namespace }] }
       );
 
     /** @member {Namespace} */
-    this.namespace = namespace;
+    Object.defineProperty(this, 'namespace', {
+      enumerable: true,
+      get() {
+        return namespace;
+      },
+    });
 
     /** @member {string} */
-    this.kind = data.kind;
+    Object.defineProperty(this, 'kind', {
+      enumerable: true,
+      get() {
+        return data.kind;
+      },
+    });
 
     /** @member {string} */
-    this.region = get(
-      data.metadata,
-      'labels["kaas.mirantis.com/region"]',
-      null
-    );
+    Object.defineProperty(this, 'region', {
+      enumerable: true,
+      get() {
+        return get(data.metadata, 'labels["kaas.mirantis.com/region"]', null);
+      },
+    });
 
     /** @member {string} */
-    this.httpProxy = data.spec.httpProxy;
+    Object.defineProperty(this, 'httpProxy', {
+      enumerable: true,
+      get() {
+        return data.spec.httpProxy;
+      },
+    });
 
     /** @member {string} */
-    this.httpsProxy = data.spec.httpsProxy;
+    Object.defineProperty(this, 'httpsProxy', {
+      enumerable: true,
+      get() {
+        return data.spec.httpsProxy;
+      },
+    });
+  }
+
+  /** @returns {string} A string representation of this instance for logging/debugging. */
+  toString() {
+    const propStr = `${super.toString()}, kind: "${this.kind}", namespace: "${
+      this.namespace.name
+    }", http: "${this.httpProxy}", https: "${this.httpsProxy}"`;
+
+    if (Object.getPrototypeOf(this).constructor === Proxy) {
+      return `{Proxy ${propStr}}`;
+    }
+
+    // this is actually an extended class instance, so return only the properties
+    return propStr;
   }
 }

--- a/src/common/Cloud.js
+++ b/src/common/Cloud.js
@@ -171,7 +171,7 @@ export class Cloud extends EventDispatcher {
     // URL to the MCC instance
     cloudUrl: [rtv.EXPECTED, rtv.STRING],
 
-    syncNamespaces: [rtv.EXPECTED, rtv.ARRAY, { $: rtv.STRING }],
+    syncedNamespaces: [rtv.EXPECTED, rtv.ARRAY, { $: rtv.STRING }],
     name: [rtv.EXPECTED, rtv.STRING],
     syncAll: [rtv.EXPECTED, rtv.BOOLEAN],
   };
@@ -189,7 +189,7 @@ export class Cloud extends EventDispatcher {
 
     let _name = null;
     let _syncAll = false;
-    let _syncNamespaces = [];
+    let _syncedNamespaces = [];
     let _token = null;
     let _expiresIn = null;
     let _tokenValidTill = null;
@@ -241,23 +241,23 @@ export class Cloud extends EventDispatcher {
     });
 
     /**
-     * @member {Array<string>} syncNamespaces A list of namespace names in the mgmt
+     * @member {Array<string>} syncedNamespaces A list of namespace names in the mgmt
      *  cluster that should be synced. If syncAll is true, this list is ignored and
      *  all existing/future namespaces are synced.
      */
-    Object.defineProperty(this, 'syncNamespaces', {
+    Object.defineProperty(this, 'syncedNamespaces', {
       enumerable: true,
       get() {
-        return _syncNamespaces;
+        return _syncedNamespaces;
       },
       set(newValue) {
         DEV_ENV &&
           rtv.verify(
             { token: newValue },
-            { token: Cloud.specTs.syncNamespaces }
+            { token: Cloud.specTs.syncedNamespaces }
           );
-        if (!isEqual(_syncNamespaces, newValue)) {
-          _syncNamespaces = newValue;
+        if (!isEqual(_syncedNamespaces, newValue)) {
+          _syncedNamespaces = newValue;
           this.dispatchEvent(CLOUD_EVENTS.SYNC_CHANGE, this);
         }
       },
@@ -597,7 +597,7 @@ export class Cloud extends EventDispatcher {
       this.cloudUrl = spec.cloudUrl;
       this.name = spec.name;
       this.syncAll = spec.syncAll;
-      this.syncNamespaces = spec.syncNamespaces;
+      this.syncedNamespaces = spec.syncedNamespaces;
       this.username = spec.username;
 
       if (spec.id_token && spec.refresh_token) {
@@ -619,7 +619,7 @@ export class Cloud extends EventDispatcher {
       cloudUrl: this.cloudUrl,
       name: this.name,
       syncAll: this.syncAll,
-      syncNamespaces: this.syncNamespaces.concat(),
+      syncedNamespaces: this.syncedNamespaces.concat(),
       username: this.username,
 
       // NOTE: the API-related properties have underscores in them since they do

--- a/src/common/ExtendedCloud.js
+++ b/src/common/ExtendedCloud.js
@@ -1,15 +1,16 @@
 import * as rtv from 'rtvjs';
 import { Cloud, CLOUD_EVENTS } from './Cloud';
-import { filter, flatten } from 'lodash';
+import { filter } from 'lodash';
 import { cloudRequest, extractJwtPayload } from '../api/apiUtil';
-import * as strings from '../strings';
 import { Namespace } from '../api/types/Namespace';
-import { Credential, credentialTypesList } from '../api/types/Credential';
+import { Credential } from '../api/types/Credential';
 import { SshKey } from '../api/types/SshKey';
-
-import { logger } from '../util/logger';
 import { Cluster } from '../api/types/Cluster';
+import { Proxy } from '../api/types/Proxy';
+import { License } from '../api/types/License';
+import { logger } from '../util/logger';
 import { EventDispatcher } from './EventDispatcher';
+import { apiEntities, apiCredentialEntities } from '../api/apiConstants';
 
 export const EXTENDED_CLOUD_EVENTS = Object.freeze({
   /**
@@ -77,97 +78,197 @@ const getErrorMessage = (error) => {
 };
 
 /**
- * Deserialize the raw list of credentials data from the API into credentials objects.
- * @param {Object} body Data response from /list/credential API by credentialTypes
- * @param {Namespace} namespace The Namespace object
- * @param {strings} credentialType one of credentialTypesList
- * @returns {Array<Credential>} Array of Credential objects.
+ * Deserialize a raw list of API entity objects into `ApiObject` instances.
+ * @param {string} entity API entity name to fetch from the `apiConstants.apiEntities` enum.
+ * @param {Object} body Data response from `/list/{entity}` API.
+ * @param {Namespace} [namespace] The related Namespace; `undefined` if fetching
+ *  namespaces themselves (i.e. `entity === apiEntities.NAMESPACE`).
+ * @returns {Array<ApiObject>} Array of API objects. Empty list if none. Any
+ *  item that can't be deserialized is ignored and not returned in the list.
  */
-const _deserializeCredentialsList = function (body, namespace, credentialType) {
+const _deserializeEntityList = function (entity, body, namespace, create) {
   if (!body || !Array.isArray(body.items)) {
-    return {
-      error: strings.extendedCloud.error.invalidCredentialsPayload(),
-    };
+    logger.error(
+      'ExtendedCloud._deserializeEntityList()',
+      `Failed to parse "${entity}" payload: Unexpected data format`
+    );
+    return [];
   }
 
   return body.items
-    .map((item, idx) => {
+    .map((data, idx) => {
       try {
-        return new Credential(item, namespace, credentialType);
+        return create({ data, namespace });
       } catch (err) {
         logger.warn(
-          'ExtendedCloud._deserializeCredentialsList()',
-          `Ignoring credential ${idx} because it could not be deserialized: ${err.message}`,
+          'ExtendedCloud._deserializeEntityList()',
+          `Ignoring "${entity}" entity ${idx}${
+            namespace ? ` from namespace "${namespace.name}"` : ''
+          }: Could not be deserialized, error="${getErrorMessage(err)}"`,
           err
         );
         return undefined;
       }
     })
-    .filter((shKey) => !!shKey);
+    .filter((obj) => !!obj);
 };
 
 /**
- * [ASYNC] Get all existing Credentials from the management cluster, for each namespace
- *  specified.
+ * [ASYNC] Best-try to get all existing entities of a given type from the management cluster,
+ *  for each namespace specified.
+ * @param {Object} params
+ * @param {string} params.entity API entity name to fetch from the `apiConstants.apiEntities` enum.
+ * @param {Cloud} params.cloud An Cloud object. Tokens will be updated/cleared
+ *  if necessary.
+ * @param {Array<Namespace>} [params.namespaces] List of namespaces in which to get the entities.
+ *  __REQUIRED__ unless `entity === apiEntities.NAMESPACE`, in which case this parameter is
+ *  ignored because we're fetching the namespaces themselves.
+ * @param {(params: { data: Object, namespace?: Namespace }) => ApiObject} params.create Function
+ *  called to create new instance of an `ApiObject`-based class that represents the API entity.
+ *  - `data` is the raw object returned from the API for the entity
+ *  - `namespace` is the related Namespace (`undefined` when fetching namespaces themselves
+ *      with `entity === apiEntities.NAMESPACE`)
+ * @returns {Promise<Object>} Never fails, always resolves in
+ *  `{ entities: { [index: string]: Array<ApiObject> }, tokensRefreshed: boolean }`,
+ *  where `entities` is a map of namespace name to list of `ApiObject`-based instances
+ *  as returned by `create()`. If an error occurs trying to get an entity or deserialize
+ *  it, it is ignored/skipped.
+ *
+ *  NOTE: If `entity === apiEntities.NAMESPACE` (i.e. fetching namespaces themselves),
+ *   `entities` is a map with a single key which is the `apiEntities.NAMESPACE` entity
+ *   mapped to the list of all namespaces in the Cloud.
+ */
+const _fetchEntityList = async function ({
+  entity,
+  cloud,
+  namespaces,
+  create,
+}) {
+  rtv.verify(
+    { entity },
+    { entity: [rtv.STRING, { oneOf: Object.values(apiEntities) }] }
+  );
+
+  let tokensRefreshed = false;
+
+  // process a result from an API call
+  // NOTE: `namespace` is `undefined` when fetching namespaces themselves
+  const processResult = (
+    { body, tokensRefreshed: refreshed, error, status },
+    namespace
+  ) => {
+    tokensRefreshed = tokensRefreshed || refreshed;
+
+    let items = [];
+    if (error) {
+      // if it's a 403 "access denied" issue, just log it but don't flag it
+      //  as an error since there are various mechianisms that could prevent
+      //  a user from accessing certain entities in the API (disabled components,
+      //  permissions, etc.)
+      logger[status === 403 ? 'log' : 'error'](
+        'ExtendedCloud._fetchEntityList',
+        `${
+          status === 403 ? '(IGNORED: Access denied) ' : ''
+        }Failed to get "${entity}" entities, namespace=${
+          namespace?.name || namespace // undefined if `entity === apiEntities.NAMESPACE`
+        }, status=${status}, error="${getErrorMessage(error)}"`
+      );
+    } else {
+      items = _deserializeEntityList(entity, body, namespace, create);
+    }
+
+    return {
+      items,
+      namespace,
+    };
+  };
+
+  let results;
+  if (entity === apiEntities.NAMESPACE) {
+    const result = await cloudRequest({
+      cloud,
+      method: 'list',
+      entity: apiEntities.NAMESPACE,
+    });
+    results = [processResult(result)];
+  } else {
+    results = await Promise.all(
+      namespaces.map(async (namespace) => {
+        const result = await cloudRequest({
+          cloud,
+          method: 'list',
+          entity,
+          args: { namespaceName: namespace.name }, // extra args
+        });
+
+        return processResult(result, namespace);
+      })
+    );
+  }
+
+  // NOTE: the loop above ensures that there are no error results; all items in
+  //  `results` have the same shape
+
+  let entities;
+  if (entity === apiEntities.NAMESPACE) {
+    entities = { [apiEntities.NAMESPACE]: results[0].items };
+  } else {
+    entities = results.reduce((acc, val) => {
+      const {
+        namespace: { name: nsName },
+        items,
+      } = val;
+      acc[nsName] = items;
+      return acc;
+    }, {});
+  }
+
+  return { entities, tokensRefreshed };
+};
+
+/**
+ * [ASYNC] Best-try to get all existing Credentials from the management cluster, for each
+ *  namespace specified.
  * @param {Cloud} cloud An Cloud object. Tokens will be updated/cleared
  *  if necessary.
  * @param {Array<Namespace>} namespaces List of namespaces.
- * @returns {Promise<Object>} On success
- *  `{ credentials: {Array<Credential>}, tokensRefreshed: boolean }`,
- *  where `credentials` is a map of namespace name to credential type, to a raw credential
- *  API object; or `{error: string}` on error. The error will be the first-found error out of
- *  all namespaces on which SSH Key retrieval was attempted.
+ * @returns {Promise<Object>} Never fails, always resolves in
+ *  `{ credentials: { [index: string]: Array<Credential> }, tokensRefreshed: boolean }`,
+ *  where `credentials` is a map of namespace name to credential (regardless of type).
+ *  If there's an error trying to get any credential, it will be skipped/ignored.
  */
 const _fetchCredentials = async function (cloud, namespaces) {
-  let tokensRefreshed = false;
   const results = await Promise.all(
-    credentialTypesList.map(async (entity) => {
-      return await Promise.all(
-        namespaces.map(async (namespace) => {
-          const {
-            body,
-            tokensRefreshed: refreshed,
-            error,
-          } = await cloudRequest({
-            cloud,
-            method: 'list',
-            entity,
-            args: { namespaceName: namespace.name }, // extra args
-          });
-
-          tokensRefreshed = tokensRefreshed || refreshed;
-
-          const items = _deserializeCredentialsList(body, namespace, entity);
-
-          return {
-            items,
-            error: error || items.error,
-            namespace,
-          };
-        })
-      );
-    })
+    Object.values(apiCredentialEntities).map((entity) =>
+      _fetchEntityList({
+        entity,
+        cloud,
+        namespaces,
+        create: ({ data, namespace }) => new Credential(data, namespace),
+      })
+    )
   );
 
-  // `results` will be an array of arrays because of each credential type that was
-  //  retrieved for each namespace
-  const flattenCreds = flatten(results);
+  // NOTE: `results` will be an array of `{ entities, tokensRefreshed }` because of each credential
+  //  type that was retrieved for each namespace
+  // NOTE: _fetchEntityList() ensures there are no error results; all items in
+  //  `results` have the same shape
 
-  const error = (flattenCreds.find((c) => c.error) || {}).error;
-  if (error) {
-    return { error };
-  }
+  let tokensRefreshed = false;
+  const credentials = results.reduce((acc, result) => {
+    const { entities, tokensRefreshed: refreshed } = result;
 
-  const credentials = flattenCreds.reduce((acc, val) => {
-    const {
-      namespace: { name: nsName },
-      items,
-    } = val;
-    if (acc[nsName]) {
-      acc[nsName] = [...acc[nsName], ...items];
-    } else {
-      acc[nsName] = [...items];
-    }
+    tokensRefreshed = tokensRefreshed || refreshed;
+
+    Object.keys(entities).forEach((nsName) => {
+      const creds = entities[nsName];
+      if (acc[nsName]) {
+        acc[nsName] = [...acc[nsName], ...creds];
+      } else {
+        acc[nsName] = [...creds];
+      }
+    });
+
     return acc;
   }, {});
 
@@ -175,171 +276,110 @@ const _fetchCredentials = async function (cloud, namespaces) {
 };
 
 /**
- * Deserialize the raw list of sshKeys data from the API into sshKeys object.
- * @param {Object} body Data response from /list/sshKey API
- * @param {Namespace} namespace The Namespace object
- * @returns {Array<SshKey>} Array of SshKey objects.
- */
-const _deserializeSshKeysList = function (body, namespace) {
-  if (!body || !Array.isArray(body.items)) {
-    return {
-      error: strings.extendedCloud.error.invalidSshKeysPayload(),
-    };
-  }
-
-  return body.items
-    .map((item, idx) => {
-      try {
-        return new SshKey(item, namespace);
-      } catch (err) {
-        logger.warn(
-          'ExtendedCloud._deserializeSshKeysList()',
-          `Ignoring sshKey ${idx} because it could not be deserialized: ${err.message}`,
-          err
-        );
-        return undefined;
-      }
-    })
-    .filter((shKey) => !!shKey);
-};
-
-/**
- * [ASYNC] Get all existing SSH Keys from the management cluster, for each namespace
- *  specified.
+ * [ASYNC] Best-try to get all existing licenses from the management cluster, for each
+ *  namespace specified.
  * @param {Cloud} cloud An Cloud object. Tokens will be updated/cleared
  *  if necessary.
  * @param {Array<Namespace>} namespaces List of namespaces.
- * @returns {Promise<Object>} On success `{ sshKeys: { [index: string]: Array<ApiSshKey> }, tokensRefreshed: boolean }`,
- *  where `sshKeys` is a map of namespace name to list of SSH keys; or `{error: string}` on error.
- *  The error will be the first-found error out of all namespaces on which SSH Key retrieval
- *  was attempted.
+ * @returns {Promise<Object>} Never fails, always resolves in
+ *  `{ licenses: { [index: string]: Array<License> }, tokensRefreshed: boolean }`
+ *  where the licenses are mapped per namespace name. If an error occurs trying to get
+ *  any license, it will be ignored/skipped.
+ */
+const _fetchLicenses = async function (cloud, namespaces) {
+  const { entities: licenses, tokensRefreshed } = await _fetchEntityList({
+    entity: apiEntities.RHEL_LICENSE,
+    cloud,
+    namespaces,
+    create: ({ data, namespace }) => new License(data, namespace),
+  });
+  return { licenses, tokensRefreshed };
+};
+
+/**
+ * [ASYNC] Best-try to get all existing proxies from the management cluster, for each
+ *  namespace specified.
+ * @param {Cloud} cloud An Cloud object. Tokens will be updated/cleared
+ *  if necessary.
+ * @param {Array<Namespace>} namespaces List of namespaces.
+ * @returns {Promise<Object>} Never fails, always resolves in
+ *  `{ proxies: { [index: string]: Array<Proxy> }, tokensRefreshed: boolean }`
+ *  where the proxies are mapped per namespace name. If an error occurs trying to get
+ *  any proxy, it will be ignored/skipped.
+ */
+const _fetchProxies = async function (cloud, namespaces) {
+  const { entities: proxies, tokensRefreshed } = await _fetchEntityList({
+    entity: apiEntities.PROXY,
+    cloud,
+    namespaces,
+    create: ({ data, namespace }) => new Proxy(data, namespace),
+  });
+  return { proxies, tokensRefreshed };
+};
+
+/**
+ * [ASYNC] Best-try to get all existing SSH keys from the management cluster, for each
+ *  namespace specified.
+ * @param {Cloud} cloud An Cloud object. Tokens will be updated/cleared
+ *  if necessary.
+ * @param {Array<Namespace>} namespaces List of namespaces.
+ * @returns {Promise<Object>} Never fails, always resolves in
+ *  `{ sshKeys: { [index: string]: Array<SshKey> }, tokensRefreshed: boolean }`
+ *  where the SSH keys are mapped per namespace name. If an error occurs trying to get
+ *  any SSH key, it will be ignored/skipped.
  */
 const _fetchSshKeys = async function (cloud, namespaces) {
-  let tokensRefreshed = false;
-  const results = await Promise.all(
-    namespaces.map(async (namespace) => {
-      const {
-        body,
-        tokensRefreshed: refreshed,
-        error,
-      } = await cloudRequest({
-        cloud,
-        method: 'list',
-        entity: 'publickey',
-        args: { namespaceName: namespace.name }, // extra args
-      });
-
-      tokensRefreshed = tokensRefreshed || refreshed;
-
-      const items = _deserializeSshKeysList(body, namespace);
-      return { items, error: error || items.error, namespace };
-    })
-  );
-
-  const error = (results.find((sk) => sk.error) || {}).error;
-  if (error) {
-    return { error };
-  }
-
-  const sshKeys = results.reduce((acc, val) => {
-    const {
-      namespace: { name: nsName },
-      items,
-    } = val;
-    acc[nsName] = items;
-    return acc;
-  }, {});
-
+  const { entities: sshKeys, tokensRefreshed } = await _fetchEntityList({
+    entity: apiEntities.PUBLIC_KEY,
+    cloud,
+    namespaces,
+    create: ({ data, namespace }) => new SshKey(data, namespace),
+  });
   return { sshKeys, tokensRefreshed };
 };
 
 /**
- * Deserialize the raw list of cluster data from the API into Cluster objects.
- * @param {Object} body Data response from /list/cluster API.
- * @param {Cloud} cloud The Cloud object used to access the clusters.
- * @param {Namespace} namespace The Namespace object
- * @returns {Array<Cluster>} Array of Cluster objects.
- */
-const _deserializeClustersList = function (body, cloud, namespace) {
-  if (!body || !Array.isArray(body.items)) {
-    return { error: strings.extendedCloud.error.invalidClusterPayload() };
-  }
-
-  return body.items
-    .map((item, idx) => {
-      try {
-        return new Cluster(item, cloud.username, namespace);
-      } catch (err) {
-        logger.warn(
-          'ExtendedCloud._deserializeClustersList()',
-          `Ignoring cluster ${idx} (namespace/name="${
-            item?.metadata?.namespace ?? '<unknown>'
-          }/${
-            item?.metadata?.name ?? '<unknown>'
-          }") because it could not be deserialized: ${err.message}`,
-          err
-        );
-        return undefined;
-      }
-    })
-    .filter((cl) => !!cl); // eliminate invalid clusters (`undefined` items)
-};
-
-/**
- * Deserialize the raw list of namespace data from the API into Namespace objects.
- * @param {Object} body Data response from /list/namespace API.
- * @returns {Array<Namespace>} Array of Namespace objects.
- */
-const _deserializeNamespacesList = function (body) {
-  if (!body || !Array.isArray(body.items)) {
-    return {
-      error: strings.extendedCloud.error.invalidNamespacePayload(),
-    };
-  }
-
-  return {
-    data: body.items
-      .map((item, idx) => {
-        try {
-          return new Namespace(item);
-        } catch (err) {
-          logger.warn(
-            'ExtendedCloud._deserializeNamespacesList()',
-            `Ignoring namespace ${idx} because it could not be deserialized: ${err.message}`,
-            err
-          );
-          return undefined;
-        }
-      })
-      .filter((cl) => !!cl), // eliminate invalid namespaces (`undefined` items)
-  };
-};
-
-/**
- * [ASYNC] Get all existing namespaces from the management cluster.
+ * [ASYNC] Best-try to get all existing clusters from the management cluster, for each
+ *  namespace specified.
  * @param {Cloud} cloud An Cloud object. Tokens will be updated/cleared
  *  if necessary.
- * @returns {Promise<Object>} On success `{ namespaces: Array<Namespace>, tokensRefreshed: boolean }`;
- *  on error `{error: string}`.
+ * @param {Array<Namespace>} namespaces List of namespaces.
+ * @returns {Promise<Object>} Never fails, always resolves in
+ *  `{ clusters: { [index: string]: Array<Cluster> }, tokensRefreshed: boolean }`
+ *  where the clusters are mapped per namespace name. If an error occurs trying to get
+ *  any cluster, it will be ignored/skipped.
+ */
+const _fetchClusters = async function (cloud, namespaces) {
+  const { entities: clusters, tokensRefreshed } = await _fetchEntityList({
+    entity: apiEntities.CLUSTER,
+    cloud,
+    namespaces,
+    create: ({ data, namespace }) =>
+      new Cluster(data, namespace, cloud.username),
+  });
+  return { clusters, tokensRefreshed };
+};
+
+/**
+ * [ASYNC] Best-try to get all existing namespaces from the management cluster.
+ * @param {Cloud} cloud An Cloud object. Tokens will be updated/cleared
+ *  if necessary.
+ * @returns {Promise<Object>} Never fails, always resolves in
+ *  `{ namespaces: Array<Namespace>, tokensRefreshed: boolean }`. If an error occurs
+ *  trying to get any namespace, it will be ignored/skipped.
  */
 const _fetchNamespaces = async function (cloud) {
   // NOTE: we always fetch ALL known namespaces because when we display metadata
   //  about this ExtendedCloud, we always need to show the actual total, not just
   //  what we're syncing
-  const { error, body, tokensRefreshed } = await cloudRequest({
+  const {
+    entities: { [apiEntities.NAMESPACE]: namespaces },
+    tokensRefreshed,
+  } = await _fetchEntityList({
+    entity: apiEntities.NAMESPACE,
     cloud,
-    method: 'list',
-    entity: 'namespace',
+    create: ({ data }) => new Namespace(data),
   });
-
-  if (error) {
-    return { error };
-  }
-
-  const { data, error: dsError } = _deserializeNamespacesList(body);
-  if (dsError) {
-    return { error: dsError };
-  }
 
   const userRoles = extractJwtPayload(cloud.token).iam_roles || [];
 
@@ -348,65 +388,34 @@ const _fetchNamespaces = async function (cloud) {
     userRoles.includes(`m:kaas:${name}@writer`);
 
   const ignoredNamespaces = cloud?.config?.ignoredNamespaces || [];
-  const namespaces = filter(
-    data,
-    (ns) => !ignoredNamespaces.includes(ns.name) && hasReadPermissions(ns.name)
-  );
 
-  return { namespaces, tokensRefreshed };
+  return {
+    namespaces: filter(
+      namespaces,
+      (ns) =>
+        !ignoredNamespaces.includes(ns.name) && hasReadPermissions(ns.name)
+    ),
+    tokensRefreshed,
+  };
 };
 
 /**
- * [ASYNC] Get all existing clusters from the management cluster, for each namespace
- *  specified.
- * @param {Cloud} cloud An Cloud object. Tokens will be updated/cleared
- *  if necessary.
- * @param {Array<Namespace>} namespaces List of namespaces.
- * @returns {Promise<Object>} On success `{ clusters: Array<Cluster>, tokensRefreshed: boolean }`
- *  where the list of clusters is flat and in the order of the specified namespaces (use
- *  `Cluster.namespace` to identify which cluster belongs to which namespace);
- *  on error `{error: string}`. The error will be the first-found error out of
- *  all namespaces on which cluster retrieval was attempted.
+ * Performs scheduled and on-demand data fetching of a given Cloud.
+ * @class ExtendedCloud
  */
-const _fetchClusters = async function (cloud, namespaces) {
-  let tokensRefreshed = false;
-
-  const results = await Promise.all(
-    namespaces.map(async (namespace) => {
-      const {
-        body,
-        tokensRefreshed: refreshed,
-        error,
-      } = await cloudRequest({
-        cloud,
-        method: 'list',
-        entity: 'cluster',
-        args: { namespaceName: namespace.name }, // extra args
-      });
-      tokensRefreshed = tokensRefreshed || refreshed;
-
-      const items = _deserializeClustersList(body, cloud, namespace);
-      return { items, error: error || items.error, namespace };
-    })
-  );
-
-  const error = (results.find((cl) => cl.error) || {}).error;
-  if (error) {
-    return { error };
-  }
-
-  let clusters = [];
-
-  results.every(({ items }) => {
-    clusters = [...clusters, ...items];
-    return true; // next
-  });
-
-  return { clusters, tokensRefreshed };
-};
-
 export class ExtendedCloud extends EventDispatcher {
-  constructor(cloud) {
+  /**
+   * @constructor
+   * @param {Cloud} cloud The Cloud that provides backing for the ExtendedCloud to access
+   *  the API and determines which namespaces are synced.
+   * @param {boolean} [preview] If truthy, declares this instance is only for preview
+   *  purposes, which reduces the amount of data fetched from the Cloud in order to
+   *  make data fetching a bit faster. Retrieving licenses and proxies can take quite
+   *  a bit more time for some reason, and we don't list their numbers when the user
+   *  is adding a new Cloud connection, so there's no point retrieving that data if
+   *  the user ultimately chooses not to add the Cloud.
+   */
+  constructor(cloud, preview) {
     super();
 
     let _loaded = false; // true if we've fetched data at least once, successfully
@@ -531,6 +540,19 @@ export class ExtendedCloud extends EventDispatcher {
       },
     });
 
+    /**
+     * @member {boolean} preview True if this instance is for previous purposes
+     *  only; false if it's for full use. Use a preview instance when letting the
+     *  user choose whether they want to add a new Cloud or not. Use a full instance
+     *  for a Cloud that has formally been added and is being synced.
+     */
+    Object.defineProperty(this, 'preview', {
+      enumerable: true,
+      get() {
+        return !!preview;
+      },
+    });
+
     //// initialize
 
     this.cloud = cloud;
@@ -575,7 +597,8 @@ export class ExtendedCloud extends EventDispatcher {
   get syncedNamespaces() {
     return this.namespaces.filter(
       (namespace) =>
-        this.cloud.syncAll || this.cloud.syncNamespaces.includes(namespace.name)
+        this.cloud.syncAll ||
+        this.cloud.syncedNamespaces.includes(namespace.name)
     );
   }
 
@@ -651,76 +674,47 @@ export class ExtendedCloud extends EventDispatcher {
     );
 
     const nsResults = await _fetchNamespaces(this.cloud);
-    let error = nsResults.error;
-    let clusterResults;
-    let keyResults;
-    let credResults;
+    const clusterResults = await _fetchClusters(
+      this.cloud,
+      nsResults.namespaces
+    );
+    const credResults = await _fetchCredentials(
+      this.cloud,
+      nsResults.namespaces
+    );
+    const keyResults = await _fetchSshKeys(this.cloud, nsResults.namespaces);
 
-    if (!nsResults.error) {
-      clusterResults = await _fetchClusters(this.cloud, nsResults.namespaces);
-      error = clusterResults.error;
-      if (!clusterResults.error) {
-        credResults = await _fetchCredentials(this.cloud, nsResults.namespaces);
-        error = credResults.error;
-        if (!credResults.error) {
-          keyResults = await _fetchSshKeys(this.cloud, nsResults.namespaces);
-          error = keyResults.error;
-        }
-      }
+    let proxyResults;
+    let licenseResults;
+    if (!this.preview) {
+      proxyResults = await _fetchProxies(this.cloud, nsResults.namespaces);
+      licenseResults = await _fetchLicenses(this.cloud, nsResults.namespaces);
+    } else {
+      logger.log(
+        'ExtendedCloud.fetchData()',
+        `Skipping proxy and license fetch for preview instance, extCloud=${this}`
+      );
     }
 
-    if (error) {
-      // NOTE: in this case, we don't set `this.namespaces`, leaving it as its
-      //  previous value so we don't lose the Cloud's last known state if we have it
-      this.error = getErrorMessage(error);
+    this.error = null;
 
-      if (nsResults?.error) {
-        logger.error(
-          'ExtendedCloud.fetchData()',
-          `Failed to fetch namespaces; error="${nsResults.error}", extCloud=${this}`
-        );
-      }
+    this.namespaces = nsResults.namespaces.map((namespace) => {
+      namespace.clusters = clusterResults?.clusters[namespace.name] || [];
+      namespace.sshKeys = keyResults?.sshKeys[namespace.name] || [];
+      namespace.credentials = credResults?.credentials[namespace.name] || [];
+      namespace.proxies = proxyResults?.proxies[namespace.name] || [];
+      namespace.licenses = licenseResults?.licenses[namespace.name] || [];
 
-      if (clusterResults?.error) {
-        logger.error(
-          'ExtendedCloud.fetchData()',
-          `Failed to get cluster metadata, error="${clusterResults?.error}", extCloud=${this}`
-        );
-      }
+      return namespace;
+    });
 
-      if (keyResults?.error) {
-        logger.error(
-          'ExtendedCloud.fetchData()',
-          `Failed to get ssh key metadata, error="${keyResults?.error}", extCloud=${this}`
-        );
-      }
-
-      if (credResults?.error) {
-        logger.error(
-          'ExtendedCloud.fetchData()',
-          `Failed to get credential metadata, error="${credResults?.error}", extCloud=${this}`
-        );
-      }
-    } else {
-      this.error = null;
-
-      this.namespaces = nsResults.namespaces.map((namespace) => {
-        namespace.clusters = clusterResults.clusters.filter(
-          (c) => c.namespace.name === namespace.name
-        );
-        namespace.sshKeys = keyResults.sshKeys[namespace.name];
-        namespace.credentials = credResults.credentials[namespace.name];
-        return namespace;
-      });
-
-      if (!this.loaded) {
-        // successfully loaded at least once
-        this.loaded = true;
-        logger.log(
-          'ExtendedCloud.fetchData()',
-          `Initial data load successful, extCloud=${this}`
-        );
-      }
+    if (!this.loaded) {
+      // successfully loaded at least once
+      this.loaded = true;
+      logger.log(
+        'ExtendedCloud.fetchData()',
+        `Initial data load successful, extCloud=${this}`
+      );
     }
 
     this.fetching = false;
@@ -755,8 +749,8 @@ export class ExtendedCloud extends EventDispatcher {
   toString() {
     return `{ExtendedCloud loaded: ${this.loaded}, fetching: ${
       this.fetching
-    }, namespaces: ${this.loaded ? this.namespaces.length : '??'}, error: ${
-      this.error
-    }, cloud: ${this.cloud}}`;
+    }, preview: ${this.preview}, namespaces: ${
+      this.loaded ? this.namespaces.length : '??'
+    }, error: ${this.error}, cloud: ${this.cloud}}`;
   }
 }

--- a/src/common/ExtendedCloud.js
+++ b/src/common/ExtendedCloud.js
@@ -83,6 +83,11 @@ const getErrorMessage = (error) => {
  * @param {Object} body Data response from `/list/{entity}` API.
  * @param {Namespace} [namespace] The related Namespace; `undefined` if fetching
  *  namespaces themselves (i.e. `entity === apiEntities.NAMESPACE`).
+ * @param {(params: { data: Object, namespace?: Namespace }) => ApiObject} params.create Function
+ *  called to create new instance of an `ApiObject`-based class that represents the API entity.
+ *  - `data` is the raw object returned from the API for the entity
+ *  - `namespace` is the related Namespace (`undefined` when fetching namespaces themselves
+ *      with `entity === apiEntities.NAMESPACE`)
  * @returns {Array<ApiObject>} Array of API objects. Empty list if none. Any
  *  item that can't be deserialized is ignored and not returned in the list.
  */

--- a/src/main/IpcMain.js
+++ b/src/main/IpcMain.js
@@ -7,10 +7,10 @@ import { observable } from 'mobx';
 import { Main, Common } from '@k8slens/extensions';
 import * as rtv from 'rtvjs';
 import {
-  clusterModelTs,
-  sshKeyModelTs,
-  credentialModelTs,
-  proxyModelTs,
+  clusterEntityModelTs,
+  sshKeyEntityModelTs,
+  credentialEntityModelTs,
+  proxyEntityModelTs,
 } from '../typesets';
 import { clusterStore } from '../store/ClusterStore';
 import { logger } from '../util/logger';
@@ -178,7 +178,7 @@ export class IpcMain extends Main.Ipc {
    * @param {boolean} [persist] If false, models will not be persisted to the store.
    */
   addClusters(models, persist = true) {
-    DEV_ENV && rtv.verify({ models }, { models: [[clusterModelTs]] });
+    DEV_ENV && rtv.verify({ models }, { models: [[clusterEntityModelTs]] });
 
     models.forEach((model) => {
       // officially add to Lens
@@ -275,7 +275,7 @@ export class IpcMain extends Main.Ipc {
       },
     ];
 
-    DEV_ENV && rtv.verify(sshKeyModels, [[sshKeyModelTs]]);
+    DEV_ENV && rtv.verify(sshKeyModels, [[sshKeyEntityModelTs]]);
 
     sshKeyModels.forEach((model) => {
       this.capture(
@@ -327,7 +327,7 @@ export class IpcMain extends Main.Ipc {
       },
     ];
 
-    DEV_ENV && rtv.verify(credentialModels, [[credentialModelTs]]);
+    DEV_ENV && rtv.verify(credentialModels, [[credentialEntityModelTs]]);
 
     credentialModels.forEach((model) => {
       this.capture(
@@ -377,7 +377,7 @@ export class IpcMain extends Main.Ipc {
       },
     ];
 
-    DEV_ENV && rtv.verify(proxyModels, [[proxyModelTs]]);
+    DEV_ENV && rtv.verify(proxyModels, [[proxyEntityModelTs]]);
 
     proxyModels.forEach((model) => {
       this.capture(

--- a/src/renderer/components/ClusterPage/ClusterView.js
+++ b/src/renderer/components/ClusterPage/ClusterView.js
@@ -1,5 +1,5 @@
 //
-// Main view for the ClusterPage
+// Main view for the ClusterPage within the 'Lens > Catalog > Cluster' UI
 //
 
 import styled from '@emotion/styled';
@@ -9,7 +9,7 @@ import * as strings from '../../../strings';
 import * as consts from '../../../constants';
 import { layout, mixinPageStyles } from '../styles';
 import { logger } from '../../../util/logger';
-import { clusterModelTs } from '../../../typesets';
+import { clusterEntityModelTs } from '../../../typesets';
 
 const { Component } = Renderer;
 
@@ -93,7 +93,7 @@ export const ClusterView = function () {
     return null;
   }
 
-  DEV_ENV && rtv.verify(clusterEntity, clusterModelTs);
+  DEV_ENV && rtv.verify(clusterEntity, clusterEntityModelTs);
 
   //
   // STATE

--- a/src/renderer/components/EnhancedTable/AdditionalInfoRows.js
+++ b/src/renderer/components/EnhancedTable/AdditionalInfoRows.js
@@ -47,7 +47,7 @@ export const AdditionalInfoRows = ({ namespace, emptyCellsCount }) => {
     },
     {
       infoName: managementClusters.table.tbodyDetailedInfo.credentials(),
-      infoCount: namespace.credentialsCount,
+      infoCount: namespace.credentialCount,
     },
   ];
   return (

--- a/src/renderer/components/EnhancedTable/EnhancedTableRow.js
+++ b/src/renderer/components/EnhancedTable/EnhancedTableRow.js
@@ -140,7 +140,7 @@ const getCloudMenuItems = (extendedCloud) => [
         name: cloudName,
         cloudUrl,
         syncAll,
-        syncNamespaces,
+        syncedNamespaces,
         connected,
       } = extendedCloud.cloud;
       const isConnected = connected && extendedCloud.loaded;
@@ -148,7 +148,7 @@ const getCloudMenuItems = (extendedCloud) => [
         cloudStore.removeCloud(cloudUrl);
       } else {
         const projects = !syncAll
-          ? syncNamespaces
+          ? syncedNamespaces
           : isConnected
           ? extendedCloud.namespaces
           : [];

--- a/src/renderer/components/GlobalPage/AddCloudInstance.js
+++ b/src/renderer/components/GlobalPage/AddCloudInstance.js
@@ -62,7 +62,8 @@ export const AddCloudInstance = ({ onAdd, onCancel }) => {
   const makeExtCloud = useCallback(() => {
     setLoading(true);
 
-    const extCl = new ExtendedCloud(cloud);
+    // just use a minimal preview instance since it's throw-away
+    const extCl = new ExtendedCloud(cloud, true);
 
     const loadingListener = () => {
       // when extCl loaded, it means extCl contains all needed data

--- a/src/renderer/components/GlobalPage/SyncView.js
+++ b/src/renderer/components/GlobalPage/SyncView.js
@@ -79,7 +79,7 @@ export const SyncView = () => {
   const openSelectiveSyncView = () => setIsSelectiveSyncView(true);
   /**
    * @param {boolean} data.syncAll
-   * @param {Array<string>} data.syncNamespaces
+   * @param {Array<string>} data.syncedNamespaces
    * @param {string} url - cloudUrl
    */
   const getDataToSync = (data, url) => {
@@ -103,10 +103,10 @@ export const SyncView = () => {
     if (!isSyncStarted && Object.keys(syncedClouds).length) {
       // go through all clouds and update properties
       Object.keys(syncedClouds).map((url) => {
-        const { syncAll, syncNamespaces } = syncedClouds[url];
+        const { syncAll, syncedNamespaces } = syncedClouds[url];
         const cloud = cloudStore.clouds[url];
         cloud.syncAll = syncAll;
-        cloud.syncNamespaces = syncNamespaces;
+        cloud.syncedNamespaces = syncedNamespaces;
       });
       closeSelectiveSyncView();
     }

--- a/src/renderer/components/GlobalPage/SynchronizeBlock.js
+++ b/src/renderer/components/GlobalPage/SynchronizeBlock.js
@@ -127,15 +127,15 @@ export const SynchronizeBlock = ({ extendedCloud, onAdd }) => {
 
   const onSynchronize = () => {
     const { cloud } = extendedCloud;
-    const { syncNamespaces, syncAll } = getSyncedData();
+    const { syncedNamespaces, syncAll } = getSyncedData();
 
-    if (!syncAll && !syncNamespaces.length) {
+    if (!syncAll && !syncedNamespaces.length) {
       Notifications.error(synchronizeBlock.error.noProjects());
       return;
     }
 
     cloud.syncAll = syncAll;
-    cloud.syncNamespaces = syncNamespaces;
+    cloud.syncedNamespaces = syncedNamespaces;
 
     onAdd(cloud);
   };
@@ -194,7 +194,7 @@ export const SynchronizeBlock = ({ extendedCloud, onAdd }) => {
                       <li>
                         <p>
                           {synchronizeBlock.checkboxesDropdownLabels.credentials()}{' '}
-                          ({namespace.credentialsCount})
+                          ({namespace.credentialCount})
                         </p>
                       </li>
                     </AccordionChildrenList>

--- a/src/renderer/components/hooks/useCheckboxes.js
+++ b/src/renderer/components/hooks/useCheckboxes.js
@@ -111,11 +111,11 @@ export function useCheckboxes(initialState) {
 
   const getSyncedData = () => {
     if (getParentCheckboxValue() === checkValues.CHECKED) {
-      return { syncAll: true, syncNamespaces: [] };
+      return { syncAll: true, syncedNamespaces: [] };
     }
     return {
       syncAll: false,
-      syncNamespaces: Object.keys(checkboxesState.children).filter(
+      syncedNamespaces: Object.keys(checkboxesState.children).filter(
         (name) => checkboxesState.children[name]
       ),
     };

--- a/src/store/ClusterStore.js
+++ b/src/store/ClusterStore.js
@@ -6,12 +6,12 @@ import { observable, action, toJS, makeObservable } from 'mobx';
 import { Common } from '@k8slens/extensions';
 import * as rtv from 'rtvjs';
 import { logger } from '../util/logger';
-import { clusterModelTs } from '../typesets';
+import { clusterEntityModelTs } from '../typesets';
 
 /** RTV.js typeset for preferences model. */
 export const storeTs = {
   /** List of models representing each cluster in the Catalog added by this extension. */
-  models: [[clusterModelTs]],
+  models: [[clusterEntityModelTs]],
 };
 
 /** Preferences auto-persisted by Lens. Singleton. Use `getInstance()` static method. */

--- a/src/strings.ts
+++ b/src/strings.ts
@@ -316,19 +316,6 @@ export const cloud: Dict = {
   },
 };
 
-export const extendedCloud: Dict = {
-  error: {
-    invalidClusterPayload: () =>
-      'Failed to parse Clusters payload: Unexpected data format.',
-    invalidNamespacePayload: () =>
-      'Failed to parse Namespaces payload: Unexpected data format.',
-    invalidCredentialsPayload: () =>
-      'Failed to parse Credentials payload: Unexpected data format.',
-    invalidSshKeysPayload: () =>
-      'Failed to parse SSH Keys payload: Unexpected data format.',
-  },
-};
-
 export const connectionStatuses: Dict = {
   cloud: {
     connected: () => 'Connected',
@@ -349,7 +336,10 @@ export const contextMenus: Dict = {
     sync: () => 'Sync now',
     openInBrowser: () => 'Open in browser',
     confirmDialog: {
-      messageHtml: (cloudName, projects) =>
+      messageHtml: (
+        cloudName,
+        projects // `projects` is `Array<Namespace>`
+      ) =>
         `
         <p>Removing management cluster “${cloudName}” will also remove the following projects and their associated catalog items${
           projects.length > 0 ? ':' : '.'

--- a/src/typesets.js
+++ b/src/typesets.js
@@ -5,11 +5,11 @@
 import * as rtv from 'rtvjs';
 
 /**
- * Describes a basic object used to create a new instance of an entity that will
+ * Typeset for a basic object used to create a new instance of an entity that will
  *  be added to the Lens Catalog.
  */
-export const entityModelTs = {
-  // based on Common.Types.CatalogEntityMetadata
+export const catalogEntityModelTs = {
+  // based on Lens Common.Types.CatalogEntityMetadata
   metadata: {
     uid: rtv.STRING,
     name: rtv.STRING,
@@ -32,10 +32,12 @@ export const entityModelTs = {
     namespace: rtv.STRING,
     cloudUrl: rtv.STRING,
   },
-  // spec is specific to the type of entity being added; for a cluster, it requires
-  //  `kubeconfigPath: string` and `kubeconfigContext: string`, but for an SshKeyEntity,
-  //  it's `publicKey: string`
+
+  // spec is specific to the type of entity being added to the Catalog; e.g. for a cluster,
+  //  it requires `kubeconfigPath: string` and `kubeconfigContext: string`, but for an
+  //  SSH key, it requires `publicKey: string`...
   spec: {},
+
   // all entities must have a status with a phase
   // based on Common.Types.CatalogEntityStatus
   status: {
@@ -47,48 +49,52 @@ export const entityModelTs = {
   },
 };
 
+export const clusterEntityPhases = Object.freeze({
+  CONNECTING: 'connecting',
+  CONNECTED: 'connected',
+  DISCONNECTING: 'disconnecting',
+  DISCONNECTED: 'disconnected',
+});
+
 /**
- * Describes an object used to create a new instance of a `Common.Catalog.KubernetesCluster`
+ * Typeset for an object used to create a new instance of a `Common.Catalog.KubernetesCluster`
  *  object that gets added to the Lens Catalog. Also describes the shape of the entity
  *  object we get from iterating "entities" of this type in the Catalog.
  */
-export const clusterModelTs = {
+export const clusterEntityModelTs = {
   metadata: {
-    ...entityModelTs.metadata,
+    ...catalogEntityModelTs.metadata,
   },
   spec: {
-    ...entityModelTs.spec,
+    ...catalogEntityModelTs.spec,
 
     kubeconfigPath: rtv.STRING, // absolute path
     kubeconfigContext: rtv.STRING,
   },
   status: {
-    ...entityModelTs.status,
+    ...catalogEntityModelTs.status,
 
     // override phase with a more specific typeset
-    phase: [
-      rtv.STRING,
-      { oneOf: ['connecting', 'connected', 'disconnecting', 'disconnected'] },
-    ],
+    phase: [rtv.STRING, { oneOf: Object.values(clusterEntityPhases) }],
   },
 };
 
 /**
- * Describes an object used to create a new instance of a `./catalog/SshKeyEntity`
+ * Typeset for an object used to create a new instance of a `./catalog/SshKeyEntity`
  *  object that gets added to the Lens Catalog. Also describes the shape of the entity
  *  object we get from iterating "entities" of this type in the Catalog.
  */
-export const sshKeyModelTs = {
+export const sshKeyEntityModelTs = {
   metadata: {
-    ...entityModelTs.metadata,
+    ...catalogEntityModelTs.metadata,
   },
   spec: {
-    ...entityModelTs.spec,
+    ...catalogEntityModelTs.spec,
 
     publicKey: rtv.STRING,
   },
   status: {
-    ...entityModelTs.status,
+    ...catalogEntityModelTs.status,
 
     // override phase with a more specific typeset
     phase: [rtv.STRING, { oneOf: ['available'] }],
@@ -96,24 +102,29 @@ export const sshKeyModelTs = {
 };
 
 /**
- * Describes an object used to create a new instance of a `./catalog/CredentialEntity`
+ * Typeset for an object used to create a new instance of a `./catalog/CredentialEntity`
  *  object that gets added to the Lens Catalog. Also describes the shape of the entity
  *  object we get from iterating "entities" of this type in the Catalog.
  */
-export const credentialModelTs = {
+export const credentialEntityModelTs = {
   metadata: {
-    ...entityModelTs.metadata,
+    ...catalogEntityModelTs.metadata,
   },
   spec: {
-    ...entityModelTs.spec,
+    ...catalogEntityModelTs.spec,
 
-    provider: [rtv.STRING, { oneOf: ['aws', 'openstack', 'equinix', 'azure'] }],
+    provider: [
+      rtv.STRING,
+      {
+        oneOf: ['aws', 'openstack', 'equinix', 'azure', 'vsphere', 'byo', 'bm'],
+      },
+    ],
     status: {
       valid: rtv.BOOLEAN,
     },
   },
   status: {
-    ...entityModelTs.status,
+    ...catalogEntityModelTs.status,
 
     // override phase with a more specific typeset
     phase: [rtv.STRING, { oneOf: ['available'] }],
@@ -121,23 +132,23 @@ export const credentialModelTs = {
 };
 
 /**
- * Describes an object used to create a new instance of a `./catalog/ProxyEntity`
+ * Typeset for an object used to create a new instance of a `./catalog/ProxyEntity`
  *  object that gets added to the Lens Catalog. Also describes the shape of the entity
  *  object we get from iterating "entities" of this type in the Catalog.
  */
-export const proxyModelTs = {
+export const proxyEntityModelTs = {
   metadata: {
-    ...entityModelTs.metadata,
+    ...catalogEntityModelTs.metadata,
   },
   spec: {
-    ...entityModelTs.spec,
+    ...catalogEntityModelTs.spec,
 
     region: rtv.STRING,
     http: rtv.STRING,
     https: rtv.STRING,
   },
   status: {
-    ...entityModelTs.status,
+    ...catalogEntityModelTs.status,
 
     // override phase with a more specific typeset
     phase: [rtv.STRING, { oneOf: ['available'] }],

--- a/src/util/mergeRtvShapes.js
+++ b/src/util/mergeRtvShapes.js
@@ -1,0 +1,28 @@
+import { mergeWith } from 'lodash'; // deep merge
+
+/**
+ * Performs a deep merge on an object with given sources per normal Lodash merge()
+ *  rules __except__ that it does not deep-merge Arrays as those are expected to
+ *  be Typesets. Those are overwritten on the `object` just like a normal string,
+ *  boolean, or non-plain object property normally would be.
+ * @param {Object} object
+ * @param {Array<Object>} ...sources
+ * @returns {Object} `object` with sources merged into it.
+ */
+export const mergeRtvShapes = function (object, ...sources) {
+  return mergeWith(
+    object,
+    ...[
+      ...sources,
+      (objValue, srcValue) => {
+        if (Array.isArray(objValue)) {
+          // if it's an Array, it's a typeset instead of a shape, and so we __overwrite__
+          //  the current value with the source just like a non-Object property would
+          //  since merging typesets is likely not the intent; we're just using Lodash
+          //  merge() to merge shapes (Objects), not Arrays (RTV.js Typesets)
+          return srcValue;
+        }
+      },
+    ]
+  );
+};

--- a/test/mocks/mockExtCloud.js
+++ b/test/mocks/mockExtCloud.js
@@ -11,7 +11,7 @@ export const mockExtCloud = {
     cloudUrl: 'https://cloud-url.com',
     name: 'Container name',
     syncAll: false,
-    syncNamespaces: [],
+    syncedNamespaces: [],
   },
   loading: false,
   namespaces: [
@@ -91,7 +91,7 @@ export const mockExtCloud2 = {
     cloudUrl: 'https://cloud-url-2.com',
     name: 'Container name 2',
     syncAll: false,
-    syncNamespaces: [],
+    syncedNamespaces: [],
   },
   loading: false,
   namespaces: [


### PR DESCRIPTION
The bulk of this change centers around the following:

- Establish the minimum RTV typesets for our expectations for
  each entity type retrieved from the API.
- Convert `ExtendedCloud.fetchData()` to a "best-try" process
  where we log errors and disregard entities instead of stopping
  the fetch and trying to have an error message. This is in part
  to greatly simplify the fetch, but also to deal with MCC
  disabled components and user permissions that lead to 403
  "access denied" responses when fetching certain entities. If at
  all possible, we don't want to have to replicate this entire
  system from MCC into the extension, so by simply being ready
  to encounter 403s and ignore them (e.g. for BareMetal features
  typically disabled), my hope is to skirt the issue.
- Rename a few key properties that weren't consistently named
  anymore with how the code has evolved.

Also:

- Each API type class (Namespace, Cluster, Proxy, etc.) is now
  more formal with getters instead of plain properties, and
  has a toString() for logging/debugging.
- Each API type class also defines a typeset, like it did before,
  but I reduced the typesets to only the data properties that are
  necessary for the information we need. Best to only care about
  what we need than to check for additional stuff which is
  inconsequential and might change on us, causing issues we
  don't need.
- Added an optimization to ExtendedCloud with a new `preview`
  parameter on the constructor to signal that the instance is
  for preview purposes only, meaning we skip retrieving proxies
  and licenses to save a bit of time. We use this in AddCloudInstance
  where the EC is just throw-away for preview purposes.