### PR TITLE
[PRODX-22315] Make DataCloud fetching more resilient

### DIFF
--- a/src/api/types/Cluster.js
+++ b/src/api/types/Cluster.js
@@ -363,7 +363,7 @@ export class Cluster extends Node {
             keyName
           )} for cluster=${logValue(this.name)}, namespace=${logValue(
             this.namespace.name
-          )}, cloud=${this.cloud}`
+          )}, cloud=${logValue(this.cloud.cloudUrl)}`
         );
       }
     });
@@ -379,7 +379,7 @@ export class Cluster extends Node {
             credName
           )} for cluster=${logValue(this.name)}, namespace=${logValue(
             this.namespace.name
-          )}, cloud=${this.cloud}`
+          )}, cloud=${logValue(this.cloud.cloudUrl)}`
         );
       }
     }
@@ -395,7 +395,7 @@ export class Cluster extends Node {
             proxyName
           )} for cluster=${logValue(this.name)}, namespace=${logValue(
             this.namespace.name
-          )}, cloud=${this.cloud}`
+          )}, cloud=${logValue(this.cloud.cloudUrl)}`
         );
       }
     }
@@ -415,7 +415,9 @@ export class Cluster extends Node {
         'Cluster.constructor()',
         `Unable to find any machines for cluster=${logValue(
           this.name
-        )}, namespace=${logValue(this.namespace.name)}, cloud=${this.cloud}`
+        )}, namespace=${logValue(this.namespace.name)}, cloud=${logValue(
+          this.cloud.cloudUrl
+        )}`
       );
     } else {
       // look for the first machine that has a license, and assume that's the one

--- a/src/api/types/SshKey.js
+++ b/src/api/types/SshKey.js
@@ -99,9 +99,13 @@ export class SshKey extends Resource {
   toString() {
     const propStr = `${super.toString()}, namespace: ${logValue(
       this.namespace.name
-    )}, publicKey: "${this.publicKey.slice(0, 15)}..${this.publicKey.slice(
-      -15
-    )}"`;
+    )}, publicKey: "${
+      // NOTE: some public keys can have newlines at the end for some reason
+      this.publicKey.slice(0, 15).replaceAll('\n', '')
+    }..${
+      // NOTE: some public keys can have newlines at the end for some reason
+      this.publicKey.slice(-15).replaceAll('\n', '')
+    }"`;
 
     if (Object.getPrototypeOf(this).constructor === SshKey) {
       return `{SshKey ${propStr}}`;

--- a/src/common/Cloud.js
+++ b/src/common/Cloud.js
@@ -847,7 +847,7 @@ export class Cloud extends EventDispatcher {
             throw new Error(
               `Cannot add unknown namespace ${logValue(
                 name
-              )} to synced set in cloud=${this}`
+              )} to synced set in cloud=${logValue(this.cloudUrl)}`
             );
           }
 
@@ -863,7 +863,7 @@ export class Cloud extends EventDispatcher {
             throw new Error(
               `Cannot add unknown namespace ${logValue(
                 name
-              )} to ignored set in cloud=${this}`
+              )} to ignored set in cloud=${logValue(this.cloudUrl)}`
             );
           }
 
