### PR TITLE
[PRODX-22307] Relate resources to clusters, add machines, add apiStatus

### DIFF
--- a/src/api/apiConstants.js
+++ b/src/api/apiConstants.js
@@ -56,6 +56,7 @@ export const apiCredentialTypes = Object.freeze(
 export const apiKinds = Object.freeze({
   NAMESPACE: 'Namespace',
   CLUSTER: 'Cluster',
+  MACHINE: 'Machine',
   PUBLIC_KEY: 'PublicKey',
   AWS_CREDENTIAL: 'AWSCredential',
   AZURE_CREDENTIAL: 'AzureCredential',
@@ -100,4 +101,15 @@ export const apiCredentialProviders = Object.freeze({
   // METAL_CREDENTIAL: '',
   OPENSTACK_CREDENTIAL: 'openstack',
   VSPHERE_CREDENTIAL: 'vsphere',
+});
+
+/**
+ * Map of API label to value.
+ * @type {{ [index: string], string }}
+ */
+export const apiLabels = Object.freeze({
+  KAAS_REGION: 'kaas.mirantis.com/region',
+  KAAS_PROVIDER: 'kaas.mirantis.com/provider',
+  CLUSTER_CONTROLLER: 'cluster.sigs.k8s.io/control-plane', // if a machine is a master (vs worker)
+  CLUSTER_NAME: 'cluster.sigs.k8s.io/cluster-name', // machine's associated cluster
 });

--- a/src/api/clients/KubernetesClient.js
+++ b/src/api/clients/KubernetesClient.js
@@ -1,4 +1,4 @@
-import { request } from '../../util/netUtil';
+import { request, buildQueryString } from '../../util/netUtil';
 import * as strings from '../../strings';
 import { apiResourceTypes } from '../apiConstants';
 import { logValue } from '../../util/logger';
@@ -41,13 +41,21 @@ export class KubernetesClient {
     );
   }
 
-  list(resourceType, { namespaceName } = {}) {
+  /**
+   * List resources within a given namespace.
+   * @param {string} resourceType
+   * @param {Object} options
+   * @param {string} options.namespaceName
+   * @param {number} [options.limit] To limit the number of items fetched.
+   */
+  list(resourceType, { namespaceName, limit } = {}) {
     const url = {
       [apiResourceTypes.NAMESPACE]: resourceType,
       [apiResourceTypes.METAL_CREDENTIAL]: `${apiResourceTypes.NAMESPACE}/${namespaceName}/${resourceType}`,
       [apiResourceTypes.EVENT]: `${apiResourceTypes.NAMESPACE}/${namespaceName}/${resourceType}`,
     };
-    return this.request(url[resourceType], {
+    const paramStr = buildQueryString({ limit });
+    return this.request(`${url[resourceType]}${paramStr}`, {
       errorMessage: strings.apiClient.error.failedToGet(resourceType),
     });
   }

--- a/src/api/types/License.js
+++ b/src/api/types/License.js
@@ -3,6 +3,7 @@ import { merge } from 'lodash';
 import { mergeRtvShapes } from '../../util/mergeRtvShapes';
 import { Resource, resourceTs } from './Resource';
 import { Namespace } from './Namespace';
+import { entityLabels } from '../../catalog/catalogEntities';
 import {
   LicenseEntity,
   licenseEntityPhases,
@@ -65,8 +66,8 @@ export class License extends Resource {
       metadata: {
         namespace: this.namespace.name,
         labels: {
-          managementCluster: this.cloud.name,
-          project: this.namespace.name,
+          [entityLabels.CLOUD]: this.cloud.name,
+          [entityLabels.NAMESPACE]: this.namespace.name,
         },
       },
       status: {

--- a/src/api/types/Machine.js
+++ b/src/api/types/Machine.js
@@ -1,0 +1,106 @@
+import * as rtv from 'rtvjs';
+import { mergeRtvShapes } from '../../util/mergeRtvShapes';
+import { apiKinds, apiLabels } from '../apiConstants';
+import { resourceTs } from './Resource';
+import { Node } from './Node';
+import { logValue } from '../../util/logger';
+
+/**
+ * Typeset for an MCC Machine API resource.
+ */
+export const machineTs = mergeRtvShapes({}, resourceTs, {
+  // NOTE: this is not intended to be fully-representative; we only list the properties
+  //  related to what we expect to find in order to create a `Credential` class instance
+
+  kind: [rtv.STRING, { oneOf: apiKinds.MACHINE }],
+  metadata: {
+    labels: [
+      rtv.OPTIONAL,
+      {
+        [apiLabels.CLUSTER_NAME]: rtv.STRING,
+        [apiLabels.CLUSTER_CONTROLLER]: [rtv.OPTIONAL, rtv.STRING], // only set if this is a master node
+        [apiLabels.KAAS_PROVIDER]: [rtv.OPTIONAL, rtv.STRING],
+        [apiLabels.KAAS_REGION]: [rtv.OPTIONAL, rtv.STRING],
+      },
+    ],
+  },
+  status: {
+    providerStatus: {
+      // readiness conditions
+      conditions: [
+        [
+          {
+            message: rtv.STRING, // ready message if `ready=true` or error message if `ready=false`
+            ready: rtv.BOOLEAN, // true if component is ready (NOTE: false if maintenance mode is active)
+            type: rtv.STRING, // component name, e.g. 'Kubelet', 'Swarm, 'Maintenance', etc.
+          },
+        ],
+      ],
+
+      // overall readiness: true if all `conditions[*].ready` are true
+      ready: rtv.BOOLEAN,
+
+      // NOTE: machines do have a `status: string` property, e.g. 'Pending', 'Ready', etc.
+      //  (not sure what all words are possible), but not sure if this property is reliable
+      //  (e.g. it can actually be "Ready" when there are still unmet `conditions`, ones that
+      //  have `ready=false`, which seems contradictory)
+      // status: rtv.STRING,
+    },
+  },
+});
+
+/**
+ * MCC machine API resource.
+ * @class Machine
+ */
+export class Machine extends Node {
+  /**
+   * @constructor
+   * @param {Object} params
+   * @param {Object} params.data Raw data payload from the API.
+   * @param {Namespace} params.namespace Namespace to which the object belongs.
+   * @param {Cloud} params.cloud Reference to the Cloud used to get the data.
+   */
+  constructor({ data, namespace, cloud }) {
+    super({ data, cloud, namespace, typeset: machineTs });
+
+    /**
+     * @readonly
+     * @member {string} clusterName
+     */
+    Object.defineProperty(this, 'clusterName', {
+      enumerable: true,
+      get() {
+        return data.metadata.labels?.[apiLabels.CLUSTER_NAME] || null;
+      },
+    });
+
+    /**
+     * @readonly
+     * @member {boolean} isController True if this Machine is a master node.
+     */
+    Object.defineProperty(this, 'isController', {
+      enumerable: true,
+      get() {
+        return !!data.metadata.labels?.[apiLabels.CLUSTER_CONTROLLER];
+      },
+    });
+  }
+
+  // NOTE: we don't have toModel() and toEntity() because we don't show Machines in
+  //  the Catalog at the moment (so we don't have a MachineEntity class for them)
+
+  /** @returns {string} A string representation of this instance for logging/debugging. */
+  toString() {
+    const propStr = `${super.toString()}, namespace: ${logValue(
+      this.namespace.name
+    )}`;
+
+    if (Object.getPrototypeOf(this).constructor === Machine) {
+      return `{Machine ${propStr}}`;
+    }
+
+    // this is actually an extended class instance, so return only the properties
+    return propStr;
+  }
+}

--- a/src/api/types/Namespace.js
+++ b/src/api/types/Namespace.js
@@ -2,6 +2,7 @@ import * as rtv from 'rtvjs';
 import { mergeRtvShapes } from '../../util/mergeRtvShapes';
 import { Resource, resourceTs } from './Resource';
 import { Cluster } from './Cluster';
+import { Machine } from './Machine';
 import { Credential } from './Credential';
 import { SshKey } from './SshKey';
 import { Proxy } from './Proxy';
@@ -30,6 +31,7 @@ export class Namespace extends Resource {
     super({ data, cloud, typeset: namespaceTs });
 
     let _clusters = [];
+    let _machines = [];
     let _sshKeys = [];
     let _credentials = [];
     let _proxies = [];
@@ -65,6 +67,32 @@ export class Namespace extends Resource {
           );
         if (newValue !== _clusters) {
           _clusters = newValue || [];
+        }
+      },
+    });
+
+    /**
+     * @member {Array<Machine>} machines Machines in this namespace. Empty if none.
+     */
+    Object.defineProperty(this, 'machines', {
+      enumerable: true,
+      get() {
+        return _machines;
+      },
+      set(newValue) {
+        DEV_ENV &&
+          rtv.verify(
+            { machines: newValue },
+            {
+              machines: [
+                rtv.EXPECTED,
+                rtv.ARRAY,
+                { $: [rtv.CLASS_OBJECT, { ctor: Machine }] },
+              ],
+            }
+          );
+        if (newValue !== _machines) {
+          _machines = newValue || [];
         }
       },
     });
@@ -182,6 +210,13 @@ export class Namespace extends Resource {
   }
 
   /**
+   * @member {number} machineCount Number of machines in this namespace.
+   */
+  get machineCount() {
+    return this.machines.length;
+  }
+
+  /**
    * @member {number} clusterCount Number of SSH keys in this namespace.
    */
   get sshKeyCount() {
@@ -213,9 +248,11 @@ export class Namespace extends Resource {
   toString() {
     const propStr = `${super.toString()}, clusters: ${
       this.clusterCount
-    }, sshKeys: ${this.sshKeyCount}, credentials: ${
-      this.credentialCount
-    }, proxies: ${this.proxyCount}, licenses: ${this.licenseCount}`;
+    }, machines: ${this.machineCount}, sshKeys: ${
+      this.sshKeyCount
+    }, credentials: ${this.credentialCount}, proxies: ${
+      this.proxyCount
+    }, licenses: ${this.licenseCount}`;
 
     if (Object.getPrototypeOf(this).constructor === Namespace) {
       return `{Namespace ${propStr}}`;

--- a/src/api/types/Node.js
+++ b/src/api/types/Node.js
@@ -1,0 +1,133 @@
+import * as rtv from 'rtvjs';
+import { apiKinds, apiLabels } from '../apiConstants';
+import { Resource } from './Resource';
+import { Namespace } from './Namespace';
+import * as strings from '../../strings';
+
+/**
+ * Base class for namespaced Machine and Cluster resources.
+ * @class Node
+ */
+export class Node extends Resource {
+  /**
+   * @constructor
+   * @param {Object} params
+   * @param {Object} params.data Raw data payload from the API.
+   * @param {Namespace} params.namespace Namespace to which the object belongs.
+   * @param {Cloud} params.cloud Reference to the Cloud used to get the data.
+   * @param {rtv.Typeset} params.typeset Typeset for verifying the data.
+   */
+  constructor({ data, namespace, cloud, typeset }) {
+    super({
+      data,
+      cloud,
+      typeset,
+    });
+
+    DEV_ENV &&
+      rtv.verify(
+        { namespace },
+        {
+          namespace: [rtv.CLASS_OBJECT, { ctor: Namespace }],
+        }
+      );
+
+    /**
+     * @readonly
+     * @member {Namespace} namespace
+     */
+    Object.defineProperty(this, 'namespace', {
+      enumerable: true,
+      get() {
+        return namespace;
+      },
+    });
+
+    /**
+     * @readonly
+     * @member {string} region
+     */
+    Object.defineProperty(this, 'region', {
+      enumerable: true,
+      get() {
+        return data.metadata.labels?.[apiLabels.KAAS_REGION] || null;
+      },
+    });
+
+    /**
+     * @readonly
+     * @member {string} provider
+     */
+    Object.defineProperty(this, 'provider', {
+      enumerable: true,
+      get() {
+        return data.metadata.labels?.[apiLabels.KAAS_PROVIDER] || null;
+      },
+    });
+
+    /**
+     * Node status message. This is a combination of all NON-ready conditions,
+     *  or if all ready, then a "Ready" message.
+     * @readonly
+     * @member {string} status
+     */
+    Object.defineProperty(this, 'status', {
+      enumerable: true,
+      get() {
+        const { providerStatus } = data.status || {};
+
+        if (!providerStatus) {
+          // we don't have any status-related info yet
+          return strings.apiResource.status.unknown();
+        }
+
+        if (providerStatus.ready) {
+          // overall status is ready, so we're ready; assume we don't need to look any further
+          return strings.apiResource.status.ready();
+        }
+
+        // NOTE: only clusters have a helm status
+        if (
+          !providerStatus.conditions &&
+          (this.kind !== apiKinds.CLUSTER || !providerStatus.helm)
+        ) {
+          // not enough info to determine status issues, but we do have some status
+          //  reporting, so go with pending
+          return strings.apiResource.status.pending();
+        }
+
+        const notices = [];
+        providerStatus.conditions.forEach((c) => {
+          if (!c.ready) {
+            notices.push(c.message);
+          }
+        });
+
+        if (this.kind === apiKinds.CLUSTER && !providerStatus.helm.ready) {
+          notices.push(strings.apiResource.notice.helmNotReady());
+        }
+
+        if (notices.length > 0) {
+          return `${strings.apiResource.status.pending()}: ${notices
+            .map((n) => `"${n}"`)
+            .join(', ')}`;
+        }
+
+        // no notices, but overall `ready` flag is false, so assume something is still missing
+        return strings.apiResource.status.pending();
+      },
+    });
+
+    /**
+     * True if the Node is fully-operational.
+     * @readonly
+     * @member {boolean} ready
+     */
+    Object.defineProperty(this, 'ready', {
+      enumerable: true,
+      get() {
+        return !!data.status?.providerStatus?.ready;
+      },
+    });
+  }
+}

--- a/src/api/types/Proxy.js
+++ b/src/api/types/Proxy.js
@@ -1,10 +1,11 @@
 import * as rtv from 'rtvjs';
-import { merge, get } from 'lodash';
+import { merge } from 'lodash';
 import { mergeRtvShapes } from '../../util/mergeRtvShapes';
 import { Resource, resourceTs } from './Resource';
 import { Namespace } from './Namespace';
+import { entityLabels } from '../../catalog/catalogEntities';
 import { ProxyEntity, proxyEntityPhases } from '../../catalog/ProxyEntity';
-import { apiKinds } from '../apiConstants';
+import { apiKinds, apiLabels } from '../apiConstants';
 import { logValue } from '../../util/logger';
 
 /**
@@ -19,7 +20,7 @@ export const proxyTs = mergeRtvShapes({}, resourceTs, {
     labels: [
       rtv.OPTIONAL,
       {
-        'kaas.mirantis.com/region': [rtv.OPTIONAL, rtv.STRING],
+        [apiLabels.KAAS_REGION]: [rtv.OPTIONAL, rtv.STRING],
       },
     ],
   },
@@ -62,7 +63,7 @@ export class Proxy extends Resource {
     Object.defineProperty(this, 'region', {
       enumerable: true,
       get() {
-        return get(data.metadata, 'labels["kaas.mirantis.com/region"]', null);
+        return data.metadata.labels?.[apiLabels.KAAS_REGION] || null;
       },
     });
 
@@ -96,8 +97,8 @@ export class Proxy extends Resource {
       metadata: {
         namespace: this.namespace.name,
         labels: {
-          managementCluster: this.cloud.name,
-          project: this.namespace.name,
+          [entityLabels.CLOUD]: this.cloud.name,
+          [entityLabels.NAMESPACE]: this.namespace.name,
         },
       },
       spec: {

--- a/src/api/types/Resource.js
+++ b/src/api/types/Resource.js
@@ -40,7 +40,10 @@ export class Resource {
       rtv.verify(
         { data, cloud },
         {
+          // if `typeset` was specified, `null` here will cause `verify()` to fail, which is good
+          //  since `typeset` should be considered required
           data: typeset,
+
           cloud: [rtv.CLASS_OBJECT, { ctor: Cloud }],
         }
       );

--- a/src/api/types/SshKey.js
+++ b/src/api/types/SshKey.js
@@ -3,6 +3,7 @@ import { merge } from 'lodash';
 import { mergeRtvShapes } from '../../util/mergeRtvShapes';
 import { Resource, resourceTs } from './Resource';
 import { Namespace } from './Namespace';
+import { entityLabels } from '../../catalog/catalogEntities';
 import { SshKeyEntity, sshKeyEntityPhases } from '../../catalog/SshKeyEntity';
 import { apiKinds } from '../apiConstants';
 import { logValue } from '../../util/logger';
@@ -73,8 +74,8 @@ export class SshKey extends Resource {
       metadata: {
         namespace: this.namespace.name,
         labels: {
-          managementCluster: this.cloud.name,
-          project: this.namespace.name,
+          [entityLabels.CLOUD]: this.cloud.name,
+          [entityLabels.NAMESPACE]: this.namespace.name,
         },
       },
       spec: {

--- a/src/catalog/CredentialEntity.ts
+++ b/src/catalog/CredentialEntity.ts
@@ -5,7 +5,7 @@
 import { Common, Renderer, Main } from '@k8slens/extensions';
 import * as rtv from 'rtvjs';
 import { mergeRtvShapes } from '../util/mergeRtvShapes';
-import { catalogEntityModelTs, requiredLabelTs } from './catalogEntities';
+import { catalogEntityModelTs, requiredLabelsTs } from './catalogEntities';
 import {
   CatalogEntityMetadata,
   CatalogEntitySpec,
@@ -40,7 +40,7 @@ export const credentialEntityModelTs = mergeRtvShapes(
   catalogEntityModelTs,
   {
     metadata: {
-      labels: requiredLabelTs,
+      labels: requiredLabelsTs,
     },
     spec: {
       provider: [

--- a/src/catalog/LicenseEntity.ts
+++ b/src/catalog/LicenseEntity.ts
@@ -5,7 +5,7 @@
 import { Common, Renderer, Main } from '@k8slens/extensions';
 import * as rtv from 'rtvjs';
 import { mergeRtvShapes } from '../util/mergeRtvShapes';
-import { catalogEntityModelTs, requiredLabelTs } from './catalogEntities';
+import { catalogEntityModelTs, requiredLabelsTs } from './catalogEntities';
 import {
   CatalogEntityMetadata,
   CatalogEntitySpec,
@@ -36,7 +36,7 @@ export const licenseEntityPhases = Object.freeze({
  */
 export const licenseEntityModelTs = mergeRtvShapes({}, catalogEntityModelTs, {
   metadata: {
-    labels: requiredLabelTs,
+    labels: requiredLabelsTs,
   },
   status: {
     phase: [rtv.STRING, { oneOf: Object.values(licenseEntityPhases) }],

--- a/src/catalog/ProxyEntity.ts
+++ b/src/catalog/ProxyEntity.ts
@@ -5,7 +5,7 @@
 import { Common, Renderer, Main } from '@k8slens/extensions';
 import * as rtv from 'rtvjs';
 import { mergeRtvShapes } from '../util/mergeRtvShapes';
-import { catalogEntityModelTs, requiredLabelTs } from './catalogEntities';
+import { catalogEntityModelTs, requiredLabelsTs } from './catalogEntities';
 import {
   CatalogEntityMetadata,
   CatalogEntitySpec,
@@ -36,7 +36,7 @@ export const proxyEntityPhases = Object.freeze({
  */
 export const proxyEntityModelTs = mergeRtvShapes({}, catalogEntityModelTs, {
   metadata: {
-    labels: requiredLabelTs,
+    labels: requiredLabelsTs,
   },
   spec: {
     region: [rtv.OPTIONAL, rtv.STRING],

--- a/src/catalog/SshKeyEntity.ts
+++ b/src/catalog/SshKeyEntity.ts
@@ -5,7 +5,7 @@
 import { Common, Renderer, Main } from '@k8slens/extensions';
 import * as rtv from 'rtvjs';
 import { mergeRtvShapes } from '../util/mergeRtvShapes';
-import { catalogEntityModelTs, requiredLabelTs } from './catalogEntities';
+import { catalogEntityModelTs, requiredLabelsTs } from './catalogEntities';
 import {
   CatalogEntityMetadata,
   CatalogEntitySpec,
@@ -36,7 +36,7 @@ export const sshKeyEntityPhases = Object.freeze({
  */
 export const sshKeyEntityModelTs = mergeRtvShapes({}, catalogEntityModelTs, {
   metadata: {
-    labels: requiredLabelTs,
+    labels: requiredLabelsTs,
   },
   spec: {
     publicKey: rtv.STRING,

--- a/src/catalog/catalogEntities.js
+++ b/src/catalog/catalogEntities.js
@@ -21,13 +21,30 @@ const {
  */
 export const KUBECONFIG_DIR_NAME = 'kubeconfigs';
 
+/** Label names for various entity types. */
+export const entityLabels = Object.freeze({
+  /** Management cluster's name (name assigned to Cloud by user when adding it). */
+  CLOUD: 'mgmt-cluster',
+  /** Resource's namespace name. */
+  NAMESPACE: 'project',
+  /** Identifies clusters that are management clusters. Value should always be "true". */
+  IS_MGMT_CLUSTER: 'is-mgmt-cluster',
+  /** Associated SSH key name(s), if any. */
+  SSH_KEY: 'ssh-key',
+  /** Associated Credential name, if any. */
+  CREDENTIAL: 'credential',
+  /** Associated Proxy name, if any. */
+  PROXY: 'proxy',
+  /** Associated License name, if any. */
+  LICENSE: 'license',
+});
+
 /**
- * Typeset representing the required labels for all entity types (except a mgmt
- *  cluster itself).
+ * Typeset representing the required labels for all entity types.
  */
-export const requiredLabelTs = {
-  managementCluster: rtv.STRING,
-  project: rtv.STRING,
+export const requiredLabelsTs = {
+  [entityLabels.CLOUD]: rtv.STRING,
+  [entityLabels.NAMESPACE]: rtv.STRING,
 };
 
 /**
@@ -126,11 +143,32 @@ export const clusterEntityModelTs = mergeRtvShapes({}, catalogEntityModelTs, {
       rtv.PLAIN_OBJECT,
       {
         $: {
-          ...requiredLabelTs,
-          sshKey: [rtv.OPTIONAL, rtv.STRING, (value) => value !== ''], // either no label, or non-empty string
-          credential: [rtv.OPTIONAL, rtv.STRING, (value) => value !== ''], // either no label, or non-empty string
-          proxy: [rtv.OPTIONAL, rtv.STRING, (value) => value !== ''], // either no label, or non-empty string
-          license: [rtv.OPTIONAL, rtv.STRING, (value) => value !== ''], // either no label, or non-empty string
+          ...requiredLabelsTs,
+          [entityLabels.IS_MGMT_CLUSTER]: [
+            rtv.OPTIONAL,
+            rtv.STRING,
+            { oneOf: 'true' },
+          ], // either no label, or "true"
+          [entityLabels.SSH_KEY]: [
+            rtv.OPTIONAL,
+            rtv.STRING,
+            (value) => value !== '',
+          ], // either no label, or non-empty string
+          [entityLabels.CREDENTIAL]: [
+            rtv.OPTIONAL,
+            rtv.STRING,
+            (value) => value !== '',
+          ], // either no label, or non-empty string
+          [entityLabels.PROXY]: [
+            rtv.OPTIONAL,
+            rtv.STRING,
+            (value) => value !== '',
+          ], // either no label, or non-empty string
+          [entityLabels.LICENSE]: [
+            rtv.OPTIONAL,
+            rtv.STRING,
+            (value) => value !== '',
+          ], // either no label, or non-empty string
         },
       },
     ],
@@ -156,8 +194,9 @@ export const clusterEntityModelTs = mergeRtvShapes({}, catalogEntityModelTs, {
 
     //// CUSTOM PROPERTIES
 
-    isManagementCluster: rtv.BOOLEAN,
+    isMgmtCluster: rtv.BOOLEAN,
     ready: rtv.BOOLEAN,
+    apiStatus: rtv.STRING,
   },
 
   // based on Lens `KubernetesClusterStatus` type

--- a/src/main/SyncManager.js
+++ b/src/main/SyncManager.js
@@ -542,10 +542,10 @@ export class SyncManager extends Singleton {
     // }
     const promises = dataCloud.syncedNamespaces.flatMap((ns) => {
       return ns.clusters.map((cluster) => {
-        if (!cluster.ready) {
+        if (!cluster.configReady) {
           return Promise.reject(
             new Error(
-              `Cannot add/update cluster that is not ready; cluster=${cluster}`
+              `Cannot add/update cluster that is not config-ready; cluster=${cluster}`
             )
           );
         }

--- a/src/renderer/catalogEntityDetails.tsx
+++ b/src/renderer/catalogEntityDetails.tsx
@@ -32,7 +32,9 @@ const {
 const {
   catalog: {
     entities: {
-      common: { details: unknownValue },
+      common: {
+        details: { unknownValue },
+      },
     },
   },
 } = strings;

--- a/src/strings.ts
+++ b/src/strings.ts
@@ -88,6 +88,7 @@ export const syncView: Dict = {
   connectButtonLabel: () => 'Connect new Management Cluster',
   autoSync: () => 'Auto-sync',
 };
+
 export const managementClusters = {
   table: {
     thead: {
@@ -142,6 +143,18 @@ export const apiClient: Dict = {
       `Failed to update ${resourceType}`,
     failedToDelete: (resourceType = 'unknown') =>
       `Failed to delete ${resourceType}`,
+  },
+};
+
+/** Generic API resource-related strings. */
+export const apiResource: Dict = {
+  notice: {
+    helmNotReady: () => 'Helm charts are not ready.',
+  },
+  status: {
+    unknown: () => 'Unknown',
+    pending: () => 'Pending', // cluster or machine isn't fully ready yet, might have an error
+    ready: () => 'Ready', // cluster or machine ready status
   },
 };
 

--- a/src/util/netUtil.js
+++ b/src/util/netUtil.js
@@ -2,6 +2,7 @@ import { get } from 'lodash';
 import nodeFetch from 'node-fetch';
 import https from 'https';
 import { Common } from '@k8slens/extensions';
+import queryString from 'query-string';
 import * as strings from '../strings';
 
 const { Util } = Common;
@@ -56,6 +57,18 @@ export function openBrowser(url) {
   }
 
   Util.openExternal(url); // open in default browser
+}
+
+/**
+ * Builds a query string from given parameters.
+ * @param {{ [index: string]: any }} params Values will be cast to a string. Parameters
+ *  with `undefined` values will be ignored.
+ * @returns {string} Query string that begins with "?" if there is at least one
+ *  parameter; empty string if none.
+ */
+export function buildQueryString(params) {
+  const str = queryString.stringify(params);
+  return `${str ? '?' : ''}${str}`;
 }
 
 /**

--- a/test/mocks/mockEntityModels.js
+++ b/test/mocks/mockEntityModels.js
@@ -13,7 +13,7 @@ export const sshKeyModels = [
       namespace: 'lex-ns-1',
       cloudUrl: 'https://container-cloud.acme.com',
       labels: {
-        managementCluster: 'mcc-1',
+        mgmtCluster: 'mcc-1',
         project: 'project-1',
       },
     },
@@ -34,7 +34,7 @@ export const sshKeyModels = [
       namespace: 'lex-ns-2',
       cloudUrl: 'https://container-cloud.acme.com',
       labels: {
-        managementCluster: 'mcc-1',
+        mgmtCluster: 'mcc-1',
         project: 'project-1',
       },
     },
@@ -58,7 +58,7 @@ export const credentialModels = [
       namespace: 'lex-ns-1',
       cloudUrl: 'https://container-cloud.acme.com',
       labels: {
-        managementCluster: 'mcc-1',
+        mgmtCluster: 'mcc-1',
         project: 'project-1',
       },
     },
@@ -81,7 +81,7 @@ export const credentialModels = [
       namespace: 'lex-ns-2',
       cloudUrl: 'https://container-cloud.acme.com',
       labels: {
-        managementCluster: 'mcc-1',
+        mgmtCluster: 'mcc-1',
         project: 'project-1',
       },
     },
@@ -107,7 +107,7 @@ export const proxyModels = [
       namespace: 'lex-ns-1',
       cloudUrl: 'https://container-cloud.acme.com',
       labels: {
-        managementCluster: 'mcc-1',
+        mgmtCluster: 'mcc-1',
         project: 'project-1',
       },
     },
@@ -130,7 +130,7 @@ export const proxyModels = [
       namespace: 'lex-ns-2',
       cloudUrl: 'https://container-cloud.acme.com',
       labels: {
-        managementCluster: 'mcc-1',
+        mgmtCluster: 'mcc-1',
         project: 'project-1',
       },
     },
@@ -156,7 +156,7 @@ export const licenseModels = [
       namespace: 'lex-ns-1',
       cloudUrl: 'https://container-cloud.acme.com',
       labels: {
-        managementCluster: 'mcc-1',
+        mgmtCluster: 'mcc-1',
         project: 'project-1',
       },
     },
@@ -176,7 +176,7 @@ export const licenseModels = [
       namespace: 'lex-ns-2',
       cloudUrl: 'https://container-cloud.acme.com',
       labels: {
-        managementCluster: 'mcc-1',
+        mgmtCluster: 'mcc-1',
         project: 'project-1',
       },
     },

--- a/test/mocks/mockExtCloud.js
+++ b/test/mocks/mockExtCloud.js
@@ -31,7 +31,7 @@ export const mockDataCloud = {
           namespace: 'namespaces-2',
           created: '2020-20-20',
           deleteInProgress: false,
-          isManagementCluster: false,
+          isMgmtCluster: false,
           ready: true,
           serverUrl: 'https://123.12.12.12:123',
           idpIssuerUrl:
@@ -58,7 +58,7 @@ export const mockDataCloud = {
           namespace: 'namespaces-3',
           created: '2020-20-20',
           deleteInProgress: false,
-          isManagementCluster: false,
+          isMgmtCluster: false,
           ready: true,
           serverUrl: 'https://123.12.12.12:123',
           idpIssuerUrl:
@@ -112,7 +112,7 @@ export const mockDataCloud2 = {
           namespace: 'namespaces-2',
           created: '2020-20-20',
           deleteInProgress: false,
-          isManagementCluster: false,
+          isMgmtCluster: false,
           ready: true,
           serverUrl: 'https://123.12.12.12:123',
           idpIssuerUrl:
@@ -139,7 +139,7 @@ export const mockDataCloud2 = {
           namespace: 'namespaces-3',
           created: '2020-20-20',
           deleteInProgress: false,
-          isManagementCluster: false,
+          isMgmtCluster: false,
           ready: true,
           serverUrl: 'https://123.12.12.12:123',
           idpIssuerUrl:


### PR DESCRIPTION
Relates other resources (SSH keys, credentials, proxies, licenses, machines)
to the clusters that use them.

Fetches all machines in all synced namespaces so that we can determine
a cluster's master and worker node counts, as well as it license
(since RHEL licenses are related to OpenStack cluster machines, not
the clusters themselves).

Adds a new `apiStatus` property to the Cluster Entity Model which
will provide a value for the "MCC Status" field in "View Details".
This is determined via "status conditions" on the cluster.

Also updates labels like this:
- Renames the much too long "managementCluster" label to "mgmt-cluster".
- Renames "sshKey" label to "ssh-key" as kebabcase seems more standard
  for label/tag names.
- Adds new "is-mgmt-cluster=true" label to all mgmt clusters.
- All clusters, whether mgmt or not, now get the "mgmt-cluster=name",
  "project=name", and any applicable of "ssh-key", "credential",
  "proxy", "license" labels since they all apply to all types of
  clusters.

Also fixed a small bug with incorrect destructuring of `unknownValue()`
string function in catalogEntityDetails.tsx leading to a crash if the
function is called for an unknown value.