### PR TITLE
[PRODX-22269] SyncManager efficient updates

### DIFF
--- a/src/api/apiUtil.js
+++ b/src/api/apiUtil.js
@@ -7,7 +7,7 @@ import { ApiClient } from './clients/ApiClient';
 import { AuthorizationClient } from './clients/AuthorizationClient';
 import { KubernetesClient } from './clients/KubernetesClient';
 import { ResourceClient } from './clients/ResourceClient';
-import { logger, logString } from '../util/logger';
+import { logger, logValue } from '../util/logger';
 import { apiResourceTypes } from './apiConstants';
 
 const typeToClient = {
@@ -151,7 +151,7 @@ export async function cloudRequest({ cloud, method, resourceType, args }) {
   if (!Client) {
     return {
       cloud,
-      error: `Unknown or unmapped resourceType=${logString(resourceType)}`,
+      error: `Unknown or unmapped resourceType=${logValue(resourceType)}`,
       status: 0,
     };
   }

--- a/src/api/clients/KubernetesClient.js
+++ b/src/api/clients/KubernetesClient.js
@@ -1,7 +1,7 @@
 import { request } from '../../util/netUtil';
 import * as strings from '../../strings';
 import { apiResourceTypes } from '../apiConstants';
-import { logString } from '../../util/logger';
+import { logValue } from '../../util/logger';
 
 /**
  * Used to work with Kubernetes cluster-wide resources (i.e. not in a namespace) resources
@@ -61,7 +61,7 @@ export class KubernetesClient {
       options: { method: 'POST', body: JSON.stringify(spec) },
       expectedStatuses: [201],
       errorMessage: strings.apiClient.error.failedToCreate(
-        `${logString(resourceType)} "${spec.metadata.name}"`
+        `${logValue(resourceType)} "${spec.metadata.name}"`
       ),
     });
   }
@@ -74,7 +74,7 @@ export class KubernetesClient {
     return this.request(url[resourceType], {
       options: { method: 'DELETE' },
       errorMessage: strings.apiClient.error.failedToDelete(
-        `${logString(resourceType)} "${name}"`
+        `${logValue(resourceType)} "${name}"`
       ),
     });
   }

--- a/src/api/clients/ResourceClient.js
+++ b/src/api/clients/ResourceClient.js
@@ -1,7 +1,7 @@
 import { request } from '../../util/netUtil';
 import * as strings from '../../strings';
 import { apiResourceTypes } from '../apiConstants';
-import { logString } from '../../util/logger';
+import { logValue } from '../../util/logger';
 
 // no start nor end slashes
 const clusterEndpoint = 'apis/cluster.k8s.io/v1alpha1';
@@ -47,7 +47,7 @@ export class ResourceClient {
     this.apiPrefix = ResourceClient.typeToApiPrefix[resourceType];
     if (!this.apiPrefix) {
       throw new Error(
-        `Unknown or unmapped resourceType=${logString(resourceType)}`
+        `Unknown or unmapped resourceType=${logValue(resourceType)}`
       );
     }
 
@@ -114,7 +114,7 @@ export class ResourceClient {
       {
         options: { method: 'DELETE' },
         errorMessage: strings.apiClient.error.failedToDelete(
-          `${logString(resourceType)} ${logString(name)}`
+          `${logValue(resourceType)} ${logValue(name)}`
         ),
       }
     );
@@ -130,7 +130,7 @@ export class ResourceClient {
           headers: { 'Content-Type': 'application/merge-patch+json' },
         },
         errorMessage: strings.apiClient.error.failedToUpdate(
-          `${logString(resourceType)} ${logString(name)}`
+          `${logValue(resourceType)} ${logValue(name)}`
         ),
       }
     );

--- a/src/api/types/Cluster.js
+++ b/src/api/types/Cluster.js
@@ -10,7 +10,7 @@ import { Proxy } from './Proxy';
 import { License } from './License';
 import { clusterEntityPhases } from '../../catalog/catalogEntities';
 import { apiKinds } from '../apiConstants';
-import { logString } from '../../util/logger';
+import { logValue } from '../../util/logger';
 import { mkKubeConfig } from '../../util/templates';
 
 const {
@@ -28,7 +28,7 @@ const getServerUrl = function (data) {
 };
 
 /**
- * Typeset for an MCC Cluster object.
+ * Typeset for an MCC Cluster API resource.
  */
 export const clusterTs = mergeRtvShapes({}, resourceTs, {
   // NOTE: this is not intended to be fully-representative; we only list the properties
@@ -85,7 +85,7 @@ export const clusterTs = mergeRtvShapes({}, resourceTs, {
 });
 
 /**
- * MCC cluster.
+ * MCC cluster API resource.
  * @class Cluster
  */
 export class Cluster extends Resource {
@@ -408,7 +408,7 @@ export class Cluster extends Resource {
   toString() {
     const propStr = `${super.toString()}, ready: ${
       this.ready
-    }, region: ${logString(this.region)}`;
+    }, region: ${logValue(this.region)}`;
 
     if (Object.getPrototypeOf(this).constructor === Cluster) {
       return `{Cluster ${propStr}}`;

--- a/src/api/types/Credential.js
+++ b/src/api/types/Credential.js
@@ -10,7 +10,7 @@ import {
 } from '../../catalog/CredentialEntity';
 
 /**
- * Typeset for an MCC Credential object.
+ * Typeset for an MCC Credential API resource.
  */
 export const credentialTs = mergeRtvShapes({}, resourceTs, {
   // NOTE: this is not intended to be fully-representative; we only list the properties
@@ -26,11 +26,18 @@ export const credentialTs = mergeRtvShapes({}, resourceTs, {
       },
     ],
   },
+  // NOTE: BYOCredential resources don't have `status` objects for some reason
+  //  so it's effectively made optional by temporarily removing it from the Typeset
+  //  in the Credential class constructor only when the kind is BYO_CREDENTIAL
   status: {
     valid: rtv.BOOLEAN,
   },
 });
 
+/**
+ * MCC credential API resource.
+ * @class Proxy
+ */
 export class Credential extends Resource {
   /**
    * @constructor

--- a/src/api/types/License.js
+++ b/src/api/types/License.js
@@ -8,10 +8,10 @@ import {
   licenseEntityPhases,
 } from '../../catalog/LicenseEntity';
 import { apiKinds } from '../apiConstants';
-import { logString } from '../../util/logger';
+import { logValue } from '../../util/logger';
 
 /**
- * Typeset for an MCC License object.
+ * Typeset for an MCC License API resource.
  */
 export const licenseTs = mergeRtvShapes({}, resourceTs, {
   // NOTE: this is not intended to be fully-representative; we only list the properties
@@ -21,10 +21,8 @@ export const licenseTs = mergeRtvShapes({}, resourceTs, {
 });
 
 /**
- * MCC license.
+ * MCC license API resource.
  * @class License
- * @param {Object} data Raw cluster data payload from the API.
- * @param {Namespace} namespace Namespace to which this object belongs.
  */
 export class License extends Resource {
   /**
@@ -87,7 +85,7 @@ export class License extends Resource {
 
   /** @returns {string} A string representation of this instance for logging/debugging. */
   toString() {
-    const propStr = `${super.toString()}, namespace: ${logString(
+    const propStr = `${super.toString()}, namespace: ${logValue(
       this.namespace.name
     )}`;
 

--- a/src/api/types/Proxy.js
+++ b/src/api/types/Proxy.js
@@ -5,10 +5,10 @@ import { Resource, resourceTs } from './Resource';
 import { Namespace } from './Namespace';
 import { ProxyEntity, proxyEntityPhases } from '../../catalog/ProxyEntity';
 import { apiKinds } from '../apiConstants';
-import { logString } from '../../util/logger';
+import { logValue } from '../../util/logger';
 
 /**
- * Typeset for an MCC Proxy object.
+ * Typeset for an MCC Proxy API resource.
  */
 export const proxyTs = mergeRtvShapes({}, resourceTs, {
   // NOTE: this is not intended to be fully-representative; we only list the properties
@@ -30,10 +30,8 @@ export const proxyTs = mergeRtvShapes({}, resourceTs, {
 });
 
 /**
- * MCC proxy.
+ * MCC proxy API resource.
  * @class Proxy
- * @param {Object} data Raw cluster data payload from the API.
- * @param {Namespace} namespace Namespace to which this object belongs.
  */
 export class Proxy extends Resource {
   /**
@@ -123,11 +121,9 @@ export class Proxy extends Resource {
 
   /** @returns {string} A string representation of this instance for logging/debugging. */
   toString() {
-    const propStr = `${super.toString()}, namespace: ${logString(
+    const propStr = `${super.toString()}, namespace: ${logValue(
       this.namespace.name
-    )}, http: ${logString(this.httpProxy)}, https: ${logString(
-      this.httpsProxy
-    )}`;
+    )}, http: ${logValue(this.httpProxy)}, https: ${logValue(this.httpsProxy)}`;
 
     if (Object.getPrototypeOf(this).constructor === Proxy) {
       return `{Proxy ${propStr}}`;

--- a/src/api/types/Resource.js
+++ b/src/api/types/Resource.js
@@ -1,7 +1,7 @@
 import * as rtv from 'rtvjs';
 import * as consts from '../../constants';
 import { Cloud } from '../../common/Cloud';
-import { logString } from '../../util/logger';
+import { logValue } from '../../util/logger';
 
 /**
  * Typeset for a basic MCC API Object.
@@ -16,6 +16,7 @@ export const resourceTs = {
   metadata: {
     uid: rtv.STRING,
     name: rtv.STRING,
+    resourceVersion: rtv.STRING,
     creationTimestamp: rtv.STRING, // ISO8601 timestamp
     deletionTimestamp: [rtv.OPTIONAL, rtv.STRING], // ISO8601 timestamp; only exists if being deleted
   },
@@ -44,7 +45,7 @@ export class Resource {
         }
       );
 
-    /** @member {Cloud} */
+    /** @member {Cloud} cloud */
     Object.defineProperty(this, 'cloud', {
       enumerable: true,
       get() {
@@ -52,7 +53,7 @@ export class Resource {
       },
     });
 
-    /** @member {string} */
+    /** @member {string} uid */
     Object.defineProperty(this, 'uid', {
       enumerable: true,
       get() {
@@ -60,7 +61,7 @@ export class Resource {
       },
     });
 
-    /** @member {string} */
+    /** @member {string} kind One of the known API kinds in the `apiConstants.apiKinds` enum. */
     Object.defineProperty(this, 'kind', {
       enumerable: true,
       get() {
@@ -68,7 +69,7 @@ export class Resource {
       },
     });
 
-    /** @member {string} */
+    /** @member {string} name */
     Object.defineProperty(this, 'name', {
       enumerable: true,
       get() {
@@ -76,7 +77,21 @@ export class Resource {
       },
     });
 
-    /** @member {Date} */
+    /**
+     * Identifies a specific version of this resource in the Kube API. This opaque
+     *  string value can be used to detect when the resource has changed, so it
+     *  essentially reprents a type of hash of the resource's values/state.
+     * @member {string} resourceVersion
+     * @see https://kubernetes.io/docs/reference/using-api/api-concepts/#efficient-detection-of-changes
+     */
+    Object.defineProperty(this, 'resourceVersion', {
+      enumerable: true,
+      get() {
+        return data.metadata.resourceVersion;
+      },
+    });
+
+    /** @member {Date} createdDate */
     Object.defineProperty(this, 'createdDate', {
       enumerable: true,
       get() {
@@ -84,7 +99,7 @@ export class Resource {
       },
     });
 
-    /** @member {boolean|null} */
+    /** @member {boolean|null} deleteInProgress */
     Object.defineProperty(this, 'deleteInProgress', {
       enumerable: true,
       get() {
@@ -107,6 +122,7 @@ export class Resource {
         labels: {},
         cloudUrl: this.cloud.cloudUrl,
         kind: this.kind,
+        resourceVersion: this.resourceVersion,
       },
       spec: {
         createdAt: this.createdDate.toISOString(),
@@ -117,10 +133,10 @@ export class Resource {
 
   /** @returns {string} A string representation of this instance for logging/debugging. */
   toString() {
-    const propStr = `name: ${logString(this.name)}, uid: ${logString(
+    const propStr = `name: ${logValue(this.name)}, uid: ${logValue(
       this.uid
-    )}, kind: ${logString(this.kind)}, cloudUrl=${logString(
-      this.cloud?.cloudUrl
+    )}, kind: ${logValue(this.kind)}, cloudUrl: ${logValue(
+      this.cloud.cloudUrl
     )}`;
 
     if (Object.getPrototypeOf(this).constructor === Resource) {

--- a/src/api/types/SshKey.js
+++ b/src/api/types/SshKey.js
@@ -5,10 +5,10 @@ import { Resource, resourceTs } from './Resource';
 import { Namespace } from './Namespace';
 import { SshKeyEntity, sshKeyEntityPhases } from '../../catalog/SshKeyEntity';
 import { apiKinds } from '../apiConstants';
-import { logString } from '../../util/logger';
+import { logValue } from '../../util/logger';
 
 /**
- * Typeset for an MCC SSH Key object.
+ * Typeset for an MCC SSH Key API resource.
  */
 export const sshKeyTs = mergeRtvShapes({}, resourceTs, {
   // NOTE: this is not intended to be fully-representative; we only list the properties
@@ -21,10 +21,8 @@ export const sshKeyTs = mergeRtvShapes({}, resourceTs, {
 });
 
 /**
- * MCC ssh key.
+ * MCC ssh key API resource.
  * @class SshKey
- * @param {Object} data Raw cluster data payload from the API.
- * @param {Namespace} namespace Namespace to which this object belongs.
  */
 export class SshKey extends Resource {
   /**
@@ -98,7 +96,7 @@ export class SshKey extends Resource {
 
   /** @returns {string} A string representation of this instance for logging/debugging. */
   toString() {
-    const propStr = `${super.toString()}, namespace: ${logString(
+    const propStr = `${super.toString()}, namespace: ${logValue(
       this.namespace.name
     )}, publicKey: "${this.publicKey.slice(0, 15)}..${this.publicKey.slice(
       -15

--- a/src/catalog/catalogEntityTypes.ts
+++ b/src/catalog/catalogEntityTypes.ts
@@ -13,6 +13,7 @@ export interface CatalogEntityMetadata extends LensCatalogEntityMetadata {
   kind: string;
   namespace: string;
   cloudUrl: string;
+  resourceVersion: string;
 }
 
 export interface CatalogEntitySpec {

--- a/src/common/Cloud.js
+++ b/src/common/Cloud.js
@@ -1,7 +1,7 @@
 import * as rtv from 'rtvjs';
 import { isEqual } from 'lodash';
 import { request } from '../util/netUtil';
-import { logger, logString } from '../util/logger';
+import { logger, logValue } from '../util/logger';
 import * as strings from '../strings';
 import * as ssoUtil from '../util/ssoUtil';
 import {
@@ -710,7 +710,7 @@ export class Cloud extends EventDispatcher {
   /** @returns {string} String representation of this Cloud for logging/debugging. */
   toString() {
     const validTillStr = logDate(this.tokenValidTill);
-    return `{Cloud url: ${logString(this.cloudUrl)}, status: ${logString(
+    return `{Cloud url: ${logValue(this.cloudUrl)}, status: ${logValue(
       this.status
     )}, token: ${
       this.token
@@ -718,7 +718,7 @@ export class Cloud extends EventDispatcher {
         : this.token
     }, valid: ${this.tokenValid}, validTill: ${
       validTillStr ? `"${validTillStr}"` : validTillStr
-    }, refreshValid: ${this.refreshTokenValid}, connectError: ${logString(
+    }, refreshValid: ${this.refreshTokenValid}, connectError: ${logValue(
       this.connectError
     )}}`;
   }

--- a/src/main/SyncManager.js
+++ b/src/main/SyncManager.js
@@ -9,15 +9,22 @@ import { DATA_CLOUD_EVENTS, DataCloud } from '../common/DataCloud';
 import { cloudStore } from '../store/CloudStore';
 import { syncStore } from '../store/SyncStore';
 import { apiCredentialKinds, apiKinds } from '../api/apiConstants';
-import { logString } from '../util/logger';
+import { logValue } from '../util/logger';
 import * as consts from '../constants';
+import {
+  KUBECONFIG_DIR_NAME,
+  catalogEntityModelTs,
+  entityToString,
+  findEntity,
+  modelToString,
+} from '../catalog/catalogEntities';
 import { SshKeyEntity } from '../catalog/SshKeyEntity';
 import { LicenseEntity } from '../catalog/LicenseEntity';
 import { ProxyEntity } from '../catalog/ProxyEntity';
 import { CredentialEntity } from '../catalog/CredentialEntity';
 
 const {
-  Catalog: { KubernetesCluster },
+  Catalog: { KubernetesCluster, CatalogEntity },
   Util: { Singleton },
 } = Common;
 
@@ -177,6 +184,9 @@ export class SyncManager extends Singleton {
         //  loaded (meaning that `SyncStore.fromStore()` has been called by Lens at
         //  least once)
         fireImmediately: true,
+        // debounce reactions to reduce churn if multiple Clouds somehow get updated
+        //  at the same time
+        delay: 100,
       }
     );
 
@@ -197,6 +207,9 @@ export class SyncManager extends Singleton {
         //  loaded (meaning that `SyncStore.fromStore()` has been called by Lens at
         //  least once)
         fireImmediately: true,
+        // debounce reactions to reduce churn; otherwise, we'll get reactions for
+        //  each individual item added/removed/updated
+        delay: 500,
       }
     );
   }
@@ -250,7 +263,93 @@ export class SyncManager extends Singleton {
   }
 
   /**
-   * Update extended clouds in the store.
+   * Removes all entities of a given DataCloud from the Catalog.
+   * @param {DataCloud} dataCloud
+   */
+  async removeFromCatalog(dataCloud) {
+    this.ipcMain.capture(
+      'info',
+      'SyncManager.removeFromCatalog()',
+      `DataCloud deleted, removing all synced entities from Catalog; dataCloud=${dataCloud}`
+    );
+
+    //// GET KUBECONFIG FILE BASE PATH
+
+    try {
+      await this.determineBaseKubeConfigPath();
+    } catch (err) {
+      this.ipcMain.capture(
+        'error',
+        'SyncManager.updateClusters()',
+        `Cannot update clusters: Failed to get Lens-designated extension file folder path; error="${err.message}"`
+      );
+      return;
+    }
+
+    //// DELETE ENTITIES AND CLUSTER KUBECONFIG FILES
+
+    // NOTE: just in case the delete came at a strange time during sync, the most effective,
+    //  sure way of removing the entities is not to loop through `dataCloud.syncedNamespaces`,
+    //  but rather to simply find all entities related to its `dataCloud.cloud.cloudUrl` and
+    //  just remove them
+    let deleteCount = 0;
+
+    ['catalog', 'syncStore'].forEach((target) => {
+      const lists =
+        target === 'catalog'
+          ? [this.catalogSource]
+          : // NOTE: we can't just flatten all the SyncStore lists into one because it'll lose its observability
+            //  and we won't get actual models, we'll get "Mobx binding items" of some kind (not what you think!)
+            syncStore.getListNames().map((name) => syncStore[name]);
+
+      lists.forEach((list) => {
+        let idx;
+        while (
+          (idx = list.findIndex((item) => {
+            // entities and models have the same basic interface
+            return item.metadata.cloudUrl === dataCloud.cloud.cloudUrl;
+          })) >= 0
+        ) {
+          const item = list[idx];
+          this.ipcMain.capture(
+            'log',
+            'SyncManager.removeFromCatalog()',
+            `Removing ${
+              target === 'catalog' ? entityToString(item) : modelToString(item)
+            } from Catalog and deleting kubeconfig file: Cloud deleted`
+          );
+
+          list.splice(idx, 1);
+
+          if (target === 'catalog') {
+            // catalog or syncStore, doesn't matter, just count once!
+            deleteCount++;
+          }
+        }
+      });
+    });
+
+    // no need to wait around for the promise to resolve or reject
+    const cloudPath = this.getKubeConfigCloudPath(dataCloud.cloud);
+    fs.rm(cloudPath, { force: true, recursive: true }).catch((err) => {
+      this.ipcMain.capture(
+        'error',
+        'SyncManager.removeFromCatalog()',
+        `Failed to delete kubeconfig cloud path ${logValue(
+          cloudPath
+        )}; error=${logValue(err.message)}`
+      );
+    });
+
+    this.ipcMain.capture(
+      'info',
+      'SyncManager.removeFromCatalog()',
+      `Done: DataCloud deleted, removed ${deleteCount} synced entities from Catalog; dataCloud=${dataCloud}`
+    );
+  }
+
+  /**
+   * Update extended clouds after a change in the CloudStore.
    * @param {Object} params
    * @param {{ [index: string]: string }} params.cloudStoreTokens Map of Cloud URL to token for
    *  the current set of known Clouds stored on disk.
@@ -259,7 +358,7 @@ export class SyncManager extends Singleton {
    * @param {Array<string>} params.cloudUrlsToRemove List of cloudUrls that must be removed
    * @private
    */
-  updateStore({
+  updateClouds({
     cloudStoreTokens,
     cloudUrlsToAdd,
     cloudUrlsToUpdate,
@@ -269,14 +368,13 @@ export class SyncManager extends Singleton {
     this.cloudTokens = cloudStoreTokens;
 
     cloudUrlsToRemove.forEach((url) => {
-      // TODO[PRODX-22269]: for each DC we're removing, we need to clean-up its kubeconfig files
-
       // destroy and remove DataCloud
       const dc = this.dataClouds[url];
       dc.removeEventListener(
         DATA_CLOUD_EVENTS.DATA_UPDATED,
         this.onDataUpdated
       );
+      this.removeFromCatalog(dc);
       dc.cloud.destroy();
       dc.destroy();
       delete this.dataClouds[url];
@@ -307,8 +405,8 @@ export class SyncManager extends Singleton {
         //  we finally have new tokens and we're reconnected)
         const updatedDC = this.dataClouds[url];
         this.ipcMain.capture(
-          'log',
-          'SyncManager.updateStore()',
+          'info',
+          'SyncManager.updateClouds()',
           `DataCloud updated, will fetch data now if connected; dataCloud=${updatedDC}`
         );
         if (updatedDC.cloud.connected) {
@@ -329,30 +427,55 @@ export class SyncManager extends Singleton {
   }
 
   /**
-   * Determines where a kubeconfig file will be stored.
+   * Determines the __directory__ where a Cloud's kubeconfig files will be stored.
    * @param {Cluster} cluster
-   * @returns {string} Absolute path to the cluster's kubeconfig file.
+   * @returns {string} Absolute path to the __directory__ in which to store all of
+   *  a Cloud's kubeconfig files.
    */
-  getKubeConfigFilePath(cluster) {
+  getKubeConfigCloudPath(cloud) {
     if (!this.baseKubeConfigPath) {
       throw new Error(
-        `Unable to generate kubeconfig path for ${cluster}: Base path is unknown`
+        `Unable to generate kubeconfig path for ${cloud}: Base path is unknown`
       );
     }
 
-    const url = new URL(cluster.cloud.cloudUrl);
+    const url = new URL(cloud.cloudUrl);
     return path.resolve(
       this.baseKubeConfigPath,
-      'kubeconfigs',
       // NOTE: we're using the host because the user might change the Cloud's name, which
       //  would be difficult to sync up to in order not to lose files, and also keep them
       //  valid from Lens' standpoint; but the host should never change (if it did, the user
       //  would have to add a new Cloud with the new host, and remove the old one, which we
       //  handle just fine)
-      url.host.replace(':', '-'), // includes port if specified
+      url.host.replace(':', '-') // includes port if specified
+    );
+  }
+
+  /**
+   * Determines where a kubeconfig file will be stored.
+   * @param {Cluster} cluster
+   * @returns {string} Absolute path to the cluster's kubeconfig file.
+   */
+  getKubeConfigFilePath(cluster) {
+    return path.resolve(
+      this.getKubeConfigCloudPath(cluster.cloud),
       cluster.namespace.name,
       `${cluster.name}_${cluster.uid}.yaml`
     );
+  }
+
+  /**
+   * Determines the base path for kubeconfig file storage if not already known.
+   * @returns {Promise} Resolves on success, rejects on failure.
+   */
+  async determineBaseKubeConfigPath() {
+    // the base path can only be obtained from Lens asynchronously and isn't specific to any
+    //  DataCloud; we determine it on first need to know basis, and then we store it so we don't
+    //  have to keep doing this
+    if (!this.baseKubeConfigPath) {
+      const extFolderPath = await this.extension.getExtensionFileFolder();
+      this.baseKubeConfigPath = path.join(extFolderPath, KUBECONFIG_DIR_NAME);
+    }
   }
 
   /**
@@ -375,7 +498,7 @@ export class SyncManager extends Singleton {
           return new CredentialEntity(model);
         }
         throw new Error(
-          `Unknown catalog model kind=${logString(model.metadata.kind)}`
+          `Unknown catalog model kind=${logValue(model.metadata.kind)}`
         );
     }
   }
@@ -386,30 +509,39 @@ export class SyncManager extends Singleton {
    */
   async updateClusters(dataCloud) {
     this.ipcMain.capture(
-      'log',
+      'info',
       'SyncManager.updateClusters()',
       `Updating Catalog cluster entities; dataCloud=${dataCloud}`
     );
 
-    // the base path can only be obtained from Lens asynchronously and isn't specific to any
-    //  DataCloud; we determine it on first need to know it, and then we store it so we don't
-    //  have to keep doing this
-    if (!this.baseKubeConfigPath) {
-      try {
-        this.baseKubeConfigPath = await this.extension.getExtensionFileFolder();
-      } catch (err) {
-        this.ipcMain.capture(
-          'error',
-          'SyncManager.updateClusters()',
-          `Failed to get Lens-designated extension file folder path; error="${err.message}"`
-        );
-        return;
-      }
+    const ACTION_ADDED = 'added';
+    const ACTION_UPDATED = 'updated';
+
+    //// GET KUBECONFIG FILE BASE PATH
+
+    try {
+      await this.determineBaseKubeConfigPath();
+    } catch (err) {
+      this.ipcMain.capture(
+        'error',
+        'SyncManager.updateClusters()',
+        `Cannot update clusters: Failed to get Lens-designated extension file folder path; error="${err.message}"`
+      );
+      return;
     }
 
-    // promises resolve to `KubernetesCluster` entity MODELS, or reject to `Error` objects
-    const promises = dataCloud.syncedNamespaces.flatMap((ns) =>
-      ns.clusters.map((cluster) => {
+    //// CREATE KUBECONFIG FILES FOR NEW ENTITIES (and update existing ones)
+
+    // start by determining what is new and what has been updated
+    // promises resolve to objects with the following shape, or reject to an `Error`:
+    //  {
+    //   cluster: Cluster,
+    //   model: clusterEntityModelTs, // model created from `cluster`
+    //   catEntity?: KubernetesCluster, // EXISTING Catalog Entity (if action not 'added')
+    //   action: 'added' | 'updated' | null
+    // }
+    const promises = dataCloud.syncedNamespaces.flatMap((ns) => {
+      return ns.clusters.map((cluster) => {
         if (!cluster.ready) {
           return Promise.reject(
             new Error(
@@ -418,100 +550,202 @@ export class SyncManager extends Singleton {
           );
         }
 
-        const kubeConfig = cluster.getKubeConfig();
-        const configFilePath = path.join(this.getKubeConfigFilePath(cluster));
-        const model = cluster.toModel(configFilePath);
+        const configFilePath = this.getKubeConfigFilePath(cluster);
         const configDirPath = path.dirname(configFilePath);
-        return fs.mkdir(configDirPath, { recursive: true }).then(
-          () =>
-            fs
-              .writeFile(
-                configFilePath,
-                // NOTE: the 'simpleKeys' YAML option ensures that the output uses implicit vs
-                //  explicit notation, which appears to fix the issue where if all of an object's
-                //  properties are `null`, the resulting notation for the object is such that each
-                //  key is preceded by a `?` YAML operator, which Lens doesn't support/expect
-                YAML.stringify(kubeConfig, { simpleKeys: true })
-              )
-              .then(
-                () => model,
-                (err) => {
-                  throw new Error(
-                    `Failed to write kubeconfig file: Unable to add cluster; filePath=${logString(
-                      configFilePath
-                    )}, error=${logString(err.message)}, cluster=${cluster}`
-                  );
-                }
-              ),
-          (err) => {
-            throw new Error(
-              `Failed to create kubeconfig directory: Unable to add cluster; path=${logString(
-                configDirPath
-              )}, error=${logString(err.message)}, cluster=${cluster}`
+        const model = cluster.toModel(configFilePath);
+
+        const catEntity = findEntity(this.catalogSource, model);
+        if (catEntity) {
+          // entity exists already in the Catalog: either same (no changes) or updated
+          if (catEntity.metadata.resourceVersion === cluster.resourceVersion) {
+            return Promise.resolve({
+              cluster,
+              model,
+              catEntity,
+              action: null, // no changes
+            });
+          } else {
+            // something about that resource has changed since the last time we fetched it
+            return Promise.resolve({
+              cluster,
+              model,
+              catEntity,
+              action: ACTION_UPDATED,
+            });
+          }
+        } else {
+          // new entity we have discovered: create kubeconfig file
+          const kubeConfig = cluster.getKubeConfig();
+          return fs.mkdir(configDirPath, { recursive: true }).then(
+            () =>
+              fs
+                .writeFile(
+                  configFilePath,
+                  // NOTE: the 'simpleKeys' YAML option ensures that the output uses implicit vs
+                  //  explicit notation, which appears to fix the issue where if all of an object's
+                  //  properties are `null`, the resulting notation for the object is such that each
+                  //  key is preceded by a `?` YAML operator, which Lens doesn't support/expect
+                  YAML.stringify(kubeConfig, { simpleKeys: true })
+                )
+                .then(
+                  () => ({
+                    cluster,
+                    model,
+                    catEntity, // will be undefined because not found in Catalog
+                    action: ACTION_ADDED,
+                  }),
+                  (err) => {
+                    throw new Error(
+                      `Failed to write kubeconfig file: Unable to add cluster; filePath=${logValue(
+                        configFilePath
+                      )}, error=${logValue(err.message)}, cluster=${cluster}`
+                    );
+                  }
+                ),
+            (err) => {
+              throw new Error(
+                `Failed to create kubeconfig directory: Unable to add cluster; path=${logValue(
+                  configDirPath
+                )}, error=${logValue(err.message)}, cluster=${cluster}`
+              );
+            }
+          );
+        }
+      });
+    });
+
+    //// ADD, UPDATE, DELETE CATALOG ENTITIES
+
+    return Promise.allSettled(promises).then((results) => {
+      const storeModels = []; // new and updated models for SyncStore, omiting deleted ones
+      const newEntities = []; // new entities for Catalog
+      const knownClusterIds = {}; // map of string -> `true` for all valid/ready clusters
+      let updateCount = 0;
+      let deleteCount = 0;
+
+      results.forEach((result) => {
+        if (result.status === 'fulfilled') {
+          const { cluster, model, catEntity, action } = result.value;
+
+          knownClusterIds[cluster.uid] = true;
+          storeModels.push(model); // new/updated/same, keep in SyncStore
+
+          if (action === ACTION_ADDED) {
+            this.ipcMain.capture(
+              'log',
+              'SyncManager.updateClusters()',
+              `Adding new ${cluster} to Catalog`
+            );
+            newEntities.push(this.mkEntity(model));
+          } else if (action === ACTION_UPDATED) {
+            this.ipcMain.capture(
+              'log',
+              'SyncManager.updateClusters()',
+              `Updating ${cluster} in Catalog: resourceVersion ${logValue(
+                catEntity.metadata.resourceVersion
+              )} -> ${logValue(cluster.resourceVersion)}`
+            );
+            this.updateEntity(catEntity, model);
+            updateCount++;
+          } else {
+            this.ipcMain.capture(
+              'log',
+              'SyncManager.updateClusters()',
+              `Skipping ${cluster} update: No changes detected`
             );
           }
-        );
-      })
-    );
-
-    // TODO[PRODX-22269]: make sync a lot more efficient instead of blind replace on every sync;
-    //  need to delete old kubeconfig files too
-    return Promise.allSettled(promises).then((results) => {
-      // @type {Array<{ model: Object, entity: KubernetesCluster }>}
-      const newSpecs = results
-        .map((result) => {
-          if (result.status === 'fulfilled') {
-            return {
-              model: result.value,
-              entity: this.mkEntity(result.value),
-            };
-          }
-
+        } else {
           this.ipcMain.capture(
             'warn',
             'SyncManager.updateClusters()',
+            // NOTE: `reason.message` already has information about the cluster affected
+            //  because it's an error message we generated in previous loop that created
+            //  all the promises whose results we're now looping through
             `(Ignoring cluster) ${result.reason.message}`
           );
-          return undefined;
-        })
-        .filter((spec) => !!spec); // remove the duds
+        }
+      });
 
-      // first, remove all cluster entities from the Catalog
+      // next, remove all cluster entities from the Catalog that no longer exist in the Cloud
       let idx;
       while (
         (idx = this.catalogSource.findIndex((entity) => {
           // NOTE: since it's our Catalog Source, it only contains our items, so we should
           //  never encounter a case where there's no mapped property
           const prop = kindtoNamespaceProp[entity.metadata.kind];
-          return 'clusters' === prop;
+          return prop === 'clusters' && !knownClusterIds[entity.metadata.uid];
         })) >= 0
       ) {
+        const entity = this.catalogSource[idx];
+        this.ipcMain.capture(
+          'log',
+          'SyncManager.updateClusters()',
+          `Removing entity ${entityToString(
+            entity
+          )} from Catalog and deleting kubeconfig file: Deleted in Cloud`
+        );
+
         this.catalogSource.splice(idx, 1);
-        // TODO[PRODX-22269]: also need to delete old kubeconfig files no longer used
+        deleteCount++;
+
+        // no need to wait around for the promise to fulfill
+        fs.rm(entity.spec.kubeconfigPath).catch((err) => {
+          this.ipcMain.capture(
+            'error',
+            'SyncManager.updateClusters()',
+            `Failed to delete kubeconfig file of ${entityToString(
+              entity
+            )}; error=${logValue(err.message)}`
+          );
+        });
       }
 
+      // finally, add all the new entities to the Catalog
+      newEntities.forEach((entity) => this.catalogSource.push(entity));
+
       this.ipcMain.capture(
-        'log',
+        'info',
         'SyncManager.updateClusters()',
-        `Adding ${newSpecs.length} cluster entities to Catalog; dataCloud=${dataCloud}`
+        `Added=${newEntities.length}, updated=${updateCount}, deleted=${deleteCount} cluster Catalog entities for dataCloud=${dataCloud}`
       );
 
-      // then, add all the new ones
-      newSpecs.forEach(({ entity }) => {
-        this.catalogSource.push(entity);
-      });
-
-      // finally, save the models in the store
-      // TODO[PRODX-22269]: not great that we're looping the same list (newSpecs) twice...
-      syncStore.clusters = newSpecs.map((spec) => spec.model);
+      // save the models in the store
+      syncStore.clusters = storeModels;
 
       this.ipcMain.capture(
-        'log',
+        'info',
         'SyncManager.updateClusters()',
         `Done: Updated Catalog cluster entities for dataCloud=${dataCloud}`
       );
     });
     // NOTE: Promise.allSettled() does not fail
+  }
+
+  /**
+   * Updates a Catalog Entity with metadata from a given Model.
+   * @param {CatalogEntity} entity
+   * @param {Object} model
+   */
+  updateEntity(entity, model) {
+    rtv.verify(
+      { entity, model },
+      {
+        entity: [rtv.CLASS_OBJECT, { ctor: CatalogEntity }],
+        model: catalogEntityModelTs,
+      }
+    );
+
+    if (entity.metadata.kind !== model.metadata.kind) {
+      throw new Error(
+        `Attempted to update ${entityToString(entity)} using ${modelToString(
+          model
+        )} with incompatible kinds`
+      );
+    }
+
+    ['metadata', 'spec', 'status'].forEach(
+      (prop) => (entity[prop] = model[prop])
+    );
   }
 
   /**
@@ -529,7 +763,7 @@ export class SyncManager extends Singleton {
 
     if (!isEqual(this.cloudTokens, cloudStoreTokens)) {
       this.ipcMain.capture(
-        'log',
+        'info',
         'SyncManager.onCloudStoreChange()',
         'CloudStore.clouds has changed: Updating DataClouds'
       );
@@ -537,7 +771,7 @@ export class SyncManager extends Singleton {
       const { cloudUrlsToAdd, cloudUrlsToUpdate, cloudUrlsToRemove } =
         this.triageCloudUrls(cloudStoreTokens);
 
-      this.updateStore({
+      this.updateClouds({
         cloudStoreTokens,
         cloudUrlsToAdd,
         cloudUrlsToUpdate,
@@ -545,7 +779,7 @@ export class SyncManager extends Singleton {
       });
 
       this.ipcMain.capture(
-        'log',
+        'info',
         'SyncManager.onCloudStoreChange()',
         'Done: DataClouds updated'
       );
@@ -564,44 +798,91 @@ export class SyncManager extends Singleton {
    * @see https://mobx.js.org/reactions.html#reaction
    */
   onSyncStoreChange = (state) => {
-    // TODO[PRODX-22269]: this type of update will need to coordinate with DataCloud data updates
     this.ipcMain.capture(
-      'log',
+      'info',
       'SyncManager.onSyncStoreChange()',
       'SyncStore state has changed: Updating Catalog'
     );
 
     Object.keys(state).forEach((type) => {
+      const newEntities = []; // new entities for Catalog
+      const knownModelIds = {}; // map of string -> `true` for all resources of this type
+      let updateCount = 0;
+      let deleteCount = 0;
       const models = state[type];
 
-      // first, remove all entities from the Catalog of this type
+      // start by determining what is new and what has been updated
+      models.forEach((model) => {
+        knownModelIds[model.metadata.uid] = true;
+
+        const entity = findEntity(this.catalogSource, model);
+        if (entity) {
+          if (
+            entity.metadata.resourceVersion === model.metadata.resourceVersion
+          ) {
+            this.ipcMain.capture(
+              'log',
+              'SyncManager.onSyncStoreChange()',
+              `Skipping ${modelToString(model)} update: No changes detected`
+            );
+          } else {
+            // something about that resource has changed since the last time we fetched it
+            this.ipcMain.capture(
+              'log',
+              'SyncManager.onSyncStoreChange()',
+              `Updating ${modelToString(
+                model
+              )} in Catalog: resourceVersion ${logValue(
+                entity.metadata.resourceVersion
+              )} -> ${logValue(model.metadata.resourceVersion)}`
+            );
+            updateCount++;
+            this.updateEntity(entity, model);
+          }
+        } else {
+          // new entity we have discovered: add to Catalog
+          this.ipcMain.capture(
+            'log',
+            'SyncManager.onSyncStoreChange()',
+            `Adding new ${modelToString(model)} to Catalog`
+          );
+          newEntities.push(this.mkEntity(model));
+        }
+      });
+
+      // next, remove all entities from the Catalog of this type that no longer exist in the SyncStore
       let idx;
       while (
         (idx = this.catalogSource.findIndex((entity) => {
           // NOTE: since it's our Catalog Source, it only contains our items, so we should
           //  never encounter a case where there's no mapped property
           const prop = kindToSyncStoreProp[entity.metadata.kind];
-          return type === prop;
+          return prop === type && !knownModelIds[entity.metadata.uid];
         })) >= 0
       ) {
+        const entity = this.catalogSource[idx];
+        this.ipcMain.capture(
+          'log',
+          'SyncManager.onSyncStoreChange()',
+          `Removing entity ${entityToString(entity)} from Catalog: Deleted`
+        );
+
         this.catalogSource.splice(idx, 1);
+        deleteCount++;
       }
 
-      this.ipcMain.capture(
-        'log',
-        'SyncManager.onSyncStoreChange()',
-        `Adding ${models.length} ${type} entities to Catalog`
-      );
+      // finally, add all the new entities to the Catalog
+      newEntities.forEach((entity) => this.catalogSource.push(entity));
 
-      // then, add new entities into the Catalog
-      models.forEach((model) => {
-        const entity = this.mkEntity(model);
-        this.catalogSource.push(entity);
-      });
+      this.ipcMain.capture(
+        'info',
+        'SyncManager.onSyncStoreChange()',
+        `Added=${newEntities.length}, updated=${updateCount}, deleted=${deleteCount} ${type} Catalog entities`
+      );
     });
 
     this.ipcMain.capture(
-      'log',
+      'info',
       'SyncManager.onSyncStoreChange()',
       'Done: Catalog updated'
     );
@@ -618,14 +899,14 @@ export class SyncManager extends Singleton {
       const dc = this.dataClouds[cloudUrl];
       if (dc.cloud.connected && !dc.fetching) {
         this.ipcMain.capture(
-          'log',
+          'info',
           'SyncManager.onSyncNow()',
           `Syncing now; dataCloud=${dc}`
         );
         dc.fetchNow();
       } else {
         this.ipcMain.capture(
-          'log',
+          'info',
           'SyncManager.onSyncNow()',
           `Cannot sync now: Cloud is either not connected or currently syncing; dataCloud=${dc}`
         );
@@ -634,7 +915,7 @@ export class SyncManager extends Singleton {
       this.ipcMain.capture(
         'error',
         'SyncManager.onSyncNow()',
-        `Unknown Cloud; cloudUrl=${logString(cloudUrl)}`
+        `Unknown Cloud; cloudUrl=${logValue(cloudUrl)}`
       );
     }
   };
@@ -646,52 +927,99 @@ export class SyncManager extends Singleton {
   onDataUpdated = (dataCloud) => {
     const types = ['sshKeys', 'credentials', 'proxies', 'licenses'];
     this.ipcMain.capture(
-      'log',
+      'info',
       'SyncManager.onDataUpdated()',
       `Updating Catalog [${types.join(
         ', '
       )}] entities for dataCloud=${dataCloud}`
     );
 
-    // TODO[PRODX-22269]: make sync a lot more efficient instead of blind replace on every sync
     types.forEach((type) => {
-      const newModels = [];
-      const newEntities = dataCloud.syncedNamespaces.flatMap((ns) =>
-        ns[type].map((apiType) => {
-          const model = apiType.toModel();
-          newModels.push(model);
-          return this.mkEntity(model);
-        })
-      );
+      const storeModels = []; // new and updated models for SyncStore, less deleted ones
+      const newEntities = []; // new entities for Catalog
+      const knownResourceIds = {}; // map of string -> `true` for all resources of this type
+      let updateCount = 0;
+      let deleteCount = 0;
 
-      // first, remove all entities from the Catalog of this type
+      // start by determining what is new and what has been updated
+      dataCloud.syncedNamespaces.forEach((ns) => {
+        ns[type].forEach((resource) => {
+          const model = resource.toModel();
+
+          knownResourceIds[resource.uid] = true;
+          storeModels.push(model); // new/updated/same, keep in SyncStore
+
+          const catEntity = findEntity(this.catalogSource, model);
+          if (catEntity) {
+            // entity exists already in the Catalog: either same (no changes) or updated
+            if (
+              catEntity.metadata.resourceVersion === resource.resourceVersion
+            ) {
+              this.ipcMain.capture(
+                'log',
+                'SyncManager.onDataUpdated()',
+                `Skipping ${resource} update: No changes detected`
+              );
+            } else {
+              // something about that resource has changed since the last time we fetched it
+              this.ipcMain.capture(
+                'log',
+                'SyncManager.onDataUpdated()',
+                `Updating ${resource} in Catalog: resourceVersion ${logValue(
+                  catEntity.metadata.resourceVersion
+                )} -> ${logValue(resource.resourceVersion)}`
+              );
+              updateCount++;
+              this.updateEntity(catEntity, model);
+            }
+          } else {
+            // new entity we have discovered: add to Catalog
+            this.ipcMain.capture(
+              'log',
+              'SyncManager.onDataUpdated()',
+              `Adding new ${resource} to Catalog`
+            );
+            newEntities.push(this.mkEntity(model));
+          }
+        });
+      });
+
+      // next, remove all entities from the Catalog of this type that no longer exist in the Cloud
       let idx;
       while (
         (idx = this.catalogSource.findIndex((entity) => {
           // NOTE: since it's our Catalog Source, it only contains our items, so we should
           //  never encounter a case where there's no mapped property
           const prop = kindtoNamespaceProp[entity.metadata.kind];
-          return type === prop;
+          return prop === type && !knownResourceIds[entity.metadata.uid];
         })) >= 0
       ) {
+        const entity = this.catalogSource[idx];
+        this.ipcMain.capture(
+          'log',
+          'SyncManager.onDataUpdated()',
+          `Removing entity ${entityToString(entity)} from Catalog: Deleted`
+        );
+
         this.catalogSource.splice(idx, 1);
+        deleteCount++;
       }
 
-      this.ipcMain.capture(
-        'log',
-        'SyncManager.onDataUpdated()',
-        `Adding ${newEntities.length} ${type} entities to Catalog; dataCloud=${dataCloud}`
-      );
-
-      // then, add all the new ones
+      // finally, add all the new entities to the Catalog
       newEntities.forEach((entity) => this.catalogSource.push(entity));
 
+      this.ipcMain.capture(
+        'info',
+        'SyncManager.onDataUpdated()',
+        `Added=${newEntities.length}, updated=${updateCount}, deleted=${deleteCount} ${type} Catalog entities for dataCloud=${dataCloud}`
+      );
+
       // save the models in the store
-      syncStore[type] = newModels;
+      syncStore[type] = storeModels;
     });
 
     this.ipcMain.capture(
-      'log',
+      'info',
       'SyncManager.onDataUpdated()',
       `Done: Updated Catalog [${types.join(
         ', '

--- a/src/renderer/components/GlobalPage/SyncView.js
+++ b/src/renderer/components/GlobalPage/SyncView.js
@@ -3,7 +3,7 @@ import { Renderer } from '@k8slens/extensions';
 import styled from '@emotion/styled';
 import { layout } from '../styles';
 import { AddCloudInstance } from './AddCloudInstance.js';
-import { useDataCloudData } from '../../store/DataCloudProvider';
+import { useDataClouds } from '../../store/DataCloudProvider';
 import { WelcomeView } from './WelcomeView';
 import { cloudStore } from '../../../store/CloudStore';
 import { syncView } from '../../../strings';
@@ -56,9 +56,7 @@ const ButtonWrapper = styled.div`
 `;
 
 export const SyncView = () => {
-  const {
-    state: { dataClouds },
-  } = useDataCloudData();
+  const { dataClouds } = useDataClouds();
   const [showAddCloudComponent, setShowAddCloudComponent] = useState(false);
   const [isSelectiveSyncView, setIsSelectiveSyncView] = useState(false);
   const [isSyncStarted, setIsSyncStarted] = useState(false);
@@ -118,10 +116,12 @@ export const SyncView = () => {
   if (showAddCloudComponent) {
     return <AddCloudInstance onAdd={handleAddCloud} onCancel={onCancel} />;
   }
+
   // in no clouds => show Welcome page
   if (!Object.keys(cloudStore.clouds).length) {
     return <WelcomeView openAddCloud={openAddCloud} />;
   }
+
   // otherwise, show dataClouds table
   if (Object.keys(dataClouds).length) {
     return (

--- a/src/store/SyncStore.js
+++ b/src/store/SyncStore.js
@@ -79,6 +79,16 @@ export class SyncStore extends Common.Store.ExtensionStore {
     Object.keys(this).forEach((key) => (this[key] = defaults[key]));
   }
 
+  /**
+   * @returns {Array<string>} Array of property names that are entity model lists
+   *  on this instance.
+   */
+  getListNames() {
+    return Object.keys(SyncStore.getDefaults()).filter((name) =>
+      Array.isArray(this[name])
+    );
+  }
+
   // NOTE: this method is not just called when reading from disk; it's also called in the
   //  sync process between the Main and Renderer threads should code on either thread
   //  update any of the store's properties

--- a/src/util/logger.js
+++ b/src/util/logger.js
@@ -38,13 +38,22 @@ export const logger = (function () {
 })();
 
 /**
- * Formats a string value for logging.
- * @param {string} [str] A string value which may not be defined.
+ * Formats a value for logging.
+ * @param {any} [value] A value which may not be defined.
  * @returns {string} Always returns a string. If it's an actual string, empty or
  *  not, the value is returned in double quotes, `"foo"`. If it's null/undefined,
  *  it's returned as-is and string-cast, which will be the string `null` or
- *  `undefined`.
+ *  `undefined`. If it's an array, it's returned as `"[...]"`. Otherwise, it's just
+ *  case to a string.
  */
-export const logString = function (str) {
-  return `${typeof str === 'string' ? `"${str}"` : str}`;
+export const logValue = function (value) {
+  if (typeof value === 'string') {
+    return `"${value}"`;
+  }
+
+  if (Array.isArray(value)) {
+    return `[${value.map(logValue).join(', ')}]`; // recursive
+  }
+
+  return `${value}`; // cast to string and we get what we get
 };


### PR DESCRIPTION
The SM is now much smarter than it was before because it leverages
the Kubernetes-provided `resourceVersion` as a way to detect if
a resource has changed since the last time it was synced.

The result is that only Catalog entities that are older than their
related resource get updated. Everything else that hasn't changed
just gets skipped. That greatly reduces churn.

Also:

- Deletes are now supported, cleaning-up unused kubeconfig files
  (deletes meaning a namespace is no longer synced, or a Cloud
  is removed).
- Fixed bug where we'd get an empty screen with a spinner at the
  top/left right after adding a new (first) Cloud.
- Fixed bug where a removed Cloud would remain in the SyncView after
  being removed.