@@ -912,7 +912,7 @@ export class Cloud extends EventDispatcher {
           throw new Error(
             `cloudUrl cannot be changed; spec.cloudUrl=${logValue(
               spec.cloudUrl
-            )}, cloud=${this}`
+            )}, cloud=${logValue(this.cloudUrl)}`
           );
         }
 
@@ -985,6 +985,8 @@ export class Cloud extends EventDispatcher {
 
     // tokens are tied to the user, so clear that too
     this.username = null;
+
+    logger.log('Cloud.resetTokens()', `Tokens reset; cloud=${this}`);
   }
 
   /**
@@ -1028,6 +1030,8 @@ export class Cloud extends EventDispatcher {
     } else {
       this.refreshTokenValidTill = new Date(now + this.refreshExpiresIn * 1000);
     }
+
+    logger.log('Cloud.updateTokens()', `Tokens updated; cloud=${this}`);
   }
 
   /**

--- a/src/main/SyncManager.js
+++ b/src/main/SyncManager.js
@@ -237,7 +237,7 @@ export class SyncManager extends Singleton {
 
     // NOTE: just in case the delete came at a strange time during sync, the most effective,
     //  sure way of removing the entities is not to loop through `dataCloud.syncedNamespaces`,
-    //  but rather to simply find all entities related to its `dataCloud.cloud.cloudUrl` and
+    //  but rather to simply find all entities related to its `dataCloud.cloudUrl` and
     //  just remove them
     let deleteCount = 0;
 
@@ -254,7 +254,7 @@ export class SyncManager extends Singleton {
         while (
           (idx = list.findIndex((item) => {
             // entities and models have the same basic interface
-            return item.metadata.cloudUrl === dataCloud.cloud.cloudUrl;
+            return item.metadata.cloudUrl === dataCloud.cloudUrl;
           })) >= 0
         ) {
           const item = list[idx];
@@ -518,7 +518,7 @@ export class SyncManager extends Singleton {
       (idx = this.catalogSource.findIndex((entity) => {
         return (
           kinds.includes(entity.metadata.kind) &&
-          entity.metadata.cloudUrl === dataCloud.cloud.cloudUrl &&
+          entity.metadata.cloudUrl === dataCloud.cloudUrl &&
           !cloudResourceIds[entity.metadata.uid]
         );
       })) >= 0
@@ -567,7 +567,7 @@ export class SyncManager extends Singleton {
       (idx = storeList.findIndex((model) => {
         // the UID should be unique, but just to be extra safe, we compare the Cloud URL too
         return (
-          model.metadata.cloudUrl === dataCloud.cloud.cloudUrl &&
+          model.metadata.cloudUrl === dataCloud.cloudUrl &&
           !cloudResourceIds[model.metadata.uid]
         );
       })) >= 0
@@ -775,7 +775,11 @@ export class SyncManager extends Singleton {
       this.ipcMain.capture(
         'info',
         'SyncManager.updateClusterEntities()',
-        `Have added=${newEntities.length}, updated=${catUpdateCount}, deleted=${catDelCount} cluster Catalog entities for dataCloud=${dataCloud}`
+        `Have added=${
+          newEntities.length
+        }, updated=${catUpdateCount}, deleted=${catDelCount} cluster Catalog entities for dataCloud=${logValue(
+          dataCloud.cloudUrl
+        )}`
       );
 
       // add all the new models to the temporary store
@@ -784,7 +788,11 @@ export class SyncManager extends Singleton {
       this.ipcMain.capture(
         'info',
         'SyncManager.updateClusterEntities()',
-        `Will add=${newModels.length}, update=${storeUpdateCount}, delete=${storeDelCount} cluster SyncStore models for dataCloud=${dataCloud}`
+        `Will add=${
+          newModels.length
+        }, update=${storeUpdateCount}, delete=${storeDelCount} cluster SyncStore models for dataCloud=${logValue(
+          dataCloud.cloudUrl
+        )}`
       );
 
       this.ipcMain.capture(
@@ -891,7 +899,11 @@ export class SyncManager extends Singleton {
       this.ipcMain.capture(
         'info',
         'SyncManager.updateCatalogEntities()',
-        `Have added=${newEntities.length}, updated=${catUpdateCount}, deleted=${catDelCount} ${type} Catalog entities for dataCloud=${dataCloud}`
+        `Have added=${
+          newEntities.length
+        }, updated=${catUpdateCount}, deleted=${catDelCount} ${type} Catalog entities for dataCloud=${logValue(
+          dataCloud.cloudUrl
+        )}`
       );
 
       // add all the new models to the temporary store
@@ -900,7 +912,11 @@ export class SyncManager extends Singleton {
       this.ipcMain.capture(
         'info',
         'SyncManager.updateCatalogEntities()',
-        `Will add=${newModels.length}, update=${storeUpdateCount}, delete=${storeDelCount} ${type} SyncStore models for dataCloud=${dataCloud}`
+        `Will add=${
+          newModels.length
+        }, update=${storeUpdateCount}, delete=${storeDelCount} ${type} SyncStore models for dataCloud=${logValue(
+          dataCloud.cloudUrl
+        )}`
       );
     });
 
@@ -1118,7 +1134,7 @@ export class SyncManager extends Singleton {
         this.ipcMain.capture(
           'info',
           'SyncManager.handleSyncNow()',
-          `Syncing now; dataCloud=${dc}`
+          `Syncing now; dataCloud=${logValue(cloudUrl)}`
         );
         dc.fetchNow();
       } else {
@@ -1149,7 +1165,7 @@ export class SyncManager extends Singleton {
         this.ipcMain.capture(
           'info',
           'SyncManager.handleReconnect()',
-          `Reconnecting; dataCloud=${dc}`
+          `Reconnecting; dataCloud=${logValue(cloudUrl)}`
         );
         dc.reconnect();
       } else {

--- a/src/store/CloudStore.js
+++ b/src/store/CloudStore.js
@@ -182,7 +182,7 @@ export class CloudStore extends Common.Store.ExtensionStore {
         'CloudStore.onCloudChange()',
         `<${this.ipcMain ? 'MAIN' : 'RENDERER'}> Processing event=${logValue(
           name
-        )} on cloud=${cloud}`
+        )} on cloud=${logValue(cloud.cloudUrl)}`
       );
 
       // NOTE: this event doesn't mean we have a new Cloud instance; it just means
