### PR TITLE
[PRODX-23155] Bundle kubelogin with the extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,9 +6,11 @@
 # testing
 /coverage
 
-# production
+# distribution
 /dist
 /dist_babel
+/tmp
+/bin
 
 # misc
 .DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 - Added warning about potential sync and management cluster performance when the number of synced projects exceeds (or may exceed through "future sync") 10 or more (per management cluster). This is an API limitation, not an extension limitation.
 - Fixed issue with "select all" checkboxes sometimes being out-of-sync with child states.
 - Fixed issue with "select all" checkboxes going from partial to unchecked instead of checked.
+- The `kubelogin` binary is now being packaged with the extension to remove the need for users to download and install it separately.
+    - The extension will support macOS x64/arm64, Linux x64, and Windows x64 (the platforms which Lens supports).
 
 ## v4.0.0-alpha.4
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "CHANGELOG.md",
     "README.md",
     "LICENSE",
+    "bin/",
     "dist/"
   ],
   "scripts": {
@@ -37,13 +38,25 @@
     "dev": "TARGET=development yarn build",
     "prebabel": "rm -rf ./dist_babel",
     "babel": "babel src --out-dir dist_babel",
+    "prestart": "yarn download:kubelogin",
     "start": "TARGET=development yarn build --watch",
     "fmt": "prettier --write \"{*,src/**/*}.+(js|ts*|yml|json)\"",
     "fmt:check": "prettier --check \"{*,src/**/*}.+(js|ts*|yml|json)\"",
     "lint": "eslint \"{*,src/**/*}.+(js|ts*)\"",
     "test:unit": "echo 'Works for me! ¯\\_(ツ)_/¯'",
     "test": "yarn lint && yarn fmt:check && yarn test:unit",
-    "prepublishOnly": "yarn test && yarn build"
+    "prepack": "yarn build && yarn download:kubelogin:all",
+    "prepublishOnly": "yarn test",
+    "download:kubelogin": "run-script-os",
+    "download:kubelogin:all": "yarn download:kubelogin:macos && yarn download:kubelogin:linux && yarn download:kubelogin:windows",
+    "predownload:kubelogin:macos": "mkdir -p ./bin",
+    "download:kubelogin:macos": "yarn download:kubelogin:macos-amd64 && yarn download:kubelogin:macos-arm64",
+    "download:kubelogin:macos-amd64": "[[ -f ./bin/kubelogin-macos-amd64 ]] || (mkdir -p ./tmp && cd ./tmp && curl -slL https://github.com/int128/kubelogin/releases/download/v1.25.1/kubelogin_darwin_amd64.zip | tar -xz && mv kubelogin ../bin/kubelogin-macos-amd64 && chmod +x ../bin/kubelogin-macos-amd64 && cd .. && rm -rf ./tmp)",
+    "download:kubelogin:macos-arm64": "[[ -f ./bin/kubelogin-macos-arm64 ]] || (mkdir -p ./tmp && cd ./tmp && curl -slL https://github.com/int128/kubelogin/releases/download/v1.25.1/kubelogin_darwin_arm64.zip | tar -xz && mv kubelogin ../bin/kubelogin-macos-arm64 && chmod +x ../bin/kubelogin-macos-arm64 && cd .. && rm -rf ./tmp)",
+    "predownload:kubelogin:linux": "mkdir -p ./bin",
+    "download:kubelogin:linux": "[[ -f ./bin/kubelogin-linux-amd64 ]] || (mkdir -p ./tmp && cd ./tmp && curl -slL https://github.com/int128/kubelogin/releases/download/v1.25.1/kubelogin_linux_amd64.zip | tar -xz && mv kubelogin ../bin/kubelogin-linux-amd64 && chmod +x ../bin/kubelogin-linux-amd64 && cd .. && rm -rf ./tmp)",
+    "predownload:kubelogin:windows": "sh -c \"mkdir -p ./bin\"",
+    "download:kubelogin:windows": "sh -c \"[[ -f ./bin/kubelogin-win-amd64.exe ]] || (mkdir -p ./tmp && cd ./tmp && curl -slL https://github.com/int128/kubelogin/releases/download/v1.25.1/kubelogin_windows_amd64.zip | tar -xz && mv kubelogin.exe ../bin/kubelogin-win-amd64.exe && chmod +x ../bin/kubelogin-win-amd64.exe && cd .. && rm -rf ./tmp)\""
   },
   "devDependencies": {
     "@babel/cli": "^7.17.6",
@@ -82,6 +95,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "rtvjs": "^4.0.0",
+    "run-script-os": "^1.1.6",
     "ts-loader": "^9.2.8",
     "typescript": "^4.6.3",
     "webpack": "^5.72.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4068,6 +4068,11 @@ run-parallel@^1.1.9:
   resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.1.10.tgz#60a51b2ae836636c81377df16cb107351bcd13ef"
   integrity sha512-zb/1OuZ6flOlH6tQyMPUrE3x3Ulxjlo9WIVXR4yVYi4H9UXQaeIsPbLn2R3O3vQCnDKkAl2qHiuocKKX4Tz/Sw==
 
+run-script-os@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/run-script-os/-/run-script-os-1.1.6.tgz#8b0177fb1b54c99a670f95c7fdc54f18b9c72347"
+  integrity sha512-ql6P2LzhBTTDfzKts+Qo4H94VUKpxKDFz6QxxwaUZN0mwvi7L3lpOI7BqPCq7lgDh3XLl0dpeXwfcVIitlrYrw==
+
 safe-buffer@^5.1.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"


### PR DESCRIPTION
Download, make executable, and package kubelogin binaries for
macOS (x64, arm64), linux (x64), and windows (x64).

Update kubeconfig template to execute the correct binary based on
current OS directly instead of through kubectl as a plugin (the
result is the same).