### PR TITLE
[PRODX-23053]: added proxies and licenses counts for synced namespaced

### DIFF
--- a/src/renderer/components/EnhancedTable/AdditionalInfoRows.js
+++ b/src/renderer/components/EnhancedTable/AdditionalInfoRows.js
@@ -50,6 +50,14 @@ export const AdditionalInfoRows = ({ namespace, emptyCellsCount }) => {
       infoName: managementClusters.table.tbodyDetailedInfo.credentials(),
       infoCount: namespace.credentialCount,
     },
+    {
+      infoName: managementClusters.table.tbodyDetailedInfo.proxies(),
+      infoCount: namespace.proxyCount,
+    },
+    {
+      infoName: managementClusters.table.tbodyDetailedInfo.licenses(),
+      infoCount: namespace.licenseCount,
+    },
   ];
   return (
     <EnhInfoRowsWrapper>

--- a/src/strings.ts
+++ b/src/strings.ts
@@ -102,6 +102,8 @@ export const managementClusters = {
       clusters: () => 'clusters',
       sshKeys: () => 'SSH keys',
       credentials: () => 'credentials',
+      proxies: () => 'proxies',
+      licenses: () => 'licenses',
     },
   },
 };
@@ -229,7 +231,6 @@ export const catalog: Dict = {
           isManagementCluster: (isManagementCluster) =>
             isManagementCluster ? 'Yes' : 'No',
           url: () => 'URL',
-          childClusters: () => 'Child clusters',
           region: () => 'Region',
           provider: () => 'Provider',
           mccStatus: () => 'MCC Status',


### PR DESCRIPTION
<img width="1168" alt="Screenshot 2022-04-06 at 14 03 21" src="https://user-images.githubusercontent.com/33761040/161961037-4a29644b-f5fa-4290-8067-9b2dff1817a8.png">
<img width="1166" alt="Screenshot 2022-04-06 at 14 03 35" src="https://user-images.githubusercontent.com/33761040/161961069-b02258d6-1bbf-4d51-b84f-908d06301985.png">

@stefcameron Should we show row for entity count if `count === 0` ?