@@ -235,7 +235,9 @@ export class CloudStore extends Common.Store.ExtensionStore {
     if (this.ipcMain) {
       logger.log(
         'CloudStore.listenForChanges()',
-        `<MAIN> Subscribing to ALL EXCEPT loading/fetching/prop changes for cloud=${cloud}`
+        `<MAIN> Subscribing to ALL EXCEPT loading/fetching/prop changes for cloud=${logValue(
+          cloud.cloudUrl
+        )}`
       );
       const excludedEvents = [
         CLOUD_EVENTS.LOADED_CHANGE, // not stored on disk
@@ -248,7 +250,9 @@ export class CloudStore extends Common.Store.ExtensionStore {
     } else {
       logger.log(
         'CloudStore.listenForChanges()',
-        `<RENDERER> Subscribing to ONLY sync and prop changes for cloud=${cloud}`
+        `<RENDERER> Subscribing to ONLY sync and prop changes for cloud=${logValue(
+          cloud.cloudUrl
+        )}`
       );
       eventNames = [
         CLOUD_EVENTS.SYNC_CHANGE, // selective sync changes only happend on RENDERER

--- a/src/strings.ts
+++ b/src/strings.ts
@@ -110,10 +110,20 @@ export const managementClusters = {
   },
 };
 
+export const dataCloud: Dict = {
+  error: {
+    fetchErrorsOccurred: () =>
+      'At least one error occurred while fetching resources',
+  },
+};
+
 export const apiUtil: Dict = {
   error: {
     sessionExpired: () => 'Session expired',
     invalidCredentials: () => 'Invalid credentials',
+    noTokens: () => 'Access token is missing',
+    invalidResourceType: (type) =>
+      `Unknown or unmapped resource type "${type}"`,
   },
 };
 


### PR DESCRIPTION
After letting Lens sit open for a while, I hit this corner case where
the refresh token expired and couldn't be renewed while fetching
namespaces, resulting in ignoring the error and processing the
data as though all namespaces had been removed.

That resulted in losing all sync settings and all items being removed
from the Catalog.

To make matters worse, I had 'sync all' enabled, so when I reconnected,
we immediately _discovered_ all these _new_ namespaces and auto-synced
all 70 of them... Not what I wanted, although it did work and was
fairly performant (proving some of the recent work to optimize
fetching has paid off).

So this PR fixes this corner case. I let Lens sit open for 6 hours
untouched and it was still connected and still syncing just fine
with these changes.

The resiliency primarily comes from `DataCloud#fetchData()` looking
for any errors during fetch, discarding the results (instead of
processing them), and scheduling a subsequent fetch just 30 seconds
later instead of waiting another 5 minutes. If that fetch is successful,
then the result ~5 minute interval resumes.

Also:
- Reduced the verbosity of some log statements that were including
  the full Cloud or DataCloud toString() result to be just the
  cloud URL.
- Added `DataCloud#cloudUrl` getter shortcut.