### PR TITLE
[PRODX-22918] Use config.js to prevent accessing disabled features

### DIFF
--- a/src/api/clients/ApiClient.js
+++ b/src/api/clients/ApiClient.js
@@ -12,11 +12,11 @@ const authRoute = 'protocol/openid-connect'; // NEVER begins/ends with a slash
  *  and refresh those tokens if they expire.
  * @class ApiClient
  * @param {Object} options
- * @param {Object} options.config The MCC Configuration object.
+ * @param {CloudConfig} options.config The MCC Configuration object.
  */
 export class ApiClient {
   constructor({ config }) {
-    if (!config || !config.keycloakLogin) {
+    if (!config || !config.ssoEnabled) {
       throw new Error(
         'config is always required and must be for an instance that uses Keycloak/SSO'
       );
@@ -40,11 +40,14 @@ export class ApiClient {
   /**
    * Makes a network request with specified options.
    * @param {string} endpoint API endpoint. Does NOT begin or end with a slash.
-   * @param {Object} config
-   * @param {Object} [config.options] Request configuration options.
-   * @param {Array<number>} [config.expectedStatuses] List of expected success
+   * @param {Object} params
+   * @param {Object} [params.options] Request configuration options.
+   * @param {Array<number>} [params.expectedStatuses] List of expected success
    *  statuses.
-   * @param {string} [config.extractBodyMethod] Name of a method on a fetch
+   * @param {string} [params.errorMessage] Error message to use if the request is
+   *  deemed to have failed (per other options); otherwise, a generated message
+   *  is used, based on response status.
+   * @param {string} [params.extractBodyMethod] Name of a method on a fetch
    *  response object to call to deserialize/extract/parse data from the response.
    *  Defaults to "json".
    * @returns {Promise<Object>} See netUtil.request() for response shape.

--- a/src/common/CloudConfig.js
+++ b/src/common/CloudConfig.js
@@ -1,0 +1,153 @@
+//
+// Represents a Cloud's config.js JSON metadata
+//
+
+import * as rtv from 'rtvjs';
+import { apiResourceTypes } from '../api/apiConstants';
+import { logValue } from '../util/logger';
+
+/** Typeset for the config.js object. */
+export const cloudConfigTs = {
+  // NOTE: this is not intended to be fully-representative; we only list the properties
+  //  related to what we expect to find in order to create a `Credential` class instance
+
+  // NOTE: if a component doesn't exist (`undefined`), it should be treated as __enabled__
+  disabledComponents: {
+    aws: [rtv.OPTIONAL, rtv.BOOLEAN],
+    azure: [rtv.OPTIONAL, rtv.BOOLEAN],
+    baremetal: [rtv.OPTIONAL, rtv.BOOLEAN],
+    byo: [rtv.OPTIONAL, rtv.BOOLEAN],
+    ceph: [rtv.OPTIONAL, rtv.BOOLEAN],
+    equinixmetal: [rtv.OPTIONAL, rtv.BOOLEAN],
+    openstack: [rtv.OPTIONAL, rtv.BOOLEAN],
+    vsphere: [rtv.OPTIONAL, rtv.BOOLEAN],
+    proxy: [rtv.OPTIONAL, rtv.BOOLEAN],
+  },
+
+  ignoredNamespaces: [[rtv.STRING]],
+  keycloakLogin: [rtv.OPTIONAL, rtv.BOOLEAN], // true if SSO-enabled
+
+  // only defined if `keycloakLogin=true`
+  keycloak: [
+    rtv.OPTIONAL,
+    {
+      'client-id': [rtv.OPTIONAL, rtv.STRING], // OAuth client ID
+      'idp-issuer-url': [rtv.OPTIONAL, rtv.STRING], // path from base URL to Keycloak service
+    },
+  ],
+};
+
+/**
+ * Represents a config.js object from a mgmt cluster.
+ * @class CloudConfig
+ */
+export class CloudConfig {
+  /**
+   * Constructor
+   * @param {string} cloudUrl URL of the mgmt cluster.
+   * @param {Object} config JSON config.js object from the mgmt cluster.
+   */
+  constructor(cloudUrl, config) {
+    DEV_ENV &&
+      rtv.verify(
+        { cloudUrl, config },
+        {
+          cloudUrl: rtv.STRING,
+          config: cloudConfigTs,
+        }
+      );
+
+    /** @member {string} cloudUrl URL of the mgmt cluster this config belongs to. */
+    Object.defineProperty(this, 'cloudUrl', {
+      enumerable: true,
+      writable: false,
+      value: cloudUrl,
+    });
+
+    // proxy everything we get via class properties of same name to maintain
+    //  the same interface
+    Object.keys(config).forEach((key) => {
+      Object.defineProperty(this, key, {
+        enumerable: true,
+        writable: false,
+        value: config[key],
+      });
+    });
+  }
+
+  /** @member {boolean} ssoEnabled True if Keycloak/SSO is supported; false otherwise. */
+  get ssoEnabled() {
+    return !!this.keycloakLogin;
+  }
+
+  /**
+   * Determines if a given API resource is available in this Cloud.
+   * @param {string} resourceType API resource type. Enum value from `apiResourceTypes`.
+   * @returns {boolean} True if available; false if not.
+   */
+  isResourceAvailable(resourceType) {
+    const isAvailable = (feature) =>
+      this.disabledComponents[feature] === undefined ||
+      !this.disabledComponents[feature];
+
+    switch (resourceType) {
+      case apiResourceTypes.CLUSTER: // fall-through
+      case apiResourceTypes.MACHINE: // fall-through
+      case apiResourceTypes.PUBLIC_KEY: // fall-through
+      case apiResourceTypes.NAMESPACE: // fall-through
+      case apiResourceTypes.EVENT: // fall-through
+      case apiResourceTypes.CLUSTER_RELEASE: // fall-through
+      case apiResourceTypes.KAAS_RELEASE: // fall-through
+      case apiResourceTypes.AUTHORIZATION: // fall-through
+      case apiResourceTypes.VSPHERE_CREDENTIAL:
+        return true; // always enabled
+
+      case apiResourceTypes.AWS_CREDENTIAL:
+      case apiResourceTypes.AWS_RESOURCE:
+        return isAvailable('aws');
+
+      case apiResourceTypes.EQUINIX_CREDENTIAL:
+        return isAvailable('equinixmetal');
+
+      case apiResourceTypes.PROXY:
+        return (
+          isAvailable('proxy') &&
+          (isAvailable('openstack') || isAvailable('vsphere'))
+        );
+
+      case apiResourceTypes.AZURE_CREDENTIAL:
+        return isAvailable('azure');
+
+      case apiResourceTypes.BYO_CREDENTIAL:
+        return isAvailable('byo');
+
+      case apiResourceTypes.METAL_CREDENTIAL:
+      case apiResourceTypes.METAL_HOST:
+        return isAvailable('baremetal');
+
+      case apiResourceTypes.RHEL_LICENSE:
+        return isAvailable('vsphere');
+
+      case apiResourceTypes.OPENSTACK_CREDENTIAL: // fall-through
+      case apiResourceTypes.OPENSTACK_RESOURCE: // fall-through
+        return isAvailable('openstack');
+
+      case apiResourceTypes.CEPH_CLUSTER:
+        return isAvailable('ceph');
+
+      default:
+        throw new Error(`Unknown API resource type ${logValue(resourceType)}`);
+    }
+  }
+
+  /** @returns {string} A string representation of this instance for logging/debugging. */
+  toString() {
+    const propStr = `ssoEnabled: ${
+      this.ssoEnabled
+    }, bmAvailable: ${this.isResourceAvailable(
+      apiResourceTypes.METAL_HOST
+    )}, cloudUrl: ${logValue(this.cloudUrl)}`;
+
+    return `{CloudConfig ${propStr}}`;
+  }
+}

--- a/src/common/DataCloud.js
+++ b/src/common/DataCloud.js
@@ -176,6 +176,16 @@ const _fetchCollection = async function ({
       }
     );
 
+  if (!cloud.config.isResourceAvailable(resourceType)) {
+    logger.log(
+      'DataCloud._fetchCollection',
+      `Cannot fetch resources of type ${logValue(
+        resourceType
+      )}: Not available; cloud=${cloud}`
+    );
+    return { resources: {}, tokensRefreshed: false };
+  }
+
   let tokensRefreshed = false;
 
   // process a result from an API call

--- a/src/util/ssoUtil.js
+++ b/src/util/ssoUtil.js
@@ -9,7 +9,7 @@ import * as strings from '../strings';
  *  redirect URI that will use the 'lens://' protocol to redirect the user
  *  to Lens and ultimately call back into `finishAuthorization()`.
  * @param {Object} options
- * @param {Object} options.config MCC Config object.
+ * @param {CloudConfig} options.config MCC Config object.
  * @param {string} [options.state] Any string that should be returned verbatim
  *  in a `state` request parameter in the redirect request.
  * @throws {Error} If the MCC instance doesn't support SSO.
@@ -18,7 +18,7 @@ import * as strings from '../strings';
 export const startAuthorization = function ({ config, state }) {
   const apiClient = new ApiClient({ config });
 
-  if (config.keycloakLogin) {
+  if (config.ssoEnabled) {
     const url = apiClient.getSsoAuthUrl({ state });
     try {
       openBrowser(url); // open in default browser (will throw if `url` is blacklisted)


### PR DESCRIPTION
Use `config.disabledComponents` to prevent making requests to API
endpoints for resources that aren't available on a given mgmt cluster.

That should improve performance because making requests to disabled
APIs results in timeouts, which take a while to resolve.