### PR TITLE
[PRODX-22722] Add LEX_CC_UNSAFE_ALLOW_SELFSIGNED_CERTS cmd line switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,22 @@ GET /oauth/code
 - Up to, and including, __Lens 5.1.3__ (and probably some versions after that as well), I get an error like, "Failed to add cluster to Lens" after choosing a cluster and clicking on the "Add cluster" button in the extension, or choosing the "Add cluster to Lens" cluster menu option in Mirantis Container Cloud v2.9 or later.
     - __Lens must be restarted__ after upgrading the extension. This is __due to a bug in Lens__ that causes the extension's registration of [IPC event handlers](https://api-docs.k8slens.dev/v5.1.2/extensions/guides/ipc/) to be ignored, leading to an error message like this. [This Lens PR](https://github.com/lensapp/lens/pull/3505) tracks the fix.
 
+## Security
+
+### Self-signed certificates
+
+By default, the extension does not support management clusters that use self-signed certificates. They are treated as untrusted hosts for security reasons (because their identity cannot be verified).
+
+There are some legitimate reasons to use self-signed certificates, however, and it is possible to enable the extension to skip certificate verification by starting Lens from the command line with a special `LEX_CC_UNSAFE_ALLOW_SELFSIGNED_CERTS` flag:
+
+```bash
+$ LEX_CC_UNSAFE_ALLOW_SELFSIGNED_CERTS=1 /Applications/Lens.app/Contents/MacOS/Lens
+```
+
+- Values of `1`, `true`, or `yes` will enable self-signed certificate support.
+
+> The above example is for macOS. It will be similar on Windows and Linux, but with different syntax for setting the environment variable, and a different installation path for Lens.
+
 ## Development
 
 > __Yarn 1.x is required__

--- a/src/util/logger.js
+++ b/src/util/logger.js
@@ -23,7 +23,7 @@ export const logger = (function () {
       }
 
       const msg = `[${pkg.name}/${scope.replace(/^\//, '')}] ${
-        level === 'error' ? 'ERROR: ' : ''
+        level === 'error' ? 'ERROR: ' : level === 'warn' ? 'Warning: ' : ''
       }${message}`;
 
       // eslint-disable-next-line no-console -- we intend to log

--- a/src/util/netUtil.js
+++ b/src/util/netUtil.js
@@ -1,18 +1,26 @@
+import process from 'process';
 import { get } from 'lodash';
 import nodeFetch from 'node-fetch';
 import https from 'https';
 import { Common } from '@k8slens/extensions';
 import queryString from 'query-string';
 import * as strings from '../strings';
+import { logger } from './logger';
 
 const { Util } = Common;
 
-// SECURITY: get around any MCC instance certificate issues
-const httpsAgent = DEV_UNSAFE_NO_CERT
-  ? new https.Agent({
-      rejectUnauthorized: false,
-    })
-  : undefined;
+let httpsAgent;
+if (process.env.LEX_CC_UNSAFE_ALLOW_SELFSIGNED_CERTS?.match(/^(true|yes|1)$/)) {
+  // SECURITY: get around issues with Clouds that have self-signed certificates (typically used
+  //  for internal test Clouds of various kinds)
+  logger.warn(
+    'netUtil',
+    'Self-signed certificates will be permitted for all network requests: Be careful!'
+  );
+  httpsAgent = new https.Agent({
+    rejectUnauthorized: false,
+  });
+}
 
 async function tryExtractBody(response, extractMethod) {
   let body = null;

--- a/src/util/netUtil.js
+++ b/src/util/netUtil.js
@@ -10,7 +10,14 @@ import { logger } from './logger';
 const { Util } = Common;
 
 let httpsAgent;
-if (process.env.LEX_CC_UNSAFE_ALLOW_SELFSIGNED_CERTS?.match(/^(true|yes|1)$/)) {
+// NOTE: there seems to be a bug with Webpack in that if we use optional chaining (`?.`)
+//  to make this statement more terse, it just removes the `?` instead of (1) leaving
+//  it there like it should (and does for the rest of the code everywhere), or (2)
+//  transpiling it to what we've explicitly used here to get around this issue
+if (
+  process.env.LEX_CC_UNSAFE_ALLOW_SELFSIGNED_CERTS &&
+  process.env.LEX_CC_UNSAFE_ALLOW_SELFSIGNED_CERTS.match(/^(true|yes|1)$/)
+) {
   // SECURITY: get around issues with Clouds that have self-signed certificates (typically used
   //  for internal test Clouds of various kinds)
   logger.warn(


### PR DESCRIPTION
This enables support for self-signed certs (i.e. disables certificate
verification) when running Lens from the command line like this:

    $ LEX_CC_UNSAFE_ALLOW_SELFSIGNED_CERTS=1 /path/to/Lens/exe.