### PR TITLE
[PRODX-22753] Fix bug when 2 clouds, disconnected, and connect just 1

### DIFF
--- a/src/api/types/Cluster.js
+++ b/src/api/types/Cluster.js
@@ -361,9 +361,9 @@ export class Cluster extends Node {
           'Cluster.constructor()',
           `Unable to find ssh key name=${logValue(
             keyName
-          )} for cluster=${logValue(this.name)} in namespace=${logValue(
+          )} for cluster=${logValue(this.name)}, namespace=${logValue(
             this.namespace.name
-          )}`
+          )}, cloud=${this.cloud}`
         );
       }
     });
@@ -377,9 +377,9 @@ export class Cluster extends Node {
           'Cluster.constructor()',
           `Unable to find credential name=${logValue(
             credName
-          )} for cluster=${logValue(this.name)} in namespace=${logValue(
+          )} for cluster=${logValue(this.name)}, namespace=${logValue(
             this.namespace.name
-          )}`
+          )}, cloud=${this.cloud}`
         );
       }
     }
@@ -393,9 +393,9 @@ export class Cluster extends Node {
           'Cluster.constructor()',
           `Unable to find proxy name=${logValue(
             proxyName
-          )} for cluster=${logValue(this.name)} in namespace=${logValue(
+          )} for cluster=${logValue(this.name)}, namespace=${logValue(
             this.namespace.name
-          )}`
+          )}, cloud=${this.cloud}`
         );
       }
     }
@@ -415,7 +415,7 @@ export class Cluster extends Node {
         'Cluster.constructor()',
         `Unable to find any machines for cluster=${logValue(
           this.name
-        )} in namespace=${logValue(this.namespace.name)}`
+        )}, namespace=${logValue(this.namespace.name)}, cloud=${this.cloud}`
       );
     } else {
       // look for the first machine that has a license, and assume that's the one

--- a/src/common/DataCloud.js
+++ b/src/common/DataCloud.js
@@ -893,7 +893,7 @@ export class DataCloud extends EventDispatcher {
     return `{DataCloud loaded: ${this.loaded}, fetching: ${
       this.fetching
     }, preview: ${this.preview}, namespaces: ${
-      this.loaded ? this.namespaces.length : '??'
+      this.loaded ? this.namespaces.length : '-1'
     }, error: ${this.error}, cloud: ${this.cloud}}`;
   }
 }

--- a/src/store/CloudStore.js
+++ b/src/store/CloudStore.js
@@ -131,7 +131,23 @@ export class CloudStore extends Common.Store.ExtensionStore {
     }, {});
 
     // return a deep-clone that is no longer observable
+    // NOTE: it's not "pure JSON" void of Mobx proxy objects, however; the sole purpose of
+    //  this is to let Lens serialize the store to the related JSON file on disk, however
+    //  it does that
     return toJS(observableThis);
+  }
+
+  /** @returns {Object} A full clone to pure JSON of this store, void of all Mobx influence. */
+  toPureJSON() {
+    // throw-away: just to get keys we care about on this
+    const defaults = CloudStore.getDefaults();
+
+    const json = Object.keys(defaults).reduce((obj, key) => {
+      obj[key] = JSON.parse(JSON.stringify(this[key]));
+      return obj;
+    }, {});
+
+    return json;
   }
 
   /**

--- a/src/store/SyncStore.js
+++ b/src/store/SyncStore.js
@@ -136,7 +136,23 @@ export class SyncStore extends Common.Store.ExtensionStore {
     }, {});
 
     // return a deep-clone that is no longer observable
+    // NOTE: it's not "pure JSON" void of Mobx proxy objects, however; the sole purpose of
+    //  this is to let Lens serialize the store to the related JSON file on disk, however
+    //  it does that
     return toJS(observableThis);
+  }
+
+  /** @returns {Object} A full clone to pure JSON of this store, void of all Mobx influence. */
+  toPureJSON() {
+    // throw-away: just to get keys we care about on this
+    const defaults = SyncStore.getDefaults();
+
+    const json = Object.keys(defaults).reduce((obj, key) => {
+      obj[key] = JSON.parse(JSON.stringify(this[key]));
+      return obj;
+    }, {});
+
+    return json;
   }
 }
 


### PR DESCRIPTION
The result before the fix was that all entities related to the still-
disconnected Cloud would get removed, when they should remain until
the Cloud is reconnected and synced, or removed outright.

The result after the fix is that only the entities and models related
to the Cloud being updated are touched in the Catalog and SyncStore.
All others are left alone. So the items for the still-disconnected
Cloud remain untouched.