### PR TITLE
[PRODX-22830] Fetch optimization: Only fetch synced ns in SyncManager

### DIFF
--- a/src/api/apiUtil.js
+++ b/src/api/apiUtil.js
@@ -96,8 +96,8 @@ export async function cloudRefresh(cloud) {
   }
 
   // token was refreshed
+  logger.log('apiUtil.cloudRefresh()', `Refreshing tokens of cloud=${cloud}`);
   cloud.updateTokens(body);
-  logger.log('apiUtil.cloudRefresh()', `Refreshed tokens of cloud=${cloud}`);
 
   return true;
 }
@@ -164,6 +164,10 @@ export async function cloudRequest({ cloud, method, resourceType, args }) {
 
   if (response && response.status === 401) {
     // assume token is expired, try to refresh
+    logger.log(
+      'apiUtil.cloudRequest()',
+      `⚠️ Requesting new tokens, status=401, cloud=${cloud}`
+    ); // TODO[PRODX-22830] REMOVE
     tokensRefreshed = await cloudRefresh(cloud);
     if (!tokensRefreshed) {
       return { cloud, error: cloud.connectError, status: 401 };

--- a/src/api/types/Namespace.js
+++ b/src/api/types/Namespace.js
@@ -24,24 +24,45 @@ delete namespaceTs.kind; // Namespace API objects don't have `kind` property for
 /**
  * MCC project/namespace.
  * @class Namespace
- * @param {Object} data Raw namespace data payload from the API.
  */
 export class Namespace extends Resource {
-  constructor({ data, cloud }) {
+  /**
+   * @constructor
+   * @param {Object} params
+   * @param {Object} params.data Raw data payload from the API.
+   * @param {Cloud} params.cloud Reference to the Cloud used to get the data.
+   * @param {boolean} [params.preview] True if this Namespace is for preview
+   *  purposes only, and so only the __count__ properties will be valid.
+   */
+  constructor({ data, cloud, preview }) {
     super({ data, cloud, typeset: namespaceTs });
 
     let _clusters = [];
+    let _clusterCount;
     let _machines = [];
+    let _machineCount;
     let _sshKeys = [];
+    let _sshKeyCount;
     let _credentials = [];
+    let _credentialCount;
     let _proxies = [];
+    let _proxyCount;
     let _licenses = [];
+    let _licenseCount;
 
     /** @member {string} */
     Object.defineProperty(this, 'phase', {
       enumerable: true,
       get() {
         return data.status.phase;
+      },
+    });
+
+    /** @member {boolean} */
+    Object.defineProperty(this, 'preview', {
+      enumerable: true,
+      get() {
+        return !!preview;
       },
     });
 
@@ -54,6 +75,12 @@ export class Namespace extends Resource {
         return _clusters;
       },
       set(newValue) {
+        if (this.preview) {
+          throw new Error(
+            `Cannot set set clusters property on preview namespace=${this}`
+          );
+        }
+
         DEV_ENV &&
           rtv.verify(
             { clusters: newValue },
@@ -65,6 +92,7 @@ export class Namespace extends Resource {
               ],
             }
           );
+
         if (newValue !== _clusters) {
           _clusters = newValue || [];
         }
@@ -80,6 +108,12 @@ export class Namespace extends Resource {
         return _machines;
       },
       set(newValue) {
+        if (this.preview) {
+          throw new Error(
+            `Cannot set set machines property on preview namespace=${this}`
+          );
+        }
+
         DEV_ENV &&
           rtv.verify(
             { machines: newValue },
@@ -91,6 +125,7 @@ export class Namespace extends Resource {
               ],
             }
           );
+
         if (newValue !== _machines) {
           _machines = newValue || [];
         }
@@ -106,6 +141,12 @@ export class Namespace extends Resource {
         return _sshKeys;
       },
       set(newValue) {
+        if (this.preview) {
+          throw new Error(
+            `Cannot set set sshKeys property on preview namespace=${this}`
+          );
+        }
+
         DEV_ENV &&
           rtv.verify(
             { sshKeys: newValue },
@@ -117,6 +158,7 @@ export class Namespace extends Resource {
               ],
             }
           );
+
         if (newValue !== _sshKeys) {
           _sshKeys = newValue || [];
         }
@@ -132,6 +174,12 @@ export class Namespace extends Resource {
         return _credentials;
       },
       set(newValue) {
+        if (this.preview) {
+          throw new Error(
+            `Cannot set set credentials property on preview namespace=${this}`
+          );
+        }
+
         DEV_ENV &&
           rtv.verify(
             { credentials: newValue },
@@ -143,6 +191,7 @@ export class Namespace extends Resource {
               ],
             }
           );
+
         if (newValue !== _credentials) {
           _credentials = newValue || [];
         }
@@ -158,6 +207,12 @@ export class Namespace extends Resource {
         return _proxies;
       },
       set(newValue) {
+        if (this.preview) {
+          throw new Error(
+            `Cannot set set proxies property on preview namespace=${this}`
+          );
+        }
+
         DEV_ENV &&
           rtv.verify(
             { proxies: newValue },
@@ -169,6 +224,7 @@ export class Namespace extends Resource {
               ],
             }
           );
+
         if (newValue !== _proxies) {
           _proxies = newValue || [];
         }
@@ -184,6 +240,12 @@ export class Namespace extends Resource {
         return _licenses;
       },
       set(newValue) {
+        if (this.preview) {
+          throw new Error(
+            `Cannot set set licenses property on preview namespace=${this}`
+          );
+        }
+
         DEV_ENV &&
           rtv.verify(
             { licenses: newValue },
@@ -195,64 +257,191 @@ export class Namespace extends Resource {
               ],
             }
           );
+
         if (newValue !== _licenses) {
           _licenses = newValue || [];
         }
       },
     });
-  }
 
-  /**
-   * @member {number} clusterCount Number of clusters in this namespace.
-   */
-  get clusterCount() {
-    return this.clusters.length;
-  }
+    /**
+     * @member {number} clusterCount Number of clusters in this namespace.
+     * @throws {Error} If setting this property when `preview` is false.
+     */
+    Object.defineProperty(this, 'clusterCount', {
+      enumerable: true,
+      get() {
+        return _clusterCount ?? this.clusters.length;
+      },
+      set(newValue) {
+        if (!this.preview) {
+          throw new Error(
+            `Cannot set clusterCount property on non-preview namespace=${this}`
+          );
+        }
 
-  /**
-   * @member {number} machineCount Number of machines in this namespace.
-   */
-  get machineCount() {
-    return this.machines.length;
-  }
+        DEV_ENV &&
+          rtv.verify(
+            { clusterCount: newValue },
+            { clusterCount: [rtv.OPTIONAL, rtv.SAFE_INT] }
+          );
 
-  /**
-   * @member {number} clusterCount Number of SSH keys in this namespace.
-   */
-  get sshKeyCount() {
-    return this.sshKeys.length;
-  }
+        if (_clusterCount !== newValue) {
+          _clusterCount = newValue ?? undefined;
+        }
+      },
+    });
 
-  /**
-   * @member {number} credentialCount Number of all credentials, doesn't matter type, in this namespace.
-   */
-  get credentialCount() {
-    return this.credentials.length;
-  }
+    /**
+     * @member {number} machineCount Number of machines in this namespace.
+     * @throws {Error} If setting this property when `preview` is false.
+     */
+    Object.defineProperty(this, 'machineCount', {
+      enumerable: true,
+      get() {
+        return _machineCount ?? this.machines.length;
+      },
+      set(newValue) {
+        if (!this.preview) {
+          throw new Error(
+            `Cannot set machineCount property on non-preview namespace=${this}`
+          );
+        }
 
-  /**
-   * @member {number} proxyCount Number of all proxies in this namespace.
-   */
-  get proxyCount() {
-    return this.proxies.length;
-  }
+        DEV_ENV &&
+          rtv.verify(
+            { machineCount: newValue },
+            { machineCount: [rtv.OPTIONAL, rtv.SAFE_INT] }
+          );
 
-  /**
-   * @member {number} licenseCount Number of all licenses in this namespace.
-   */
-  get licenseCount() {
-    return this.licenses.length;
+        if (_machineCount !== newValue) {
+          _machineCount = newValue ?? undefined;
+        }
+      },
+    });
+
+    /**
+     * @member {number} clusterCount Number of SSH keys in this namespace.
+     * @throws {Error} If setting this property when `preview` is false.
+     */
+    Object.defineProperty(this, 'sshKeyCount', {
+      enumerable: true,
+      get() {
+        return _sshKeyCount ?? this.sshKeys.length;
+      },
+      set(newValue) {
+        if (!this.preview) {
+          throw new Error(
+            `Cannot set sshKeyCount property on non-preview namespace=${this}`
+          );
+        }
+
+        DEV_ENV &&
+          rtv.verify(
+            { sshKeyCount: newValue },
+            { sshKeyCount: [rtv.OPTIONAL, rtv.SAFE_INT] }
+          );
+
+        if (_sshKeyCount !== newValue) {
+          _sshKeyCount = newValue ?? undefined;
+        }
+      },
+    });
+
+    /**
+     * @member {number} credentialCount Number of all credentials, doesn't matter type, in this namespace.
+     * @throws {Error} If setting this property when `preview` is false.
+     */
+    Object.defineProperty(this, 'credentialCount', {
+      enumerable: true,
+      get() {
+        return _credentialCount ?? this.credentials.length;
+      },
+      set(newValue) {
+        if (!this.preview) {
+          throw new Error(
+            `Cannot set credentialCount property on non-preview namespace=${this}`
+          );
+        }
+
+        DEV_ENV &&
+          rtv.verify(
+            { credentialCount: newValue },
+            { credentialCount: [rtv.OPTIONAL, rtv.SAFE_INT] }
+          );
+
+        if (_credentialCount !== newValue) {
+          _credentialCount = newValue ?? undefined;
+        }
+      },
+    });
+
+    /**
+     * @member {number} proxyCount Number of all proxies in this namespace.
+     * @throws {Error} If setting this property when `preview` is false.
+     */
+    Object.defineProperty(this, 'proxyCount', {
+      enumerable: true,
+      get() {
+        return _proxyCount ?? this.proxies.length;
+      },
+      set(newValue) {
+        if (!this.preview) {
+          throw new Error(
+            `Cannot set proxyCount property on non-preview namespace=${this}`
+          );
+        }
+
+        DEV_ENV &&
+          rtv.verify(
+            { proxyCount: newValue },
+            { proxyCount: [rtv.OPTIONAL, rtv.SAFE_INT] }
+          );
+
+        if (_proxyCount !== newValue) {
+          _proxyCount = newValue ?? undefined;
+        }
+      },
+    });
+
+    /**
+     * @member {number} licenseCount Number of all licenses in this namespace.
+     * @throws {Error} If setting this property when `preview` is false.
+     */
+    Object.defineProperty(this, 'licenseCount', {
+      enumerable: true,
+      get() {
+        return _licenseCount ?? this.licenses.length;
+      },
+      set(newValue) {
+        if (!this.preview) {
+          throw new Error(
+            `Cannot set licenseCount property on non-preview namespace=${this}`
+          );
+        }
+
+        DEV_ENV &&
+          rtv.verify(
+            { licenseCount: newValue },
+            { licenseCount: [rtv.OPTIONAL, rtv.SAFE_INT] }
+          );
+
+        if (_licenseCount !== newValue) {
+          _licenseCount = newValue ?? undefined;
+        }
+      },
+    });
   }
 
   /** @returns {string} A string representation of this instance for logging/debugging. */
   toString() {
-    const propStr = `${super.toString()}, clusters: ${
+    const propStr = `${super.toString()}, preview: ${this.preview}, clusters: ${
       this.clusterCount
-    }, machines: ${this.machineCount}, sshKeys: ${
+    }, credentials: ${this.credentialCount}, sshKeys: ${
       this.sshKeyCount
-    }, credentials: ${this.credentialCount}, proxies: ${
-      this.proxyCount
-    }, licenses: ${this.licenseCount}`;
+    }, machines: ${this.machineCount}, proxies: ${this.proxyCount}, licenses: ${
+      this.licenseCount
+    }`;
 
     if (Object.getPrototypeOf(this).constructor === Namespace) {
       return `{Namespace ${propStr}}`;

--- a/src/common/DataCloud.js
+++ b/src/common/DataCloud.js
@@ -260,20 +260,26 @@ const _fetchCollection = async function ({
  * @param {Cloud} cloud An Cloud object. Tokens will be updated/cleared
  *  if necessary.
  * @param {Array<Namespace>} namespaces List of namespaces.
+ * @param {boolean} [preview] If true, only the count per namespace is retrieved.
  * @returns {Promise<Object>} Never fails, always resolves in
- *  `{ credentials: { [index: string]: Array<Credential> }, tokensRefreshed: boolean }`,
+ *  `{ credentials: { [index: string]: Array<Credential|Object> }, tokensRefreshed: boolean, preview: boolean }`,
  *  where `credentials` is a map of namespace name to credential (regardless of type).
- *  If there's an error trying to get any credential, it will be skipped/ignored.
+ *  If `preview=true`, `credentials` is a map of namespace name to empty objects since
+ *  only the count is desired. If there's an error trying to get any credential, it will be
+ *  skipped/ignored.
  */
-const _fetchCredentials = async function (cloud, namespaces) {
+const _fetchCredentials = async function (cloud, namespaces, preview = false) {
   const results = await Promise.all(
     Object.values(apiCredentialTypes).map((resourceType) =>
       _fetchCollection({
         resourceType,
         cloud,
         namespaces,
-        create: ({ data, namespace }) =>
-          new Credential({ data, namespace, cloud }),
+        create: ({ data, namespace }) => {
+          return preview
+            ? {} // skip full object creation; we just need a count
+            : new Credential({ data, namespace, cloud });
+        },
       })
     )
   );
@@ -301,7 +307,7 @@ const _fetchCredentials = async function (cloud, namespaces) {
     return acc;
   }, {});
 
-  return { credentials, tokensRefreshed };
+  return { credentials, tokensRefreshed, preview };
 };
 
 /**
@@ -352,19 +358,25 @@ const _fetchProxies = async function (cloud, namespaces) {
  * @param {Cloud} cloud An Cloud object. Tokens will be updated/cleared
  *  if necessary.
  * @param {Array<Namespace>} namespaces List of namespaces.
+ * @param {boolean} [preview] If true, only the count per namespace is retrieved.
  * @returns {Promise<Object>} Never fails, always resolves in
- *  `{ sshKeys: { [index: string]: Array<SshKey> }, tokensRefreshed: boolean }`
- *  where the SSH keys are mapped per namespace name. If an error occurs trying to get
- *  any SSH key, it will be ignored/skipped.
+ *  `{ sshKeys: { [index: string]: Array<SshKey|Object> }, tokensRefreshed: boolean, preview: boolean }`
+ *  where the SSH keys are mapped per namespace name. If `preview=true`, `sshKeys` is a map of
+ *  namespace name to empty objects since only the count is desired. If an error occurs trying
+ *  to get any SSH key, it will be ignored/skipped.
  */
-const _fetchSshKeys = async function (cloud, namespaces) {
+const _fetchSshKeys = async function (cloud, namespaces, preview = false) {
   const { resources: sshKeys, tokensRefreshed } = await _fetchCollection({
     resourceType: apiResourceTypes.PUBLIC_KEY,
     cloud,
     namespaces,
-    create: ({ data, namespace }) => new SshKey({ data, namespace, cloud }),
+    create: ({ data, namespace }) => {
+      return preview
+        ? {} // skip full object creation; we just need a count
+        : new SshKey({ data, namespace, cloud });
+    },
   });
-  return { sshKeys, tokensRefreshed };
+  return { sshKeys, tokensRefreshed, preview };
 };
 
 /**
@@ -398,30 +410,37 @@ const _fetchMachines = async function (cloud, namespaces) {
  *  NOTE: Each namespace is expected to already contain all known Credentials,
  *   SSH Keys, Proxies, Machines, and Licenses that this Cluster might reference.
  *
+ * @param {boolean} [preview] If true, only the count per namespace is retrieved.
  * @returns {Promise<Object>} Never fails, always resolves in
- *  `{ clusters: { [index: string]: Array<Cluster> }, tokensRefreshed: boolean }`
- *  where the clusters are mapped per namespace name. If an error occurs trying to get
- *  any cluster, it will be ignored/skipped.
+ *  `{ clusters: { [index: string]: Array<Cluster|Object> }, tokensRefreshed: boolean, preview: boolean }`
+ *  where the clusters are mapped per namespace name. If `preview=true`, `clusters` is a map
+ *  of namespace name to empty objects since only the count is desired. If an error occurs
+ *  trying to get any cluster, it will be ignored/skipped.
  */
-const _fetchClusters = async function (cloud, namespaces) {
+const _fetchClusters = async function (cloud, namespaces, preview) {
   const { resources: clusters, tokensRefreshed } = await _fetchCollection({
     resourceType: apiResourceTypes.CLUSTER,
     cloud,
     namespaces,
-    create: ({ data, namespace }) => new Cluster({ data, namespace, cloud }),
+    create: ({ data, namespace }) => {
+      return preview
+        ? {} // skip full object creation; we just need a count
+        : new Cluster({ data, namespace, cloud });
+    },
   });
-  return { clusters, tokensRefreshed };
+  return { clusters, tokensRefreshed, preview };
 };
 
 /**
  * [ASYNC] Best-try to get all existing namespaces from the management cluster.
  * @param {Cloud} cloud An Cloud object. Tokens will be updated/cleared
  *  if necessary.
+ * @param {boolean} [preview] True to create a preview version of the Namespace.
  * @returns {Promise<Object>} Never fails, always resolves in
- *  `{ namespaces: Array<Namespace>, tokensRefreshed: boolean }`. If an error occurs
- *  trying to get any namespace, it will be ignored/skipped.
+ *  `{ namespaces: Array<Namespace>, tokensRefreshed: boolean, preview: boolean }`.
+ *  If an error occurs trying to get any namespace, it will be ignored/skipped.
  */
-const _fetchNamespaces = async function (cloud) {
+const _fetchNamespaces = async function (cloud, preview = false) {
   // NOTE: we always fetch ALL known namespaces because when we display metadata
   //  about this DataCloud, we always need to show the actual total, not just
   //  what we're syncing
@@ -431,7 +450,7 @@ const _fetchNamespaces = async function (cloud) {
   } = await _fetchCollection({
     resourceType: apiResourceTypes.NAMESPACE,
     cloud,
-    create: ({ data }) => new Namespace({ data, cloud }),
+    create: ({ data }) => new Namespace({ data, cloud, preview }),
   });
 
   const userRoles = extractJwtPayload(cloud.token).iam_roles || [];
@@ -465,11 +484,8 @@ export class DataCloud extends EventDispatcher {
    * @param {Cloud} cloud The Cloud that provides backing for the DataCloud to access
    *  the API and determines which namespaces are synced.
    * @param {boolean} [preview] If truthy, declares this instance is only for preview
-   *  purposes, which reduces the amount of data fetched from the Cloud in order to
-   *  make data fetching a bit faster. Retrieving licenses and proxies can take quite
-   *  a bit more time for some reason, and we don't list their numbers when the user
-   *  is adding a new Cloud connection, so there's no point retrieving that data if
-   *  the user ultimately chooses not to add the Cloud.
+   *  purposes (i.e. not used for actual sync to the Catalog), which reduces the amount
+   *  of data fetched from the Cloud in order to make data fetching a bit faster.
    */
   constructor(cloud, preview) {
     super();
@@ -512,9 +528,9 @@ export class DataCloud extends EventDispatcher {
 
           logger.log(
             'DataCloud.cloud:set',
-            `Received new Cloud: Scheduling new data fetch; dataCloud=${this}`
+            `Received new Cloud: Fetching new data now; dataCloud=${this}`
           );
-          this.dispatchEvent(DATA_CLOUD_EVENTS.FETCH_DATA, this);
+          this.fetchNow();
         }
       },
     });
@@ -598,9 +614,8 @@ export class DataCloud extends EventDispatcher {
 
     /**
      * @member {boolean} preview True if this instance is for previous purposes
-     *  only; false if it's for full use. Use a preview instance when letting the
-     *  user choose whether they want to add a new Cloud or not. Use a full instance
-     *  for a Cloud that has formally been added and is being synced.
+     *  only; false if it's for full use. Use a preview instance when not using
+     *  it for sync purposes to reduce the amount of data fetched.
      */
     Object.defineProperty(this, 'preview', {
       enumerable: true,
@@ -704,11 +719,13 @@ export class DataCloud extends EventDispatcher {
 
   /** Called when the Cloud's sync-related properties have changed. */
   onCloudSyncChange = () => {
-    logger.log(
-      'DataCloud.onCloudSyncChange()',
-      `Cloud sync props have changed: Scheduling new data fetch on next frame; dataCloud=${this}`
-    );
-    this.dispatchEvent(DATA_CLOUD_EVENTS.FETCH_DATA, this);
+    if (!this.fetching) {
+      logger.log(
+        'DataCloud.onCloudSyncChange()',
+        `Cloud sync props have changed: Fetching new data now; dataCloud=${this}`
+      );
+      this.fetchNow();
+    }
   };
 
   /**
@@ -727,12 +744,14 @@ export class DataCloud extends EventDispatcher {
    * Update the Cloud's list of namespaces given all known namespaces and the Cloud's
    *  `syncAll` flag (i.e. add any new namespaces to its synced or ignored list, and
    *  remove any old ones).
+   * @param {Array<Namespace>} allNamespaces All existing/known namespaces from the
+   *  latest data fetch.
    */
-  updateCloudNamespaces() {
+  updateCloudNamespaces(allNamespaces) {
     const syncedList = [];
     const ignoredList = [];
 
-    this.namespaces.forEach(({ name }) => {
+    allNamespaces.forEach(({ name }) => {
       if (this.cloud.syncAll) {
         if (this.cloud.ignoredNamespaces.includes(name)) {
           ignoredList.push(name);
@@ -748,7 +767,7 @@ export class DataCloud extends EventDispatcher {
       }
     });
 
-    this.cloud.updateNamespaces(syncedList, ignoredList, true);
+    this.cloud.updateNamespaces(syncedList, ignoredList);
   }
 
   /** Called when __this__ DataCloud should fetch new data from its Cloud. */
@@ -765,7 +784,7 @@ export class DataCloud extends EventDispatcher {
 
     // make sure we have a Cloud and it's connected
     if (!this.cloud?.connected) {
-      // if no config (eg when we restore cloud from disk) try to load it
+      // if no config (eg. when we restore cloud from disk) try to load it
       if (!this.cloud.config) {
         await this.cloud.loadConfig();
         // if loadConfig error we get it as connectError
@@ -779,54 +798,74 @@ export class DataCloud extends EventDispatcher {
     if (!this.cloud.connected) {
       logger.log(
         'DataCloud.fetchData()',
-        `Cannot fetch data for dataCloud=${this}: Cloud is ${
+        `Cannot fetch data: Cloud is ${
           this.cloud ? this.cloud.status : 'unknown'
-        }`
+        }; dataCloud=${this}`
       );
       return;
     }
 
     this.fetching = true;
-
     logger.log('DataCloud.fetchData()', `Fetching data for dataCloud=${this}`);
 
-    const nsResults = await _fetchNamespaces(this.cloud);
+    // NOTE: we always fetch ALL namespaces (which should be quite cheap to do)
+    //  since we need to discover new ones, and know when existing ones are removed
+    const nsResults = await _fetchNamespaces(this.cloud, this.preview);
+    const allNamespaces = nsResults.namespaces.concat();
+
+    // update the synced vs ignored namespace lists of the Cloud
+    this.updateCloudNamespaces(allNamespaces);
+
+    // if we're not generating a preview, only fetch full data for synced namespaces
+    //  (which may contain some newly-discovered ones after the update we just did
+    //  using `allNamespaces`)
+    const fetchNamespaces = this.preview
+      ? allNamespaces
+      : allNamespaces.filter((ns) =>
+          this.cloud.syncedNamespaces.includes(ns.name)
+        );
+
     const credResults = await _fetchCredentials(
       this.cloud,
-      nsResults.namespaces
+      fetchNamespaces,
+      this.preview
     );
-    const keyResults = await _fetchSshKeys(this.cloud, nsResults.namespaces);
+    const keyResults = await _fetchSshKeys(
+      this.cloud,
+      fetchNamespaces,
+      this.preview
+    );
 
     // map all the resources fetched so far into their respective Namespaces
-    const newNamespaces = nsResults.namespaces.map((namespace) => {
-      namespace.sshKeys = keyResults?.sshKeys[namespace.name] || [];
-      namespace.credentials = credResults?.credentials[namespace.name] || [];
-      return namespace;
+    fetchNamespaces.forEach((namespace) => {
+      if (keyResults.preview) {
+        namespace.sshKeyCount = keyResults.sshKeys[namespace.name]?.length ?? 0;
+      } else {
+        namespace.sshKeys = keyResults.sshKeys[namespace.name] || [];
+      }
+
+      if (credResults.preview) {
+        namespace.credentialCount =
+          credResults.credentials[namespace.name]?.length ?? 0;
+      } else {
+        namespace.credentials = credResults.credentials[namespace.name] || [];
+      }
     });
 
     if (!this.preview) {
-      const proxyResults = await _fetchProxies(
-        this.cloud,
-        nsResults.namespaces
-      );
-      const licenseResults = await _fetchLicenses(
-        this.cloud,
-        nsResults.namespaces
-      );
+      const proxyResults = await _fetchProxies(this.cloud, fetchNamespaces);
+      const licenseResults = await _fetchLicenses(this.cloud, fetchNamespaces);
       // map fetched proxies and licenses into their respective Namespaces
-      newNamespaces.forEach((namespace) => {
+      fetchNamespaces.forEach((namespace) => {
         namespace.proxies = proxyResults.proxies[namespace.name] || [];
         namespace.licenses = licenseResults.licenses[namespace.name] || [];
       });
 
       // NOTE: fetch machines only AFTER licenses have been fetched and added
       //  into the Namespaces because the Machine resource expects to find Licenses
-      const machineResults = await _fetchMachines(
-        this.cloud,
-        nsResults.namespaces
-      );
+      const machineResults = await _fetchMachines(this.cloud, fetchNamespaces);
       // map fetched machines into their respective Namespaces
-      newNamespaces.forEach((namespace) => {
+      fetchNamespaces.forEach((namespace) => {
         namespace.machines = machineResults.machines[namespace.name] || [];
       });
     } else {
@@ -841,28 +880,36 @@ export class DataCloud extends EventDispatcher {
     //  other resources
     const clusterResults = await _fetchClusters(
       this.cloud,
-      nsResults.namespaces
+      fetchNamespaces,
+      this.preview
     );
 
     // map fetched clusters into their respective Namespaces
-    newNamespaces.forEach((namespace) => {
-      namespace.clusters = clusterResults.clusters[namespace.name] || [];
+    fetchNamespaces.forEach((namespace) => {
+      if (clusterResults.preview) {
+        namespace.clusterCount =
+          clusterResults.clusters[namespace.name]?.length ?? 0;
+      } else {
+        namespace.clusters = clusterResults.clusters[namespace.name] || [];
+      }
     });
 
     this.error = null;
-    this.namespaces = newNamespaces;
-
-    this.updateCloudNamespaces();
+    this.namespaces = fetchNamespaces;
 
     if (!this.loaded) {
       // successfully loaded at least once
-      this.loaded = true;
       logger.log(
         'DataCloud.fetchData()',
-        `Initial data load successful, dataCloud=${this}`
+        `Initial data load successful; dataCloud=${this}`
       );
+      this.loaded = true;
     }
 
+    logger.log(
+      'DataCloud.fetchData()',
+      `Data fetch complete; dataCloud=${this}`
+    );
     this.fetching = false;
   }
 

--- a/src/common/EventDispatcher.js
+++ b/src/common/EventDispatcher.js
@@ -2,6 +2,8 @@
 // Base class providing event dispatching capabilities
 //
 
+import { logger, logValue } from '../util/logger'; // TODO[PRODX-22830] REMOVE
+
 export class EventDispatcher {
   constructor() {
     const _eventListeners = {}; // map of event name to array of functions that are handlers
@@ -102,11 +104,19 @@ export class EventDispatcher {
         value(name, ...params) {
           const event = _eventQueue.find((e) => e.name === name);
           if (event) {
+            logger.log(
+              'EventDispatcher.dispatchEvent()',
+              `✳️ Updating params for event=${logValue(name)}, this=${this}`
+            ); // TODO[PRODX-22830] REMOVE
             event.params = params;
             // don't schedule dispatch in this case because we wouldn't already
             //  scheduled it when the event was first added to the queue; we
             //  just haven't gotten to the next frame yet where we'll dispatch it
           } else {
+            logger.log(
+              'EventDispatcher.dispatchEvent()',
+              `⚡️ Dispatching event=${logValue(name)}, this=${this}`
+            ); // TODO[PRODX-22830] REMOVE
             _eventQueue.push({ name, params });
             _scheduleDispatch();
           }

--- a/src/main/SyncManager.js
+++ b/src/main/SyncManager.js
@@ -433,6 +433,8 @@ export class SyncManager extends Singleton {
         }
       } else {
         // add new DC to store (initial fetch is scheduled by the DC itself)
+        // NOTE: SyncManager only runs on the MAIN thread and always needs full data
+        //  so we create full instances, not preview ones
         const dc = new DataCloud(cloud);
         dc.addEventListener(DATA_CLOUD_EVENTS.DATA_UPDATED, this.onDataUpdated);
         this.dataClouds[url] = dc;

--- a/src/renderer/store/DataCloudProvider.js
+++ b/src/renderer/store/DataCloudProvider.js
@@ -143,7 +143,9 @@ const _updateStore = function ({
       pr.store.dataClouds[url].cloud = cloud;
     } else {
       // otherwise create new DataCloud
-      const dc = new DataCloud(cloud);
+      // NOTE: DataCloudProvider only runs on the RENDERER thread, and it only needs
+      //  preview data, not full data, so always create preview instances
+      const dc = new DataCloud(cloud, true);
       // add new DC to store
       pr.store.dataClouds[url] = dc;
     }

--- a/src/store/CloudStore.js
+++ b/src/store/CloudStore.js
@@ -79,6 +79,10 @@ export class CloudStore extends Common.Store.ExtensionStore {
             if (existingClouds[cloudUrl]) {
               // update existing Cloud with new data instead of creating a new instance
               //  so that currently-bound objects don't leak
+              logger.log(
+                'CloudStore.fromStore()',
+                `♻️ Updating cloudUrl=${cloudUrl} with new data from disk`
+              ); // TODO[PRODX-22830] REMOVE
               cloud = existingClouds[cloudUrl].update(cloudJson);
             } else {
               // add new Cloud we don't know about yet


### PR DESCRIPTION
SyncManager now only fetches synced namespace metadata instead of
fetching metadata for ALL namespaces in ALL mgmt clusters.

Also, DataCloud, when in preview mode, doesn't create new instances
of Clusters, Credentials, and SshKeys. It just creates dummy objects
and then the Namespace class has setters for count properties which
are set instead of its typical array properties.

So now, DataCloudProvider always provides __preview__ instances
of DataClouds, while SyncManager always uses full instances.

This isn't enough, though, more to follow.

And the endless loop issue isn't fixed. Some `// TODO[PRODX-22830]`
comments remain in the code where I added additional logging in
hopes that, when it happens again (not sure what triggers it either),
we have more information to look at. And it's possible this issue
goes away with the optimizations we're going to make.

[PRODX-22830]: https://mirantis.jira.com/browse/PRODX-22830?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