### PR TITLE
[PRODX-22248]: Replaced status bar button with top bar button to view extension page

### DIFF
--- a/src/renderer/renderer.tsx
+++ b/src/renderer/renderer.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Renderer } from '@k8slens/extensions';
-import { GlobalPage, GlobalPageIcon } from './components/GlobalPage/GlobalPage';
+import { GlobalPage } from './components/GlobalPage/GlobalPage';
 import {
   ClusterPage,
   ClusterPageIcon,
@@ -17,6 +17,7 @@ import { getLensClusters } from './rendererUtil';
 import { mkClusterContextName } from '../util/templates';
 import { EXT_EVENT_OAUTH_CODE, EXT_EVENT_ACTIVATE_CLUSTER } from './eventBus';
 import { catalogEntityDetails } from './catalogEntityDetails';
+import { registerTopBarItems } from './topBar';
 
 const {
   LensExtension,
@@ -25,7 +26,6 @@ const {
 } = Renderer;
 
 const logger: any = loggerUtil; // get around TS compiler's complaining
-const statusItemColor = 'white'; // CSS color; Lens hard-codes the color of the workspace indicator item to 'white' also
 
 declare const FEAT_CLUSTER_PAGE_ENABLED: any; // TODO[clusterpage]: remove
 
@@ -72,19 +72,8 @@ export default class ExtensionRenderer extends LensExtension {
   //     at decorate (mobx.module.js:363)
   //     at decoratorFactory (mobx.module.js:384)
   // ============
-  statusBarItems = [
-    {
-      item: (
-        <div
-          className="flex align-center gaps"
-          title={strings.extension.statusBar['label']()}
-          onClick={() => this.navigate(ROUTE_GLOBAL_PAGE)}
-        >
-          <GlobalPageIcon size={16} fill={statusItemColor} />
-        </div>
-      ),
-    },
-  ];
+
+  topBarItems = registerTopBarItems(this);
 
   catalogEntityDetailItems = catalogEntityDetails;
 

--- a/src/renderer/topBar.tsx
+++ b/src/renderer/topBar.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import { ROUTE_GLOBAL_PAGE } from '../routes';
+import { GlobalPageIcon } from './components/GlobalPage/GlobalPage';
+import { layout } from './components/styles';
+import * as strings from '../strings';
+
+const statusItemColor = '#8F9296';
+
+const TopBarExtension = styled.div`
+  position: absolute;
+  top: ${layout.grid * 1.25}px;
+  right: ${layout.grid * 15}px;
+  display: flex;
+  align-items: center;
+  background-color: var(--mainBackground);
+  padding: ${layout.pad * 0.25}px ${layout.pad * 0.5}px;
+  border-radius: 4px;
+  cursor: pointer;
+`;
+
+const TopBarExtensionTitle = styled.p`
+  font-size: calc(var(--font-size) * 0.85);
+  line-height: 1.17;
+  color: #c4c4c4;
+  max-width: ${layout.grid * 22.5}px;
+  margin-left: ${layout.grid * 1.25}px;
+`;
+
+export function registerTopBarItems(extension) {
+  return [
+    {
+      components: {
+        Item: () => {
+          return (
+            <TopBarExtension
+              onClick={() => extension.navigate(ROUTE_GLOBAL_PAGE)}
+            >
+              <GlobalPageIcon size={24} fill={statusItemColor} />
+              <TopBarExtensionTitle>
+                {strings.extension.statusBar['label']()}
+              </TopBarExtensionTitle>
+            </TopBarExtension>
+          );
+        },
+      },
+    },
+  ];
+}

--- a/src/renderer/topBar.tsx
+++ b/src/renderer/topBar.tsx
@@ -5,15 +5,10 @@ import { GlobalPageIcon } from './components/GlobalPage/GlobalPage';
 import { layout } from './components/styles';
 import * as strings from '../strings';
 
-const statusItemColor = '#8F9296';
-
 const TopBarExtension = styled.div`
-  position: absolute;
-  top: ${layout.grid * 1.25}px;
-  right: ${layout.grid * 15}px;
   display: flex;
   align-items: center;
-  background-color: var(--mainBackground);
+  background-color: var(--layoutTabsBackground);
   padding: ${layout.pad * 0.25}px ${layout.pad * 0.5}px;
   border-radius: 4px;
   cursor: pointer;
@@ -22,7 +17,7 @@ const TopBarExtension = styled.div`
 const TopBarExtensionTitle = styled.p`
   font-size: calc(var(--font-size) * 0.85);
   line-height: 1.17;
-  color: #c4c4c4;
+  color: var(--textColorPrimary);
   max-width: ${layout.grid * 22.5}px;
   margin-left: ${layout.grid * 1.25}px;
 `;
@@ -36,7 +31,7 @@ export function registerTopBarItems(extension) {
             <TopBarExtension
               onClick={() => extension.navigate(ROUTE_GLOBAL_PAGE)}
             >
-              <GlobalPageIcon size={24} fill={statusItemColor} />
+              <GlobalPageIcon size={24} fill="var(--textColorPrimary)" />
               <TopBarExtensionTitle>
                 {strings.extension.statusBar['label']()}
               </TopBarExtensionTitle>


### PR DESCRIPTION
UPD: Added new screenshots with dark/light versions
<img width="1280" alt="Screenshot 2022-03-20 at 19 49 02" src="https://user-images.githubusercontent.com/33761040/159175655-245e3fcd-168d-45ca-9aaa-6326a55e5380.png">
<img width="1280" alt="Screenshot 2022-03-20 at 19 48 48" src="https://user-images.githubusercontent.com/33761040/159175658-a4e5e4fb-99f0-4c26-8e90-1b0ecab80a92.png">
