### PR TITLE
[PRODX-22267][PRODX-20046] Sync clusters down from MCC instances

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "ts-loader": "^9.2.7",
     "typescript": "^4.6.2",
     "webpack": "^5.70.0",
-    "webpack-cli": "^4.9.2"
+    "webpack-cli": "^4.9.2",
+    "yaml": "^1.10.2"
   }
 }

--- a/src/api/apiUtil.js
+++ b/src/api/apiUtil.js
@@ -112,10 +112,10 @@ export async function cloudLogout(cloud) {
     baseUrl: cloud.cloudUrl,
     config: cloud.config,
   });
-  const { error: refreshError } = await apiClient.logout(cloud.refreshToken);
+  const { error: logoutError } = await apiClient.logout(cloud.refreshToken);
 
-  if (refreshError) {
-    return refreshError;
+  if (logoutError) {
+    return logoutError;
   }
 
   return null;

--- a/src/api/clients/ApiClient.js
+++ b/src/api/clients/ApiClient.js
@@ -44,14 +44,14 @@ export class ApiClient {
    * @param {Object} [config.options] Request configuration options.
    * @param {Array<number>} [config.expectedStatuses] List of expected success
    *  statuses.
-   * @param {string} [config.extractDataMethod] Name of a method on a fetch
+   * @param {string} [config.extractBodyMethod] Name of a method on a fetch
    *  response object to call to deserialize/extract/parse data from the response.
    *  Defaults to "json".
    * @returns {Promise<Object>} See netUtil.request() for response shape.
    */
   request(
     endpoint,
-    { options = {}, expectedStatuses = [200], errorMessage, extractDataMethod }
+    { options = {}, expectedStatuses = [200], errorMessage, extractBodyMethod }
   ) {
     const headers = {
       Accept: 'application/json',
@@ -64,7 +64,7 @@ export class ApiClient {
         ...options,
         headers: { ...headers, ...((options && options.headers) || {}) },
       },
-      { expectedStatuses, errorMessage, extractDataMethod }
+      { expectedStatuses, errorMessage, extractBodyMethod }
     );
   }
 
@@ -170,7 +170,7 @@ export class ApiClient {
       },
       errorMessage: strings.apiClient.error.failedToLogout(),
       expectedStatuses: [200, 204],
-      extractDataMethod: null,
+      extractBodyMethod: null,
     });
   }
 }

