### PR TITLE
PRODX-22081 Updated extractJwtPayload and add missed Credential type

### DIFF
--- a/src/api/apiUtil.js
+++ b/src/api/apiUtil.js
@@ -46,8 +46,15 @@ export function extractJwtPayload(token) {
   }
 
   const base64Payload = token.split('.')[1];
+  let base64DecodedValue
+  if (typeof atob === 'function') {
+    base64DecodedValue = atob(base64Payload);
+  } else {
+    // assume we're in Node.js env and use Buffer
+    base64DecodedValue = Buffer.from(base64Payload, 'base64').toString();
+  }
   const decoded = decodeURIComponent(
-    atob(base64Payload)
+    base64DecodedValue
       .split('')
       .map((char) => '%' + ('00' + char.charCodeAt(0).toString(16)).slice(-2))
       .join('')

--- a/src/api/apiUtil.js
+++ b/src/api/apiUtil.js
@@ -46,7 +46,7 @@ export function extractJwtPayload(token) {
   }
 
   const base64Payload = token.split('.')[1];
-  let base64DecodedValue
+  let base64DecodedValue;
   if (typeof atob === 'function') {
     base64DecodedValue = atob(base64Payload);
   } else {

--- a/src/api/types/Credential.js
+++ b/src/api/types/Credential.js
@@ -15,6 +15,7 @@ export const credentialKinds = Object.freeze({
   EQUINIX: 'EquinixMetalCredential',
   AZURE: 'AzureCredential',
   AWS: 'AWSCredential',
+  BYO: 'BYOCredential',
   // TODO: there may be one more kind here for BM credentials (i.e. secrets) but we
   //  first need to test this in an MCC+BM env
 });


### PR DESCRIPTION
[Link to the ticket](https://mirantis.jira.com/browse/PRODX-22081)
- Used Buffer instead of `atob` for Node.js env
- Added one more Credential kind to the validation list