### PR TITLE
[PRODX-22268] SyncManager blindly restores Catalog from SyncStore

### DIFF
--- a/src/api/types/Cluster.js
+++ b/src/api/types/Cluster.js
@@ -346,7 +346,7 @@ export class Cluster extends ApiObject {
    * @override
    */
   toModel(kubeconfigPath) {
-    const entity = super.toModel();
+    const model = super.toModel();
 
     DEV_ENV && rtv.verify({ kubeconfigPath }, { kubeconfigPath: rtv.STRING });
 
@@ -375,7 +375,7 @@ export class Cluster extends ApiObject {
       }
     }
 
-    return merge({}, entity, {
+    return merge({}, model, {
       metadata: {
         namespace: this.namespace.name,
         labels,

--- a/src/api/types/Credential.js
+++ b/src/api/types/Credential.js
@@ -100,9 +100,9 @@ export class Credential extends ApiObject {
    * @override
    */
   toModel() {
-    const entity = super.toModel();
+    const model = super.toModel();
 
-    return merge({}, entity, {
+    return merge({}, model, {
       metadata: {
         namespace: this.namespace.name,
         labels: {

--- a/src/api/types/License.js
+++ b/src/api/types/License.js
@@ -61,9 +61,9 @@ export class License extends ApiObject {
    * @override
    */
   toModel() {
-    const entity = super.toModel();
+    const model = super.toModel();
 
-    return merge({}, entity, {
+    return merge({}, model, {
       metadata: {
         namespace: this.namespace.name,
         labels: {

--- a/src/api/types/Proxy.js
+++ b/src/api/types/Proxy.js
@@ -92,9 +92,9 @@ export class Proxy extends ApiObject {
    * @override
    */
   toModel() {
-    const entity = super.toModel();
+    const model = super.toModel();
 
-    return merge({}, entity, {
+    return merge({}, model, {
       metadata: {
         namespace: this.namespace.name,
         labels: {

--- a/src/api/types/SshKey.js
+++ b/src/api/types/SshKey.js
@@ -69,9 +69,9 @@ export class SshKey extends ApiObject {
    * @override
    */
   toModel() {
-    const entity = super.toModel();
+    const model = super.toModel();
 
-    return merge({}, entity, {
+    return merge({}, model, {
       metadata: {
         namespace: this.namespace.name,
         labels: {

--- a/src/catalog/catalogEntities.js
+++ b/src/catalog/catalogEntities.js
@@ -104,7 +104,7 @@ export const clusterEntityModelTs = mergeRtvShapes({}, catalogEntityModelTs, {
     //// CUSTOM PROPERTIES
 
     labels: [
-      // either it's a mgmt cluster and we no labels
+      // either it's a mgmt cluster and we have no labels
       rtv.HASH_MAP,
       { length: 0 },
 
@@ -113,27 +113,11 @@ export const clusterEntityModelTs = mergeRtvShapes({}, catalogEntityModelTs, {
       {
         $: {
           ...requiredLabelTs,
-          sshKey: [rtv.OPTIONAL, rtv.STRING, (value) => !!value], // either no label, or non-empty string
-          credential: [rtv.OPTIONAL, rtv.STRING, (value) => !!value], // either no label, or non-empty string
-          proxy: [rtv.OPTIONAL, rtv.STRING, (value) => !!value], // either no label, or non-empty string
-          license: [rtv.OPTIONAL, rtv.STRING, (value) => !!value], // either no label, or non-empty string
+          sshKey: [rtv.OPTIONAL, rtv.STRING, (value) => value !== ''], // either no label, or non-empty string
+          credential: [rtv.OPTIONAL, rtv.STRING, (value) => value !== ''], // either no label, or non-empty string
+          proxy: [rtv.OPTIONAL, rtv.STRING, (value) => value !== ''], // either no label, or non-empty string
+          license: [rtv.OPTIONAL, rtv.STRING, (value) => value !== ''], // either no label, or non-empty string
         },
-      },
-
-      // custom validator (called as long as at least one of the previous types
-      //  is a match) reinforces the mgmt cluster check based on the actual
-      //  properties of the entity being validated
-      (value, match, ts, { originalValue: entity, parent }) => {
-        if (entity.spec.isManagementCluster) {
-          if (Object.keys(parent.labels).length > 0) {
-            // mgmt cluster has no labels at this time
-            throw new Error(
-              `Unexpected labels for management cluster: [${Object.keys(
-                parent.labels
-              ).join(', ')}]`
-            );
-          }
-        }
       },
     ],
   },

--- a/src/store/CloudStore.js
+++ b/src/store/CloudStore.js
@@ -61,6 +61,11 @@ export class CloudStore extends Common.Store.ExtensionStore {
 
     const json = result.valid ? store : CloudStore.getDefaults();
 
+    logger.log(
+      'CloudStore.fromStore()',
+      `Updating store: clouds=[${Object.keys(store.clouds).join(', ')}]`
+    );
+
     Object.keys(json).forEach((key) => {
       if (key === 'clouds') {
         // restore from a map of cloudUrl to JSON object -> into a map of cloudUrl
@@ -98,6 +103,11 @@ export class CloudStore extends Common.Store.ExtensionStore {
         this[key] = json[key];
       }
     });
+
+    logger.log(
+      'CloudStore.fromStore()',
+      `Store updated: clouds=[${Object.keys(store.clouds).join(', ')}]`
+    );
   }
 
   toJSON() {

--- a/src/store/SyncStore.js
+++ b/src/store/SyncStore.js
@@ -25,19 +25,34 @@ export class SyncStore extends Common.Store.ExtensionStore {
   //  Lens gives the extension, but we don't know what it is until later
   // static defaultSavePath = null;
 
-  /** @member {Array} credentials List of entity objects that match `credentialEntityModelTs`. */
+  /**
+   * @member {Array} credentials List of Catalog Entity Models that match
+   *  `credentialEntityModelTs`.
+   */
   @observable credentials;
 
-  /** @member {Array} sshKeys List of entity objects that match `sshKeyEntityModelTs`. */
+  /**
+   * @member {Array} sshKeys List of Catalog Entity Models that match
+   *  `sshKeyEntityModelTs`.
+   */
   @observable sshKeys;
 
-  /** @member {Array} clusters List of entity objects that match `clusterEntityModelTs`. */
+  /**
+   * @member {Array} clusters List of Catalog Entity Models that match
+   *  `clusterEntityModelTs`.
+   */
   @observable clusters;
 
-  /** @member {Array} licenses List of entity objects that match `licenseEntityModelTs`. */
+  /**
+   * @member {Array} licenses List of Catalog Entity Models that match
+   *  `licenseEntityModelTs`.
+   */
   @observable licenses;
 
-  /** @member {Array} proxies List of entity objects that match `proxyEntityModelTs`. */
+  /**
+   * @member {Array} proxies List of Catalog Entity Models that match
+   *  `proxyEntityModelTs`.
+   */
   @observable proxies;
 
   static getDefaults() {
@@ -80,9 +95,23 @@ export class SyncStore extends Common.Store.ExtensionStore {
 
     const json = result.valid ? store : SyncStore.getDefaults();
 
+    logger.log(
+      'SyncStore.fromStore()',
+      `Updating store: ${Object.entries(json)
+        .map(([key, value]) => `${key}=${value.length}`)
+        .join(', ')}`
+    );
+
     Object.keys(json).forEach((key) => {
       this[key] = json[key];
     });
+
+    logger.log(
+      'SyncStore.fromStore()',
+      `Store updated: ${Object.entries(json)
+        .map(([key, value]) => `${key}=${value.length}`)
+        .join(', ')}`
+    );
   }
 
   toJSON() {


### PR DESCRIPTION
It doesn't sync anything. It just reads the SyncStore and re-creates
all entities, even if a Cloud is disconnected.

Also moved from MobX autorun() to reaction() so we have more
control over what we're reacting to.