### PR TITLE
PRODX-21945 Fixed Selective sync UX issues

### DIFF
--- a/src/common/Cloud.js
+++ b/src/common/Cloud.js
@@ -476,7 +476,7 @@ export class Cloud extends EventDispatcher {
       },
     });
 
-    Object.defineProperty(this, 'updateNamespaces', {
+    Object.defineProperty(Object.getPrototypeOf(this), 'updateNamespaces', {
       enumerable: true,
       /**
        * @param {Array<string>} syncedList A list of namespace names in the mgmt cluster that should be synced.
@@ -538,6 +538,13 @@ export class Cloud extends EventDispatcher {
     }
 
     return CONNECTION_STATUSES.DISCONNECTED;
+  }
+
+  /**
+   * @member {Array<string>} returns syncedNamespaces + ignoredNamespaces array
+   */
+  get allNamespaces() {
+    return this.syncedNamespaces.concat(this.ignoredNamespaces)
   }
 
   /**

--- a/src/common/Cloud.js
+++ b/src/common/Cloud.js
@@ -544,7 +544,7 @@ export class Cloud extends EventDispatcher {
    * @member {Array<string>} returns syncedNamespaces + ignoredNamespaces array
    */
   get allNamespaces() {
-    return this.syncedNamespaces.concat(this.ignoredNamespaces)
+    return this.syncedNamespaces.concat(this.ignoredNamespaces);
   }
 
   /**

--- a/src/common/ExtendedCloud.js
+++ b/src/common/ExtendedCloud.js
@@ -600,10 +600,17 @@ export class ExtendedCloud extends EventDispatcher {
    *  empty if none or the namespaces haven't been successfully fetched at least once yet.
    */
   get syncedNamespaces() {
+    return this.namespaces.filter((namespace) =>
+      this.cloud.syncedNamespaces.includes(namespace.name)
+    );
+  }
+
+  /**
+   * @member {Array<Namespace>} ignoredNamespaces List of namespaces the Cloud is not syncing;
+   */
+  get ignoredNamespaces() {
     return this.namespaces.filter(
-      (namespace) =>
-        this.cloud.syncAll ||
-        this.cloud.syncedNamespaces.includes(namespace.name)
+      (namespace) => !this.cloud.ignoredNamespaces.includes(namespace.name)
     );
   }
 

--- a/src/common/ExtendedCloud.js
+++ b/src/common/ExtendedCloud.js
@@ -643,6 +643,32 @@ export class ExtendedCloud extends EventDispatcher {
     this.dispatchEvent(EXTENDED_CLOUD_EVENTS.FETCH_DATA, this);
   }
 
+  /**
+   * check if for projects and depending on syncAll we add them to Cloud.syncedNamespaces or Cloud.ignoredNamespaces
+   */
+  updateCloudNamespaceLists() {
+    const syncedList = [];
+    const ignoredList = [];
+
+    this.namespaces.forEach(({ name }) => {
+      if (this.cloud.syncAll) {
+        if (this.cloud.ignoredNamespaces.includes(name)) {
+          ignoredList.push(name);
+        } else {
+          syncedList.push(name);
+        }
+      } else {
+        if (this.cloud.syncedNamespaces.includes(name)) {
+          syncedList.push(name);
+        } else {
+          ignoredList.push(name);
+        }
+      }
+    });
+
+    this.cloud.updateNamespaces(syncedList, ignoredList, true);
+  }
+
   /** Called when __this__ ExtendedCloud should fetch new data from its Cloud. */
   onFetchData = () => this.fetchData();
 
@@ -720,6 +746,7 @@ export class ExtendedCloud extends EventDispatcher {
       return namespace;
     });
 
+    this.updateCloudNamespaceLists();
     if (!this.loaded) {
       // successfully loaded at least once
       this.loaded = true;

--- a/src/renderer/components/EnhancedTable/EnhancedTable.js
+++ b/src/renderer/components/EnhancedTable/EnhancedTable.js
@@ -4,7 +4,7 @@ import styled from '@emotion/styled';
 import { layout } from '../styles';
 import { EnhancedTableHead } from './EnhancedTableHead';
 import { getTableData, sortData } from './tableUtil';
-import { EnhancedTableRow } from './EnhancedTableRow';
+import { TableRowListenerWrapper } from './TableRowListenerWrapper';
 
 const SelectiveSyncTableItem = styled.table`
   width: 100%;
@@ -57,7 +57,7 @@ export const EnhancedTable = ({
         {sortData(extendedClouds, sortedBy, order, path).map((url) => {
           const key = `${url}-${isSelectiveSyncView ? 'selective' : ''}`;
           return (
-            <EnhancedTableRow
+            <TableRowListenerWrapper
               key={key}
               extendedCloud={extendedClouds[url]}
               withCheckboxes={isSelectiveSyncView}

--- a/src/renderer/components/EnhancedTable/EnhancedTableRow.js
+++ b/src/renderer/components/EnhancedTable/EnhancedTableRow.js
@@ -248,7 +248,7 @@ export const EnhancedTableRow = ({
     if (withCheckboxes) {
       autoSyncSuffix =
         isParent && !extendedCloud.cloud.connected
-          ? `( ${connectionStatuses.cloud.disconnected()})`
+          ? ` (${connectionStatuses.cloud.disconnected()})`
           : '';
       return (
         <TriStateCheckbox

--- a/src/renderer/components/EnhancedTable/EnhancedTableRow.js
+++ b/src/renderer/components/EnhancedTable/EnhancedTableRow.js
@@ -247,9 +247,10 @@ export const EnhancedTableRow = ({
   const makeNameCell = (name, isParent) => {
     let autoSyncSuffix = '';
     if (withCheckboxes) {
-      autoSyncSuffix = (isParent && !extendedCloud.cloud.connected)
-        ? `( ${connectionStatuses.cloud.disconnected()})`
-        : '';
+      autoSyncSuffix =
+        isParent && !extendedCloud.cloud.connected
+          ? `( ${connectionStatuses.cloud.disconnected()})`
+          : '';
       return (
         <TriStateCheckbox
           label={`${name}${autoSyncSuffix}`}
@@ -412,7 +413,12 @@ EnhancedTableRow.propTypes = {
   isSyncStarted: PropTypes.bool,
   getDataToSync: PropTypes.func,
   namespaces: PropTypes.arrayOf(
-    PropTypes.oneOfType([PropTypes.instanceOf(Namespace), PropTypes.object])
+    PropTypes.oneOfType([
+      PropTypes.instanceOf(Namespace),
+      PropTypes.shape({
+        name: PropTypes.string.isRequired,
+      }),
+    ])
   ).isRequired,
   fetching: PropTypes.bool.isRequired,
 };

--- a/src/renderer/components/EnhancedTable/EnhancedTableRow.js
+++ b/src/renderer/components/EnhancedTable/EnhancedTableRow.js
@@ -34,7 +34,8 @@ const EnhTableRow = styled.tr`
 `;
 
 const EnhTableRowCell = styled.td`
-  width: ${({ isBigger }) => isBigger && '40%'};
+  width: ${({ isBigger, withCheckboxes }) =>
+    isBigger && !withCheckboxes && '40%'};
   border: 0;
   font-size: var(--font-size);
   line-height: normal;
@@ -267,13 +268,13 @@ export const EnhancedTableRow = ({
    */
   const getExpandIcon = (condition, showSecondLevel = true) => {
     // EG when namespace isn't loaded, we show first level but not second
-    if(!showSecondLevel) {
-      return null
+    if (!showSecondLevel) {
+      return null;
     }
 
     // SyncView mode - don't show if namespaces not loaded
     // but if it's Selective Sync  - show the icon (we use syncedNamespaces then)
-    if ((!extendedCloud.loaded && !withCheckboxes)) {
+    if (!extendedCloud.loaded && !withCheckboxes) {
       return null;
     }
     const material = condition ? 'expand_more' : 'chevron_right';

--- a/src/renderer/components/EnhancedTable/EnhancedTableRow.js
+++ b/src/renderer/components/EnhancedTable/EnhancedTableRow.js
@@ -4,9 +4,16 @@ import styled from '@emotion/styled';
 import { Renderer } from '@k8slens/extensions';
 import { layout } from '../styles';
 import { AdditionalInfoRows } from './AdditionalInfoRows';
-import { connectionStatuses, contextMenus } from '../../../strings';
+import {
+  connectionStatuses,
+  contextMenus,
+  synchronizeBlock,
+} from '../../../strings';
 import { EXTENDED_CLOUD_EVENTS } from '../../../common/ExtendedCloud';
-import { TriStateCheckbox } from '../TriStateCheckbox/TriStateCheckbox';
+import {
+  checkValues,
+  TriStateCheckbox,
+} from '../TriStateCheckbox/TriStateCheckbox';
 import {
   useCheckboxes,
   makeCheckboxesInitialState,
@@ -209,6 +216,7 @@ export const EnhancedTableRow = ({
   isSyncStarted,
   getDataToSync,
 }) => {
+  const [syncAll, setSyncAll] = useState(extendedCloud.cloud.syncAll);
   const { getCheckboxValue, setCheckboxValue, getSyncedData } = useCheckboxes(
     makeCheckboxesInitialState(extendedCloud, extendedCloud.syncedNamespaces)
   );
@@ -262,12 +270,16 @@ export const EnhancedTableRow = ({
 
   useEffect(() => {
     if (isSyncStarted && typeof getDataToSync === 'function') {
-      getDataToSync(getSyncedData(), extendedCloud.cloud.cloudUrl);
+      getDataToSync(
+        { ...getSyncedData(), syncAll },
+        extendedCloud.cloud.cloudUrl
+      );
     }
   }, [
     getDataToSync,
     isSyncStarted,
     getSyncedData,
+    syncAll,
     extendedCloud.cloud.cloudUrl,
   ]);
 
@@ -315,7 +327,7 @@ export const EnhancedTableRow = ({
 
   /**
    * @param {string} name cloud or namespace name
-   * @param {boolean?} isParent if true - then it's a main, cloud checkbox
+   * @param {boolean} [isParent] if true - then it's a main, cloud checkbox
    * @return {JSX.Element|string}
    */
   const makeCell = (name, isParent) => {
@@ -357,8 +369,17 @@ export const EnhancedTableRow = ({
           </EnhCollapseBtn>
           {makeCell(extendedCloud.cloud.name, true)}
         </EnhTableRowCell>
+        {withCheckboxes && (
+          <EnhTableRowCell>
+            <TriStateCheckbox
+              label={synchronizeBlock.synchronizeFutureProjects()}
+              onChange={() => setSyncAll(!syncAll)}
+              value={syncAll ? checkValues.CHECKED : checkValues.UNCHECKED}
+            />
+          </EnhTableRowCell>
+        )}
         <EnhTableRowCell>{extendedCloud.cloud.cloudUrl}</EnhTableRowCell>
-        {withCheckboxes ? null : (
+        {!withCheckboxes && (
           <>
             <EnhTableRowCell>{extendedCloud.cloud.username}</EnhTableRowCell>
             <EnhTableRowCell style={connectColor}>

--- a/src/renderer/components/EnhancedTable/EnhancedTableRow.js
+++ b/src/renderer/components/EnhancedTable/EnhancedTableRow.js
@@ -431,7 +431,7 @@ export const EnhancedTableRow = ({
             {openedSecondLevelListIndex.includes(index) && (
               <AdditionalInfoRows
                 namespace={namespace}
-                emptyCellsCount={withCheckboxes ? 1 : 4}
+                emptyCellsCount={withCheckboxes ? 2 : 4}
               />
             )}
           </EnhRowsWrapper>

--- a/src/renderer/components/EnhancedTable/EnhancedTableRow.js
+++ b/src/renderer/components/EnhancedTable/EnhancedTableRow.js
@@ -22,6 +22,7 @@ import {
 import { CONNECTION_STATUSES } from '../../../common/Cloud';
 import { openBrowser } from '../../../util/netUtil';
 import { cloudStore } from '../../../store/CloudStore';
+import { sortNamespaces } from './tableUtil';
 
 const { Icon, MenuItem, MenuActions, ConfirmDialog } = Renderer.Component;
 
@@ -211,7 +212,7 @@ export const EnhancedTableRow = ({
   );
   const [syncAll, setSyncAll] = useState(extendedCloud.cloud.syncAll);
   const [isOpenFirstLevel, setIsOpenFirstLevel] = useState(false);
-  const [openNamespaceIndexes, setOpenNamespaceIndexes] = useState([]);
+  const [openNamespaces, setOpenNamespaces] = useState([]);
 
   useEffect(() => {
     if (isSyncStarted && typeof getDataToSync === 'function') {
@@ -229,13 +230,11 @@ export const EnhancedTableRow = ({
     extendedCloud.cloud.cloudUrl,
   ]);
 
-  const setOpenedList = (index) => {
-    if (openNamespaceIndexes.includes(index)) {
-      setOpenNamespaceIndexes(
-        openNamespaceIndexes.filter((rowIndex) => rowIndex !== index)
-      );
+  const setOpenedList = (name) => {
+    if (openNamespaces.includes(name)) {
+      setOpenNamespaces(openNamespaces.filter((n) => n !== name));
     } else {
-      setOpenNamespaceIndexes([...openNamespaceIndexes, index]);
+      setOpenNamespaces([...openNamespaces, name]);
     }
   };
 
@@ -278,10 +277,8 @@ export const EnhancedTableRow = ({
       return null;
     }
 
-    // for SyncView mode:
-    // Don't show the icon if namespaces are not loaded - ???
-    // and don't show if we don't have any syncedNamespaces
-    if (!withCheckboxes && !namespaces.length) {
+    // don't show if no namespaces, no matter which mode is it
+    if (!namespaces.length) {
       return null;
     }
     const material = condition ? 'expand_more' : 'chevron_right';
@@ -380,13 +377,13 @@ export const EnhancedTableRow = ({
         {renderRestSyncTableRows()}
       </EnhTableRow>
       {isOpenFirstLevel &&
-        namespaces.map((namespace, index) => (
+        sortNamespaces(namespaces).map((namespace) => (
           <EnhRowsWrapper key={namespace.name}>
             <EnhTableRow>
               <EnhTableRowCell isFirstLevel withCheckboxes={withCheckboxes}>
-                <EnhCollapseBtn onClick={() => setOpenedList(index)}>
+                <EnhCollapseBtn onClick={() => setOpenedList(namespace.name)}>
                   {getExpandIcon(
-                    openNamespaceIndexes.includes(index),
+                    openNamespaces.includes(namespace.name),
                     extendedCloud.loaded
                   )}
                 </EnhCollapseBtn>
@@ -395,7 +392,7 @@ export const EnhancedTableRow = ({
               {renderNamespaceRows(namespace)}
             </EnhTableRow>
 
-            {openNamespaceIndexes.includes(index) && (
+            {openNamespaces.includes(namespace.name) && (
               <AdditionalInfoRows
                 namespace={namespace}
                 emptyCellsCount={withCheckboxes ? 2 : 4}

--- a/src/renderer/components/EnhancedTable/TableRowListenerWrapper.js
+++ b/src/renderer/components/EnhancedTable/TableRowListenerWrapper.js
@@ -9,13 +9,13 @@ import { EnhancedTableRow } from './EnhancedTableRow';
  * @param {boolean} withCheckboxes
  * @return {Array<Object>} It might be an array og Namespaces or just {name: _namespaceName_ }, depending on cloud.connected
  */
-const getNamespaces = ({extendedCloud, usedNamespaces, withCheckboxes}) => {
+const getNamespaces = ({ extendedCloud, usedNamespaces, withCheckboxes }) => {
   // if loaded return Namespaces class object from EC
   if (extendedCloud.loaded) {
     return extendedCloud[usedNamespaces];
   }
   // if cloud disconnected and Selected view - return allNamespaces stored in Cloud
-  if(withCheckboxes) {
+  if (withCheckboxes) {
     return extendedCloud.cloud.allNamespaces.map((name) => ({ name }));
   }
   // if cloud disconnected and Sync View - return just syncedNamespaces stored in Cloud
@@ -35,7 +35,7 @@ export const TableRowListenerWrapper = ({
   const usedNamespaces = withCheckboxes ? 'namespaces' : 'syncedNamespaces';
 
   const [actualNamespaces, setActualNamespaces] = useState(
-    getNamespaces({extendedCloud, usedNamespaces, withCheckboxes})
+    getNamespaces({ extendedCloud, usedNamespaces, withCheckboxes })
   );
   const [isFetching, setFetching] = useState(false);
 

--- a/src/renderer/components/EnhancedTable/TableRowListenerWrapper.js
+++ b/src/renderer/components/EnhancedTable/TableRowListenerWrapper.js
@@ -6,14 +6,19 @@ import { EnhancedTableRow } from './EnhancedTableRow';
 /**
  * @param {ExtendedCloud} extendedCloud
  * @param {'namespaces'|'syncedNamespaces'} usedNamespaces if true and connected - it returns all namespaces to populate in SyncView mode
+ * @param {boolean} withCheckboxes
  * @return {Array<Object>} It might be an array og Namespaces or just {name: _namespaceName_ }, depending on cloud.connected
  */
-const getNamespaces = (extendedCloud, usedNamespaces) => {
+const getNamespaces = ({extendedCloud, usedNamespaces, withCheckboxes}) => {
   // if loaded return Namespaces class object from EC
   if (extendedCloud.loaded) {
     return extendedCloud[usedNamespaces];
   }
-  // if cloud disconnected - return just syncedNamespaces (names) stored in Cloud
+  // if cloud disconnected and Selected view - return allNamespaces stored in Cloud
+  if(withCheckboxes) {
+    return extendedCloud.cloud.allNamespaces.map((name) => ({ name }));
+  }
+  // if cloud disconnected and Sync View - return just syncedNamespaces stored in Cloud
   return extendedCloud.cloud.syncedNamespaces.map((name) => ({ name }));
 };
 
@@ -30,7 +35,7 @@ export const TableRowListenerWrapper = ({
   const usedNamespaces = withCheckboxes ? 'namespaces' : 'syncedNamespaces';
 
   const [actualNamespaces, setActualNamespaces] = useState(
-    getNamespaces(extendedCloud, usedNamespaces)
+    getNamespaces({extendedCloud, usedNamespaces, withCheckboxes})
   );
   const [isFetching, setFetching] = useState(false);
 

--- a/src/renderer/components/EnhancedTable/TableRowListenerWrapper.js
+++ b/src/renderer/components/EnhancedTable/TableRowListenerWrapper.js
@@ -1,0 +1,83 @@
+import { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import { EXTENDED_CLOUD_EVENTS } from '../../../common/ExtendedCloud';
+import { EnhancedTableRow } from './EnhancedTableRow';
+
+/**
+ * @param {ExtendedCloud} extendedCloud
+ * @param {'namespaces'|'syncedNamespaces'} usedNamespaces if true and connected - it returns all namespaces to populate in SyncView mode
+ * @return {Array<Object>} It might be an array og Namespaces or just {name: _namespaceName_ }, depending on cloud.connected
+ */
+const getNamespaces = (extendedCloud, usedNamespaces) => {
+  // if loaded return Namespaces class object from EC
+  if (extendedCloud.loaded) {
+    return extendedCloud[usedNamespaces];
+  }
+  // if cloud disconnected - return just syncedNamespaces (names) stored in Cloud
+  return extendedCloud.cloud.syncedNamespaces.map((name) => ({ name }));
+};
+
+// We need this level of abstraction mostly for 'key' prop for `EnhancedTableRow`.
+// When EC is connecting or fetch data, we use EC.cloud.syncedNamespaces in selective mode (we don't know namespaces yet)
+// When they come by updateNamespaces listener - we have to fully rerender row component to force useCheckboxes hook to take new extendedCloud data
+// without that we have incorrect checkboxes state in Selected Sync view
+// besides - keep useEffect listeners in separate level looks not so bad. Code become more readable
+export const TableRowListenerWrapper = ({
+  extendedCloud,
+  withCheckboxes,
+  ...rest
+}) => {
+  const usedNamespaces = withCheckboxes ? 'namespaces' : 'syncedNamespaces';
+
+  const [actualNamespaces, setActualNamespaces] = useState(
+    getNamespaces(extendedCloud, usedNamespaces)
+  );
+  const [isFetching, setFetching] = useState(false);
+
+  const updateNamespaces = (updatedRow) => {
+    if (updatedRow) {
+      setActualNamespaces(updatedRow[usedNamespaces]);
+    }
+  };
+
+  const listenFetching = (cl) => setFetching(cl.fetching);
+
+  useEffect(() => {
+    // Listen namespaces update
+    extendedCloud.addEventListener(
+      EXTENDED_CLOUD_EVENTS.DATA_UPDATED,
+      updateNamespaces
+    );
+    // Listen fetching status (updating namespaces)
+    extendedCloud.addEventListener(
+      EXTENDED_CLOUD_EVENTS.FETCHING_CHANGE,
+      listenFetching
+    );
+    return () => {
+      extendedCloud.removeEventListener(
+        EXTENDED_CLOUD_EVENTS.DATA_UPDATED,
+        updateNamespaces
+      );
+      extendedCloud.removeEventListener(
+        EXTENDED_CLOUD_EVENTS.FETCHING_CHANGE,
+        listenFetching
+      );
+    };
+  });
+
+  return (
+    <EnhancedTableRow
+      key={`${extendedCloud.cloud.url}-${actualNamespaces.length}`}
+      extendedCloud={extendedCloud}
+      withCheckboxes={withCheckboxes}
+      namespaces={actualNamespaces}
+      fetching={isFetching}
+      {...rest}
+    />
+  );
+};
+
+TableRowListenerWrapper.propTypes = {
+  extendedCloud: PropTypes.object.isRequired,
+  withCheckboxes: PropTypes.bool.isRequired,
+};

--- a/src/renderer/components/EnhancedTable/tableUtil.js
+++ b/src/renderer/components/EnhancedTable/tableUtil.js
@@ -2,11 +2,13 @@ import { get, orderBy } from 'lodash';
 
 const SELECTIVE_HEAD_CELL_VALUES = {
   NAME: 'Name',
+  AUTOSYNC: 'Autosync',
   URL: 'URL',
 };
 
 const selectivePathToData = {
   [SELECTIVE_HEAD_CELL_VALUES.NAME]: ['cloud', 'name'],
+  [SELECTIVE_HEAD_CELL_VALUES.AUTOSYNC]: ['cloud', 'syncAll'],
   [SELECTIVE_HEAD_CELL_VALUES.URL]: ['cloud', 'cloudUrl'],
 };
 

--- a/src/renderer/components/EnhancedTable/tableUtil.js
+++ b/src/renderer/components/EnhancedTable/tableUtil.js
@@ -44,5 +44,29 @@ export const sortData = (obj, sortBy, order, path) => {
 
   const sorted = orderBy(sortByValueArr, Object.keys(obj), [order]);
 
-  return sorted.map((a) => Object.keys(a));
+  return sorted.map(Object.keys);
 };
+
+const compareNamespaces = (first, second) => {
+  const nameA = first.name.toUpperCase();
+  const nameB = second.name.toUpperCase();
+  // sort namespaces alphabetically based on name,
+  // with the exception of always putting the "default" namespace at the top of the list.
+  if (nameA.includes('DEFAULT')) {
+    return -1;
+  }
+  if (nameB.includes('DEFAULT')) {
+    return 1;
+  }
+  if (nameA < nameB) {
+    return -1;
+  }
+  if (nameA > nameB) {
+    return 1;
+  }
+
+  return 0;
+};
+
+export const sortNamespaces = (namespaces) =>
+  namespaces.sort(compareNamespaces);

--- a/src/renderer/components/EnhancedTable/tableUtil.js
+++ b/src/renderer/components/EnhancedTable/tableUtil.js
@@ -48,24 +48,13 @@ export const sortData = (obj, sortBy, order, path) => {
 };
 
 const compareNamespaces = (first, second) => {
-  const nameA = first.name.toUpperCase();
-  const nameB = second.name.toUpperCase();
-  // sort namespaces alphabetically based on name,
-  // with the exception of always putting the "default" namespace at the top of the list.
-  if (nameA.includes('DEFAULT')) {
+  if (first.name === 'default') {
     return -1;
   }
-  if (nameB.includes('DEFAULT')) {
+  if (second.name === 'default') {
     return 1;
   }
-  if (nameA < nameB) {
-    return -1;
-  }
-  if (nameA > nameB) {
-    return 1;
-  }
-
-  return 0;
+  return first.name.localeCompare(second.name);
 };
 
 export const sortNamespaces = (namespaces) =>

--- a/src/renderer/components/GlobalPage/SyncView.js
+++ b/src/renderer/components/GlobalPage/SyncView.js
@@ -110,8 +110,7 @@ export const SyncView = () => {
           syncedClouds[url];
         const cloud = cloudStore.clouds[url];
         cloud.syncAll = syncAll;
-        cloud.syncedNamespaces = syncedNamespaces;
-        cloud.ignoredNamespaces = ignoredNamespaces;
+        cloud.updateNamespaces(syncedNamespaces, ignoredNamespaces);
       });
       closeSelectiveSyncView();
     }

--- a/src/renderer/components/GlobalPage/SyncView.js
+++ b/src/renderer/components/GlobalPage/SyncView.js
@@ -59,7 +59,7 @@ export const SyncView = () => {
   const {
     state: { extendedClouds },
   } = useExtendedCloudData();
-  const [showAddCloudComponent, setShowAddCloudComponent] = useState();
+  const [showAddCloudComponent, setShowAddCloudComponent] = useState(false);
   const [isSelectiveSyncView, setIsSelectiveSyncView] = useState(false);
   const [isSyncStarted, setIsSyncStarted] = useState(false);
   const [syncedClouds, setSyncedClouds] = useState({});
@@ -77,7 +77,9 @@ export const SyncView = () => {
     setSyncedClouds({});
   };
   const openSelectiveSyncView = () => setIsSelectiveSyncView(true);
+
   /**
+   * @param {Object} data
    * @param {boolean} data.syncAll
    * @param {Array<string>} data.syncedNamespaces
    * @param {Array<string>} data.ignoredNamespaces
@@ -123,7 +125,7 @@ export const SyncView = () => {
   if (!Object.keys(cloudStore.clouds).length) {
     return <WelcomeView openAddCloud={openAddCloud} />;
   }
-  // otherwise show extendedClouds table
+  // otherwise, show extendedClouds table
   if (Object.keys(extendedClouds).length) {
     return (
       <Content>

--- a/src/renderer/components/GlobalPage/SyncView.js
+++ b/src/renderer/components/GlobalPage/SyncView.js
@@ -80,6 +80,7 @@ export const SyncView = () => {
   /**
    * @param {boolean} data.syncAll
    * @param {Array<string>} data.syncedNamespaces
+   * @param {Array<string>} data.ignoredNamespaces
    * @param {string} url - cloudUrl
    */
   const getDataToSync = (data, url) => {
@@ -103,10 +104,12 @@ export const SyncView = () => {
     if (!isSyncStarted && Object.keys(syncedClouds).length) {
       // go through all clouds and update properties
       Object.keys(syncedClouds).map((url) => {
-        const { syncAll, syncedNamespaces } = syncedClouds[url];
+        const { syncAll, syncedNamespaces, ignoredNamespaces } =
+          syncedClouds[url];
         const cloud = cloudStore.clouds[url];
         cloud.syncAll = syncAll;
         cloud.syncedNamespaces = syncedNamespaces;
+        cloud.ignoredNamespaces = ignoredNamespaces;
       });
       closeSelectiveSyncView();
     }

--- a/src/renderer/components/GlobalPage/SynchronizeBlock.js
+++ b/src/renderer/components/GlobalPage/SynchronizeBlock.js
@@ -134,8 +134,7 @@ export const SynchronizeBlock = ({ extendedCloud, onAdd }) => {
     const { syncedNamespaces, ignoredNamespaces } = getSyncedData();
 
     cloud.syncAll = syncAll;
-    cloud.syncedNamespaces = syncedNamespaces;
-    cloud.ignoredNamespaces = ignoredNamespaces;
+    cloud.updateNamespaces(syncedNamespaces, ignoredNamespaces);
 
     onAdd(cloud);
   };

--- a/src/renderer/components/GlobalPage/SynchronizeBlock.js
+++ b/src/renderer/components/GlobalPage/SynchronizeBlock.js
@@ -13,6 +13,7 @@ import {
   useCheckboxes,
   makeCheckboxesInitialState,
 } from '../hooks/useCheckboxes';
+import { sortNamespaces } from '../EnhancedTable/tableUtil';
 
 const { Button, Icon } = Renderer.Component;
 
@@ -171,7 +172,7 @@ export const SynchronizeBlock = ({ extendedCloud, onAdd }) => {
             synchronizeBlock.noProjectsFound()
           ) : (
             <ProjectsList>
-              {projectsList.map((namespace) => (
+              {sortNamespaces(projectsList).map((namespace) => (
                 <li key={namespace.name}>
                   <Accordion
                     title={

--- a/src/renderer/components/GlobalPage/SynchronizeBlock.js
+++ b/src/renderer/components/GlobalPage/SynchronizeBlock.js
@@ -2,7 +2,10 @@ import PropTypes from 'prop-types';
 import { useState } from 'react';
 import styled from '@emotion/styled';
 import { Renderer } from '@k8slens/extensions';
-import { TriStateCheckbox } from '../TriStateCheckbox/TriStateCheckbox';
+import {
+  checkValues,
+  TriStateCheckbox,
+} from '../TriStateCheckbox/TriStateCheckbox';
 import { Accordion } from '../Accordion/Accordion';
 import { layout } from '../styles';
 import { synchronizeBlock } from '../../../strings';
@@ -11,7 +14,7 @@ import {
   makeCheckboxesInitialState,
 } from '../hooks/useCheckboxes';
 
-const { Notifications, Button, Icon } = Renderer.Component;
+const { Button, Icon } = Renderer.Component;
 
 const Content = styled.div(() => ({
   marginTop: layout.gap * 2,
@@ -21,10 +24,10 @@ const Content = styled.div(() => ({
   flexDirection: 'column',
   width: '100%',
 }));
-
-const Title = styled.h3(() => ({
+const TitleWrapper = styled.div(() => ({
+  display: 'flex',
+  justifyContent: 'space-between',
   marginBottom: layout.pad,
-  alignSelf: 'start',
 }));
 
 const Projects = styled.div(() => ({
@@ -95,6 +98,7 @@ const SortButton = styled.button`
 `;
 
 export const SynchronizeBlock = ({ extendedCloud, onAdd }) => {
+  const [syncAll, setSyncAll] = useState(false);
   const { setCheckboxValue, getCheckboxValue, getSyncedData } = useCheckboxes(
     makeCheckboxesInitialState(extendedCloud)
   );
@@ -127,22 +131,25 @@ export const SynchronizeBlock = ({ extendedCloud, onAdd }) => {
 
   const onSynchronize = () => {
     const { cloud } = extendedCloud;
-    const { syncedNamespaces, syncAll } = getSyncedData();
-
-    if (!syncAll && !syncedNamespaces.length) {
-      Notifications.error(synchronizeBlock.error.noProjects());
-      return;
-    }
+    const { syncedNamespaces, ignoredNamespaces } = getSyncedData();
 
     cloud.syncAll = syncAll;
     cloud.syncedNamespaces = syncedNamespaces;
+    cloud.ignoredNamespaces = ignoredNamespaces;
 
     onAdd(cloud);
   };
 
   return (
     <Content>
-      <Title>{synchronizeBlock.title()}</Title>
+      <TitleWrapper>
+        <h3>{synchronizeBlock.title()}</h3>
+        <TriStateCheckbox
+          label={synchronizeBlock.synchronizeFutureProjects()}
+          onChange={() => setSyncAll(!syncAll)}
+          value={syncAll ? checkValues.CHECKED : checkValues.UNCHECKED}
+        />
+      </TitleWrapper>
       <Projects>
         {projectsList.length ? (
           <ProjectsHead>

--- a/src/renderer/components/TriStateCheckbox/TriStateCheckbox.js
+++ b/src/renderer/components/TriStateCheckbox/TriStateCheckbox.js
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 import { Renderer } from '@k8slens/extensions';
 import { layout } from '../styles';
 
-const { Component } = Renderer;
+const { Icon } = Renderer.Component;
 
 const CheckboxItem = styled.div(() => ({
   minWidth: 64,
@@ -69,10 +69,10 @@ export const TriStateCheckbox = ({ label, onChange, value }) => {
       <CheckboxControlPart>
         <CheckboxControl isChecked={value !== checkValues.UNCHECKED}>
           {value === checkValues.MIXED && (
-            <Component.Icon material="remove" style={iconStyles} />
+            <Icon material="remove" style={iconStyles} />
           )}
           {value === checkValues.CHECKED && (
-            <Component.Icon material="check" style={iconStyles} />
+            <Icon material="check" style={iconStyles} />
           )}
         </CheckboxControl>
         <CheckboxLabel>

--- a/src/renderer/components/hooks/useCheckboxes.js
+++ b/src/renderer/components/hooks/useCheckboxes.js
@@ -21,8 +21,8 @@ const setParentCheckboxState = (children) => {
 const makeCheckboxesStateObj = (extCloud) => {
   // if EC.namespaces aren't loaded yet, we use stored syncedNamespaces names from Cloud
   if (!extCloud.loaded) {
-    return extCloud.cloud.syncedNamespaces.reduce((acc, name) => {
-      acc[name] = true;
+    return extCloud.cloud.allNamespaces.reduce((acc, name) => {
+      acc[name] = extCloud.cloud.syncedNamespaces.includes(name);
       return acc;
     }, {});
   }

--- a/src/renderer/components/hooks/useCheckboxes.js
+++ b/src/renderer/components/hooks/useCheckboxes.js
@@ -19,7 +19,7 @@ const setParentCheckboxState = (children) => {
  * @return {Object} {[namespaceName]: boolean}
  */
 const makeCheckboxesStateObj = (extCloud) => {
-  // if EC.namespaces aren't loaded yet, we should use stored syncedNamespaces names from Cloud
+  // if EC.namespaces aren't loaded yet, we use stored syncedNamespaces names from Cloud
   if (!extCloud.loaded) {
     return extCloud.cloud.syncedNamespaces.reduce((acc, name) => {
       acc[name] = true;

--- a/src/renderer/components/hooks/useCheckboxes.js
+++ b/src/renderer/components/hooks/useCheckboxes.js
@@ -44,7 +44,7 @@ const makeCheckboxesStateObj = (extCloud, syncedNamespaces) => {
 export const makeCheckboxesInitialState = (extCloud, syncedNamespaces = []) => {
   const children = makeCheckboxesStateObj(extCloud, syncedNamespaces);
   return {
-    parent: extCloud?.cloud?.syncAll || setParentCheckboxState(children),
+    parent: setParentCheckboxState(children),
     children,
   };
 };
@@ -89,8 +89,8 @@ export function useCheckboxes(initialState) {
 
   /**
    *
-   * @param {string?} name has to be present for children (optional for parent)
-   * @param {boolean?} isParent has to be true for parent.
+   * @param {string} [name] has to be present for children (optional for parent)
+   * @param {boolean} [isParent] has to be true for parent.
    * @return {string} one of checkValues
    */
   const getCheckboxValue = ({ name, isParent }) =>
@@ -118,17 +118,18 @@ export function useCheckboxes(initialState) {
   };
 
   const getSyncedData = () => {
-    if (getParentCheckboxValue() === checkValues.CHECKED) {
-      return {
-        syncAll: true,
-        syncedNamespaces: Object.keys(checkboxesState.children),
-      };
-    }
+    let ignoredNamespaces = [];
+    const syncedNamespaces = [];
+    Object.keys(checkboxesState.children).forEach((name) => {
+      if (checkboxesState.children[name]) {
+        syncedNamespaces.push(name);
+      } else {
+        ignoredNamespaces.push(name);
+      }
+    });
     return {
-      syncAll: false,
-      syncedNamespaces: Object.keys(checkboxesState.children).filter(
-        (name) => checkboxesState.children[name]
-      ),
+      syncedNamespaces,
+      ignoredNamespaces,
     };
   };
 

--- a/src/renderer/components/hooks/useCheckboxes.js
+++ b/src/renderer/components/hooks/useCheckboxes.js
@@ -65,6 +65,10 @@ export function useCheckboxes(initialState) {
 
   const getParentCheckboxValue = () => {
     const childrenCheckboxes = Object.values(checkboxesState.children);
+    // if no children
+    if (!childrenCheckboxes.length) {
+      return checkValues.UNCHECKED;
+    }
 
     if (
       checkboxesState.parent &&
@@ -100,6 +104,13 @@ export function useCheckboxes(initialState) {
    */
   const setCheckboxValue = ({ name, isParent }) => {
     if (isParent) {
+      // if no children we can't check parent
+      if (
+        !Object.keys(checkboxesState.children).length &&
+        !checkboxesState.parent
+      ) {
+        return;
+      }
       setCheckboxesState({
         parent: !checkboxesState.parent,
         children: getNewChildren(!checkboxesState.parent),

--- a/src/strings.ts
+++ b/src/strings.ts
@@ -86,6 +86,7 @@ export const syncView: Dict = {
   synchronizeProjectsButtonLabel: () => 'Synchronize selected projects',
   syncButtonLabel: () => 'Selective sync...',
   connectButtonLabel: () => 'Connect new Management Cluster',
+  autoSync: () => 'auto-sync',
 };
 export const managementClusters = {
   table: {

--- a/src/strings.ts
+++ b/src/strings.ts
@@ -66,6 +66,7 @@ export const addCloudInstance = {
 export const synchronizeBlock = {
   title: () => 'Select projects to synchronize',
   synchronizeButtonLabel: () => 'Synchronize selected projects',
+  synchronizeFutureProjects: () => 'Synchronize future projects',
   checkAllCheckboxLabel: () => 'Project name',
   noProjectsFound: () =>
     'No projects found. At least one project is required for syncing. Try another management cluster.',
@@ -92,6 +93,7 @@ export const managementClusters = {
       name: () => 'Name',
       url: () => 'URL',
       username: () => 'Username',
+      autosync: () => 'Autosync',
       status: () => 'Status',
     },
     tbodyDetailedInfo: {

--- a/src/strings.ts
+++ b/src/strings.ts
@@ -86,7 +86,7 @@ export const syncView: Dict = {
   synchronizeProjectsButtonLabel: () => 'Synchronize selected projects',
   syncButtonLabel: () => 'Selective sync...',
   connectButtonLabel: () => 'Connect new Management Cluster',
-  autoSync: () => 'auto-sync',
+  autoSync: () => 'Auto-sync',
 };
 export const managementClusters = {
   table: {
@@ -94,7 +94,7 @@ export const managementClusters = {
       name: () => 'Name',
       url: () => 'URL',
       username: () => 'Username',
-      autosync: () => 'Autosync',
+      autosync: () => 'Auto-sync',
       status: () => 'Status',
     },
     tbodyDetailedInfo: {

--- a/test/mocks/mockExtCloud.js
+++ b/test/mocks/mockExtCloud.js
@@ -12,6 +12,7 @@ export const mockExtCloud = {
     name: 'Container name',
     syncAll: false,
     syncedNamespaces: [],
+    ignoredNamespaces: [],
   },
   loading: false,
   namespaces: [
@@ -92,6 +93,7 @@ export const mockExtCloud2 = {
     name: 'Container name 2',
     syncAll: false,
     syncedNamespaces: [],
+    ignoredNamespaces: [],
   },
   loading: false,
   namespaces: [


### PR DESCRIPTION
[Link to the ticket](https://mirantis.jira.com/browse/PRODX-21945)
Main changes: 
- Added 'Synchronize future projects' checkboxes for `syncAll` bool in SynchronizeBlock and in SelectiveSync Table
- Added `Cloud.ignoredNamespaces` where we store all unchecked projects
- Added logic to ExtendedCloud, which updates `Cloud.ignoredNamespaces`  and `Cloud.syncedNamespaces` in it got new project. Depending on `syncAll` we're choosing where to move new project ignored or synced
- Fixed issue when SelectiveSync table isn't updated after new data come (eg when Cloud disconnected=> we reconnect it and go to SelectiveSync view before EC.dataFetch is finished)


<img width="1327" alt="image" src="https://user-images.githubusercontent.com/95434160/154734857-646c89aa-5156-4b15-bfd5-1c310c2c4705.png">
<img width="908" alt="image" src="https://user-images.githubusercontent.com/95434160/154734993-ebfd4228-ea17-4538-86bb-f3b2ee6e6e40.png">
