### PR TITLE
[PRODX-22315] Ignore terminated namespaces

### DIFF
--- a/src/api/apiConstants.js
+++ b/src/api/apiConstants.js
@@ -126,3 +126,12 @@ export const apiChangeTypes = Object.freeze({
   MODIFIED: 'MODIFIED',
   DELETED: 'DELETED',
 });
+
+/**
+ * Map of API namespace (status) phases to value.
+ * @type {{ [index: string], string }}
+ */
+export const apiNamespacePhases = Object.freeze({
+  ACTIVE: 'Active',
+  TERMINATING: 'Terminating',
+});

--- a/src/catalog/catalogEntities.js
+++ b/src/catalog/catalogEntities.js
@@ -107,7 +107,9 @@ export const catalogEntityModelTs = {
   },
 };
 
-/** Map of phase name to phase value as understood by Lens. */
+/**
+ * Map of phase name to LENS phase value (related to Lens' connection status with the cluster).
+ */
 export const clusterEntityPhases = Object.freeze({
   CONNECTING: 'connecting',
   CONNECTED: 'connected',

--- a/src/common/DataCloud.js
+++ b/src/common/DataCloud.js
@@ -16,6 +16,7 @@ import {
   apiResourceTypes,
   apiCredentialTypes,
   apiChangeTypes,
+  apiNamespacePhases,
 } from '../api/apiConstants';
 import * as strings from '../strings';
 
@@ -697,7 +698,9 @@ const _fetchNamespaces = async function (cloud, preview = false) {
     namespaces: filter(
       namespaces,
       (ns) =>
-        !ignoredNamespaces.includes(ns.name) && hasReadPermissions(ns.name)
+        ns.phase !== apiNamespacePhases.TERMINATING &&
+        !ignoredNamespaces.includes(ns.name) &&
+        hasReadPermissions(ns.name)
     ),
     watches,
     tokensRefreshed,


### PR DESCRIPTION
When discovering namespaces, ignore ones that still exist, but have
been terminated.