--- a/src/api/types/ApiObject.js
+++ b/src/api/types/ApiObject.js
@@ -119,7 +119,9 @@ export class ApiObject {
   toString() {
     const propStr = `name: ${logString(this.name)}, uid: ${logString(
       this.uid
-    )}, kind: ${logString(this.kind)}`;
+    )}, kind: ${logString(this.kind)}, cloudUrl=${logString(
+      this.cloud?.cloudUrl
+    )}`;
 
     if (Object.getPrototypeOf(this).constructor === ApiObject) {
       return `{ApiObject ${propStr}}`;

--- a/src/catalog/catalogEntities.js
+++ b/src/catalog/catalogEntities.js
@@ -49,7 +49,7 @@ export const catalogEntityModelTs = {
     // enough info to relate this entity to a namespace in a Cloud in `CloudStore.clouds`
     //  if necessary
     namespace: rtv.STRING,
-    cloudUrl: rtv.STRING,
+    cloudUrl: [rtv.STRING, (v) => !v.endsWith('/')], // no trailing slash
   },
 
   // spec is specific to the type of entity being added to the Catalog; e.g. for a cluster,
@@ -80,6 +80,7 @@ export const catalogEntityModelTs = {
 export const clusterEntityPhases = Object.freeze({
   CONNECTING: 'connecting',
   CONNECTED: 'connected',
+  DELETING: 'deleting',
   DISCONNECTING: 'disconnecting',
   DISCONNECTED: 'disconnected',
 });
@@ -91,9 +92,17 @@ export const clusterEntityPhases = Object.freeze({
  *
  * NOTE: As this is meant for Lens to consume, it will NOT MATCH the kube spec object
  *  retrieved from the MCC API for the same object.
+ *
+ * @see node_modules/@k8slens/extensions/dist/src/common/catalog-entities/kubernetes-cluster.d.ts
  */
 export const clusterEntityModelTs = mergeRtvShapes({}, catalogEntityModelTs, {
+  // based on Lens `KubernetesClusterMetadata` type
   metadata: {
+    distro: [rtv.OPTIONAL, rtv.STRING],
+    kubeVersion: [rtv.OPTIONAL, rtv.STRING],
+
+    //// CUSTOM PROPERTIES
+
     labels: [
       // either it's a mgmt cluster and we no labels
       rtv.HASH_MAP,
@@ -128,12 +137,27 @@ export const clusterEntityModelTs = mergeRtvShapes({}, catalogEntityModelTs, {
       },
     ],
   },
+
+  // based on Lens `KubernetesClusterSpec` type
   spec: {
     kubeconfigPath: rtv.STRING, // absolute path
     kubeconfigContext: rtv.STRING,
+    icon: [
+      rtv.OPTIONAL,
+      {
+        src: [rtv.OPTIONAL, rtv.STRING],
+        material: [rtv.OPTIONAL, rtv.STRING],
+        background: [rtv.OPTIONAL, rtv.STRING],
+      },
+    ],
+
+    //// CUSTOM PROPERTIES
+
     isManagementCluster: rtv.BOOLEAN,
     ready: rtv.BOOLEAN,
   },
+
+  // based on Lens `KubernetesClusterStatus` type
   status: {
     phase: [rtv.STRING, { oneOf: Object.values(clusterEntityPhases) }],
   },

--- a/src/catalog/catalogEntityTypes.ts
+++ b/src/catalog/catalogEntityTypes.ts
@@ -7,6 +7,8 @@ import { Common } from '@k8slens/extensions';
 type LensCatalogEntityMetadata = Common.Catalog.CatalogEntityMetadata;
 type LensCatalogEntityStatus = Common.Catalog.CatalogEntityStatus;
 
+export type LensKubernetesCluster = Common.Catalog.KubernetesCluster;
+
 export interface CatalogEntityMetadata extends LensCatalogEntityMetadata {
   kind: string;
   namespace: string;

--- a/src/common/DataCloud.js
+++ b/src/common/DataCloud.js
@@ -466,7 +466,7 @@ export class DataCloud extends EventDispatcher {
           );
 
           logger.log(
-            'DataCloud.[set]cloud',
+            'DataCloud.cloud:set',
             `Received new Cloud: Scheduling new data fetch; dataCloud=${this}`
           );
           this.dispatchEvent(DATA_CLOUD_EVENTS.FETCH_DATA, this);

--- a/src/constants.js
+++ b/src/constants.js
@@ -9,6 +9,7 @@ const mccEntityGroup = `entity.${mccCodeName}.dev`.toLowerCase();
 const lensCatalogGroup = 'catalog.k8slens.dev';
 const lensEntityGroup = 'entity.k8slens.dev';
 const v1alpha1 = 'v1alpha1';
+const v1alpha2 = 'v1alpha2';
 
 /** Catalog-related constants. */
 export const catalog = deepFreeze({
@@ -52,6 +53,7 @@ export const catalog = deepFreeze({
       group: mccEntityGroup,
       versions: {
         v1alpha1,
+        v1alpha2, // Equinix Metal has v1 and v2
       },
     },
     /** MCC Proxy (custom) */

--- a/src/main/IpcMain.js
+++ b/src/main/IpcMain.js
@@ -42,8 +42,13 @@ export class IpcMain extends Main.Ipc {
   capture(level, context, message, ...rest) {
     DEV_ENV && rtv.verify({ level, context, message }, captureTs);
 
-    const params = [`__MAIN__/${context}`, message, ...rest];
-    logger[level](...params);
-    this.broadcast(ipcEvents.broadcast.LOGGER, level, ...params);
+    logger[level](context, message, ...rest);
+    this.broadcast(
+      ipcEvents.broadcast.LOGGER,
+      level,
+      `__MAIN__/${context}`,
+      message,
+      ...rest
+    );
   }
 }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -31,7 +31,7 @@ export default class ExtensionMain extends Main.LensExtension {
 
     // AFTER load stores
     IpcMain.createInstance(this);
-    SyncManager.createInstance(catalogSource, IpcMain.getInstance());
+    SyncManager.createInstance(this, catalogSource, IpcMain.getInstance());
   }
 
   onDeactivate() {

--- a/src/renderer/catalogEntityDetails.tsx
+++ b/src/renderer/catalogEntityDetails.tsx
@@ -6,7 +6,9 @@ import { SshKeyEntity } from '../catalog/SshKeyEntity';
 import { CredentialEntity } from '../catalog/CredentialEntity';
 import { ProxyEntity } from '../catalog/ProxyEntity';
 import { LicenseEntity } from '../catalog/LicenseEntity';
+import { LensKubernetesCluster } from '../catalog/catalogEntityTypes';
 import * as strings from '../strings';
+import * as consts from '../constants';
 
 dayjs.extend(dayjsRelativeTimePlugin);
 
@@ -36,6 +38,31 @@ const {
 } = strings;
 
 export const catalogEntityDetails = [
+  {
+    kind: consts.catalog.entities.kubeCluster.kind,
+    apiVersions: [
+      `${consts.catalog.entities.kubeCluster.group}/${consts.catalog.entities.kubeCluster.versions.v1alpha1}`,
+    ],
+    components: {
+      Details: (props: CatalogEntityDetailsProps<LensKubernetesCluster>) => (
+        <>
+          <DrawerTitle
+            title={strings.catalog.entities.common.details.title()}
+          />
+          <DrawerItem
+            name={strings.catalog.entities.common.details.props.uid()}
+          >
+            {props.entity.metadata.uid || unknownValue()}
+          </DrawerItem>
+          <DrawerItem
+            name={strings.catalog.entities.common.details.props.dateCreated()}
+          >
+            {getCreatedValue(props.entity.spec.createdAt)}
+          </DrawerItem>
+        </>
+      ),
+    },
+  },
   {
     kind: SshKeyEntity.kind,
     apiVersions: [SshKeyEntity.apiVersion],

--- a/src/renderer/components/GlobalPage/AddCloudInstance.js
+++ b/src/renderer/components/GlobalPage/AddCloudInstance.js
@@ -82,10 +82,11 @@ export const AddCloudInstance = ({ onAdd, onCancel }) => {
   }, [dataCloud, cloud]);
 
   const cleanCloudsState = () => {
-    setCloud(null);
-
     dataCloud?.destroy();
     setDataCloud(null);
+
+    cloud?.destroy();
+    setCloud(null);
   };
 
   useEffect(() => {
@@ -94,7 +95,8 @@ export const AddCloudInstance = ({ onAdd, onCancel }) => {
     }
   }, [cloud, loading, dataCloud, makeDataCloud]);
 
-  // propertly destroy the DataCloud object on unmount
+  // propertly destroy the DataCloud object on unmount, but NOT the Cloud because
+  //  we may have passed it back through `onAdd()`
   useEffect(() => {
     return () => dataCloud?.destroy();
   }, [dataCloud]);

--- a/src/store/CloudStore.js
+++ b/src/store/CloudStore.js
@@ -182,6 +182,7 @@ export class CloudStore extends Common.Store.ExtensionStore {
     const cloud = this.clouds[cloudUrl];
     if (cloud) {
       this.stopListeningForChanges(cloud);
+      cloud.destroy();
       delete this.clouds[cloudUrl];
     }
   }

--- a/src/strings.ts
+++ b/src/strings.ts
@@ -174,7 +174,7 @@ export const catalog: Dict = {
 
       // details panel
       details: {
-        title: () => 'More Information',
+        title: () => mccFullName,
         unknownValue: () => '<Unknown>', // when a value is null/undefined/empty
         props: {
           dateCreated: () => 'Date created',

--- a/src/util/templates.js
+++ b/src/util/templates.js
@@ -17,18 +17,31 @@ export const mkClusterContextName = function ({
 
 /**
  * Generates a KubeConfig for a specific cluster.
+ *
+ * If a `token` is not given, the generated kubeconfig will require the
+ *  https://github.com/int128/kubelogin Kubernetes plugin to be installed on the local
+ *  system in order for Lens to open the cluster.
+ *
+ * Rather than needing a cluster-specific token (which would require going to the browser
+ *  to get the user to sign in to MCC again for each cluster added), the generating of the
+ *  token is offset to the moment when Lens tries to open the cluster from the Catalog.
+ *  Then `oidc-login` (which is this `kubelogin` plugin) will be automatically invoked,
+ *  opening the user's default browser so they can sign in to MCC and generate a token
+ *  for the cluster.
+ *
  * @param {Object} config Configuration parameters for the template.
- * @param {string} config.username Username for authentication.
- * @param {string} config.token OAuth token for user for this cluster.
- * @param {string} config.refreshToken OAuth refresh token for user for this cluster.
  * @param {Cluster} config.cluster Cluster for which to generate the config.
+ * @param {string} config.username Username for authentication.
+ * @param {string} [config.token] Optional OAuth token for user for this cluster.
+ * @param {string} [config.refreshToken] Optional OAuth refresh token for user for this cluster.
+ *  Ignored if `token` is not specified.
  * @returns {Object} JSON object representing the KubeConfig for accessing the cluster.
  */
-export const kubeConfigTemplate = function ({
+export const mkKubeConfig = function ({
+  cluster,
   username,
   token,
   refreshToken,
-  cluster,
 }) {
   return {
     apiVersion: 'v1',
@@ -54,21 +67,39 @@ export const kubeConfigTemplate = function ({
     kind: 'Config',
     preferences: {},
     users: [
-      {
-        name: username,
-        user: {
-          'auth-provider': {
-            config: {
-              'client-id': cluster.idpClientId,
-              'id-token': token,
-              'idp-certificate-authority-data': cluster.idpCertificate,
-              'idp-issuer-url': cluster.idpIssuerUrl,
-              'refresh-token': refreshToken,
+      token
+        ? {
+            name: username,
+            user: {
+              'auth-provider': {
+                config: {
+                  'client-id': cluster.idpClientId,
+                  'id-token': token,
+                  'idp-certificate-authority-data': cluster.idpCertificate,
+                  'idp-issuer-url': cluster.idpIssuerUrl,
+                  'refresh-token': refreshToken,
+                },
+                name: 'oidc',
+              },
             },
-            name: 'oidc',
+          }
+        : {
+            name: username,
+            user: {
+              // See https://github.com/int128/kubelogin#setup for this config
+              exec: {
+                apiVersion: 'client.authentication.k8s.io/v1beta1',
+                command: 'kubectl',
+                args: [
+                  'oidc-login',
+                  'get-token',
+                  `--oidc-issuer-url=${cluster.idpIssuerUrl}`,
+                  `--oidc-client-id=${cluster.idpClientId}`,
+                  `--certificate-authority-data=${cluster.idpCertificate}`,
+                ],
+              },
+            },
           },
-        },
-      },
     ],
   };
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -4636,6 +4636,11 @@ yallist@^4.0.0:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
+yaml@^1.10.2:
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
+  integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
+
 yaml@^1.7.2:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.0.tgz#3b593add944876077d4d683fee01081bd9fff31e"


### PR DESCRIPTION
This commit adds cluster syncing to the SyncManager. It doesn't
store anything yet in the SyncStore, so it recreates the cluster
objects every time a DataCloud fetches new data.

It uses the `kubelogin` k8s plugin to allow Lens to connect to the
cluster, pushing cluster-specifi token generation to the point
where the cluster is opened in Lens so that the SyncManager doesn't
have to make SSO requests to generate those tokens, which would
require opening the user's default browser (UX would be very bad).

Also:
- Fixed bug in ApiClient.request() that was not letting the caller
  specify the method to use to decode the body (so far, it was just
  working as a fluke that all requests were 'json', which was the
  default).
- For properties that are URLs, add custom validator to typesets
  to make sure they don't end with a slash.
- Add a custom property to Lens built-in KubernetesCluster Catalog
  entity type to check that it's possible to extend the details
  panel. Remaining work to be done in PRODX-22031.
- Fix bug with Cloud.updateNamespaces() where it was being created
  on prototype (as we wanted) but because it was being created
  with Object.defineProperty() instead of just being a class
  method, we were overwriting that method for every new Cloud
  we would create, which was breaking any already-existing Cloud
  instances (well, actually, we'd get a crash because we'd try
  to re-define an already-defined and non-configurable property).
- Added API logout to Cloud.disconnect() to make sure the session
  is ended.
- Fixed rendering crash when disconnecting and loging out from
  a Cloud without removing the Cloud (had to force this case because
  the UI currently doesn't allow just disconnecting without also
  removing) because DataCloudProvider and SyncManager weren't
  accounting for `null` tokens when determining which Clouds
  had changed after a ClusterStore update.
- Moved getStatus() from EnhancedTableRow to TableRowListenerWrapper
  to fix the "Connected/Updating/Disconnected" Cloud label not
  updating to "Disconnected" when manually logging out of the Cloud
  (forced use case, but surfaced a few bugs that were good to fix).