### PR TITLE
Add NamedResource base class for all namespaced resources

### DIFF
--- a/src/api/types/Cluster.js
+++ b/src/api/types/Cluster.js
@@ -2,8 +2,7 @@ import * as rtv from 'rtvjs';
 import { get, merge } from 'lodash';
 import { Common } from '@k8slens/extensions';
 import { mergeRtvShapes } from '../../util/mergeRtvShapes';
-import { resourceTs } from './Resource';
-import { Node } from './Node';
+import { Node, nodeTs } from './Node';
 import {
   entityLabels,
   clusterEntityPhases,
@@ -29,7 +28,7 @@ const getServerUrl = function (data) {
 /**
  * Typeset for an MCC Cluster API resource.
  */
-export const clusterTs = mergeRtvShapes({}, resourceTs, {
+export const clusterTs = mergeRtvShapes({}, nodeTs, {
   // NOTE: this is not intended to be fully-representative; we only list the properties
   //  related to what we expect to find in order to create a `Credential` class instance
 

--- a/src/api/types/Credential.js
+++ b/src/api/types/Credential.js
@@ -2,19 +2,17 @@ import * as rtv from 'rtvjs';
 import { merge, pick } from 'lodash';
 import { mergeRtvShapes } from '../../util/mergeRtvShapes';
 import { apiCredentialKinds, apiLabels } from '../apiConstants';
-import { Resource, resourceTs } from './Resource';
-import { Namespace } from './Namespace';
+import { NamedResource, namedResourceTs } from './NamedResource';
 import { entityLabels } from '../../catalog/catalogEntities';
 import {
   CredentialEntity,
   credentialEntityPhases,
 } from '../../catalog/CredentialEntity';
-import { logValue } from '../../util/logger';
 
 /**
  * Typeset for an MCC Credential API resource.
  */
-export const credentialTs = mergeRtvShapes({}, resourceTs, {
+export const credentialTs = mergeRtvShapes({}, namedResourceTs, {
   // NOTE: this is not intended to be fully-representative; we only list the properties
   //  related to what we expect to find in order to create a `Credential` class instance
 
@@ -40,7 +38,7 @@ export const credentialTs = mergeRtvShapes({}, resourceTs, {
  * MCC credential API resource.
  * @class Credential
  */
-export class Credential extends Resource {
+export class Credential extends NamedResource {
   /**
    * @constructor
    * @param {Object} params
@@ -51,28 +49,13 @@ export class Credential extends Resource {
   constructor({ data, namespace, cloud }) {
     super({
       data,
+      namespace,
       cloud,
       // NOTE: BYOCredential objects do not have a `status` for some reason
       typeset:
         data.kind === apiCredentialKinds.BYO_CREDENTIAL
           ? pick(credentialTs, ['metadata', 'spec'])
           : credentialTs,
-    });
-
-    DEV_ENV &&
-      rtv.verify(
-        { namespace },
-        {
-          namespace: [rtv.CLASS_OBJECT, { ctor: Namespace }],
-        }
-      );
-
-    /** @member {Namespace} namespace */
-    Object.defineProperty(this, 'namespace', {
-      enumerable: true,
-      get() {
-        return namespace;
-      },
     });
 
     /** @member {string} region */
@@ -139,9 +122,7 @@ export class Credential extends Resource {
 
   /** @returns {string} A string representation of this instance for logging/debugging. */
   toString() {
-    const propStr = `${super.toString()}, namespace: ${logValue(
-      this.namespace.name
-    )}, valid: ${this.valid}`;
+    const propStr = `${super.toString()}, valid: ${this.valid}`;
 
     if (Object.getPrototypeOf(this).constructor === Credential) {
       return `{Credential ${propStr}}`;

--- a/src/api/types/License.js
+++ b/src/api/types/License.js
@@ -1,20 +1,18 @@
 import * as rtv from 'rtvjs';
 import { merge } from 'lodash';
 import { mergeRtvShapes } from '../../util/mergeRtvShapes';
-import { Resource, resourceTs } from './Resource';
-import { Namespace } from './Namespace';
+import { NamedResource, namedResourceTs } from './NamedResource';
 import { entityLabels } from '../../catalog/catalogEntities';
 import {
   LicenseEntity,
   licenseEntityPhases,
 } from '../../catalog/LicenseEntity';
 import { apiKinds } from '../apiConstants';
-import { logValue } from '../../util/logger';
 
 /**
  * Typeset for an MCC License API resource.
  */
-export const licenseTs = mergeRtvShapes({}, resourceTs, {
+export const licenseTs = mergeRtvShapes({}, namedResourceTs, {
   // NOTE: this is not intended to be fully-representative; we only list the properties
   //  related to what we expect to find in order to create a `Credential` class instance
 
@@ -25,7 +23,7 @@ export const licenseTs = mergeRtvShapes({}, resourceTs, {
  * MCC license API resource.
  * @class License
  */
-export class License extends Resource {
+export class License extends NamedResource {
   /**
    * @constructor
    * @param {Object} params
@@ -34,23 +32,7 @@ export class License extends Resource {
    * @param {Cloud} params.cloud Reference to the Cloud used to get the data.
    */
   constructor({ data, namespace, cloud }) {
-    super({ data, cloud, typeset: licenseTs });
-
-    DEV_ENV &&
-      rtv.verify(
-        { namespace },
-        {
-          namespace: [rtv.CLASS_OBJECT, { ctor: Namespace }],
-        }
-      );
-
-    /** @member {Namespace} namespace */
-    Object.defineProperty(this, 'namespace', {
-      enumerable: true,
-      get() {
-        return namespace;
-      },
-    });
+    super({ data, namespace, cloud, typeset: licenseTs });
   }
 
   /**
@@ -86,9 +68,7 @@ export class License extends Resource {
 
   /** @returns {string} A string representation of this instance for logging/debugging. */
   toString() {
-    const propStr = `${super.toString()}, namespace: ${logValue(
-      this.namespace.name
-    )}`;
+    const propStr = `${super.toString()}`;
 
     if (Object.getPrototypeOf(this).constructor === License) {
       return `{License ${propStr}}`;

--- a/src/api/types/Machine.js
+++ b/src/api/types/Machine.js
@@ -1,14 +1,13 @@
 import * as rtv from 'rtvjs';
 import { mergeRtvShapes } from '../../util/mergeRtvShapes';
 import { apiKinds, apiLabels } from '../apiConstants';
-import { resourceTs } from './Resource';
-import { Node } from './Node';
+import { Node, nodeTs } from './Node';
 import { logger, logValue } from '../../util/logger';
 
 /**
  * Typeset for an MCC Machine API resource.
  */
-export const machineTs = mergeRtvShapes({}, resourceTs, {
+export const machineTs = mergeRtvShapes({}, nodeTs, {
   // NOTE: this is not intended to be fully-representative; we only list the properties
   //  related to what we expect to find in order to create a `Credential` class instance
 

--- a/src/api/types/NamedResource.js
+++ b/src/api/types/NamedResource.js
@@ -1,0 +1,63 @@
+import * as rtv from 'rtvjs';
+import { mergeRtvShapes } from '../../util/mergeRtvShapes';
+import { Resource, resourceTs } from './Resource';
+import { Namespace } from './Namespace';
+import { logValue } from '../../util/logger';
+
+/**
+ * Typeset for an MCC namespaced API resource.
+ */
+export const namedResourceTs = mergeRtvShapes({}, resourceTs, {
+  // NOTE: this is not intended to be fully-representative; we only list the properties
+  //  related to what we expect to find in order to create a `Credential` class instance
+  // nothing specific for now
+});
+
+/**
+ * MCC resource that lives in a namespace as opposed to a cluster-wide resource
+ *  like a Namespace.
+ * @class NamedResource
+ */
+export class NamedResource extends Resource {
+  /**
+   * @constructor
+   * @param {Object} params
+   * @param {Object} params.data Raw data payload from the API.
+   * @param {Namespace} params.namespace Namespace to which the object belongs.
+   * @param {Cloud} params.cloud Reference to the Cloud used to get the data.
+   * @param {rtv.Typeset} params.typeset Typeset for verifying the data.
+   */
+  constructor({ data, namespace, cloud, typeset }) {
+    super({ data, cloud, typeset });
+
+    DEV_ENV &&
+      rtv.verify(
+        { namespace },
+        {
+          namespace: [rtv.CLASS_OBJECT, { ctor: Namespace }],
+        }
+      );
+
+    /** @member {Namespace} namespace */
+    Object.defineProperty(this, 'namespace', {
+      enumerable: true,
+      get() {
+        return namespace;
+      },
+    });
+  }
+
+  /** @returns {string} A string representation of this instance for logging/debugging. */
+  toString() {
+    const propStr = `${super.toString()}, namespace: ${logValue(
+      this.namespace.name
+    )}`;
+
+    if (Object.getPrototypeOf(this).constructor === NamedResource) {
+      return `{NamedResource ${propStr}}`;
+    }
+
+    // this is actually an extended class instance, so return only the properties
+    return propStr;
+  }
+}

--- a/src/api/types/Node.js
+++ b/src/api/types/Node.js
@@ -1,14 +1,22 @@
-import * as rtv from 'rtvjs';
+import { mergeRtvShapes } from '../../util/mergeRtvShapes';
 import { apiKinds, apiLabels } from '../apiConstants';
-import { Resource } from './Resource';
-import { Namespace } from './Namespace';
+import { NamedResource, namedResourceTs } from './NamedResource';
 import * as strings from '../../strings';
+
+/**
+ * Typeset for a namespaced Machine and Cluster resources.
+ */
+export const nodeTs = mergeRtvShapes({}, namedResourceTs, {
+  // NOTE: this is not intended to be fully-representative; we only list the properties
+  //  related to what we expect to find in order to create a `Credential` class instance
+  // nothing specific for now
+});
 
 /**
  * Base class for namespaced Machine and Cluster resources.
  * @class Node
  */
-export class Node extends Resource {
+export class Node extends NamedResource {
   /**
    * @constructor
    * @param {Object} params
@@ -18,30 +26,7 @@ export class Node extends Resource {
    * @param {rtv.Typeset} params.typeset Typeset for verifying the data.
    */
   constructor({ data, namespace, cloud, typeset }) {
-    super({
-      data,
-      cloud,
-      typeset,
-    });
-
-    DEV_ENV &&
-      rtv.verify(
-        { namespace },
-        {
-          namespace: [rtv.CLASS_OBJECT, { ctor: Namespace }],
-        }
-      );
-
-    /**
-     * @readonly
-     * @member {Namespace} namespace
-     */
-    Object.defineProperty(this, 'namespace', {
-      enumerable: true,
-      get() {
-        return namespace;
-      },
-    });
+    super({ data, namespace, cloud, typeset });
 
     /**
      * @readonly
@@ -129,5 +114,17 @@ export class Node extends Resource {
         return !!data.status?.providerStatus?.ready;
       },
     });
+  }
+
+  /** @returns {string} A string representation of this instance for logging/debugging. */
+  toString() {
+    const propStr = `${super.toString()}`;
+
+    if (Object.getPrototypeOf(this).constructor === Node) {
+      return `{Node ${propStr}}`;
+    }
+
+    // this is actually an extended class instance, so return only the properties
+    return propStr;
   }
 }

--- a/src/api/types/Proxy.js
+++ b/src/api/types/Proxy.js
@@ -1,8 +1,7 @@
 import * as rtv from 'rtvjs';
 import { merge } from 'lodash';
 import { mergeRtvShapes } from '../../util/mergeRtvShapes';
-import { Resource, resourceTs } from './Resource';
-import { Namespace } from './Namespace';
+import { NamedResource, namedResourceTs } from './NamedResource';
 import { entityLabels } from '../../catalog/catalogEntities';
 import { ProxyEntity, proxyEntityPhases } from '../../catalog/ProxyEntity';
 import { apiKinds, apiLabels } from '../apiConstants';
@@ -11,7 +10,7 @@ import { logValue } from '../../util/logger';
 /**
  * Typeset for an MCC Proxy API resource.
  */
-export const proxyTs = mergeRtvShapes({}, resourceTs, {
+export const proxyTs = mergeRtvShapes({}, namedResourceTs, {
   // NOTE: this is not intended to be fully-representative; we only list the properties
   //  related to what we expect to find in order to create a `Credential` class instance
 
@@ -34,7 +33,7 @@ export const proxyTs = mergeRtvShapes({}, resourceTs, {
  * MCC proxy API resource.
  * @class Proxy
  */
-export class Proxy extends Resource {
+export class Proxy extends NamedResource {
   /**
    * @constructor
    * @param {Object} params
@@ -43,21 +42,7 @@ export class Proxy extends Resource {
    * @param {Cloud} params.cloud Reference to the Cloud used to get the data.
    */
   constructor({ data, namespace, cloud }) {
-    super({ data, cloud, typeset: proxyTs });
-
-    DEV_ENV &&
-      rtv.verify(
-        { namespace },
-        { namespace: [rtv.CLASS_OBJECT, { ctor: Namespace }] }
-      );
-
-    /** @member {Namespace} namespace */
-    Object.defineProperty(this, 'namespace', {
-      enumerable: true,
-      get() {
-        return namespace;
-      },
-    });
+    super({ data, namespace, cloud, typeset: proxyTs });
 
     /** @member {string} region */
     Object.defineProperty(this, 'region', {
@@ -122,9 +107,9 @@ export class Proxy extends Resource {
 
   /** @returns {string} A string representation of this instance for logging/debugging. */
   toString() {
-    const propStr = `${super.toString()}, namespace: ${logValue(
-      this.namespace.name
-    )}, http: ${logValue(this.httpProxy)}, https: ${logValue(this.httpsProxy)}`;
+    const propStr = `${super.toString()}, http: ${logValue(
+      this.httpProxy
+    )}, https: ${logValue(this.httpsProxy)}`;
 
     if (Object.getPrototypeOf(this).constructor === Proxy) {
       return `{Proxy ${propStr}}`;

--- a/src/api/types/SshKey.js
+++ b/src/api/types/SshKey.js
@@ -1,17 +1,15 @@
 import * as rtv from 'rtvjs';
 import { merge } from 'lodash';
 import { mergeRtvShapes } from '../../util/mergeRtvShapes';
-import { Resource, resourceTs } from './Resource';
-import { Namespace } from './Namespace';
+import { NamedResource, namedResourceTs } from './NamedResource';
 import { entityLabels } from '../../catalog/catalogEntities';
 import { SshKeyEntity, sshKeyEntityPhases } from '../../catalog/SshKeyEntity';
 import { apiKinds } from '../apiConstants';
-import { logValue } from '../../util/logger';
 
 /**
  * Typeset for an MCC SSH Key API resource.
  */
-export const sshKeyTs = mergeRtvShapes({}, resourceTs, {
+export const sshKeyTs = mergeRtvShapes({}, namedResourceTs, {
   // NOTE: this is not intended to be fully-representative; we only list the properties
   //  related to what we expect to find in order to create a `Credential` class instance
 
@@ -25,7 +23,7 @@ export const sshKeyTs = mergeRtvShapes({}, resourceTs, {
  * MCC ssh key API resource.
  * @class SshKey
  */
-export class SshKey extends Resource {
+export class SshKey extends NamedResource {
   /**
    * @constructor
    * @param {Object} params
@@ -34,23 +32,7 @@ export class SshKey extends Resource {
    * @param {Cloud} params.cloud Reference to the Cloud used to get the data.
    */
   constructor({ data, namespace, cloud }) {
-    super({ data, cloud, typeset: sshKeyTs });
-
-    DEV_ENV &&
-      rtv.verify(
-        { namespace },
-        {
-          namespace: [rtv.CLASS_OBJECT, { ctor: Namespace }],
-        }
-      );
-
-    /** @member {Namespace} namespace */
-    Object.defineProperty(this, 'namespace', {
-      enumerable: true,
-      get() {
-        return namespace;
-      },
-    });
+    super({ data, namespace, cloud, typeset: sshKeyTs });
 
     /** @member {string} publicKey */
     Object.defineProperty(this, 'publicKey', {
@@ -97,9 +79,7 @@ export class SshKey extends Resource {
 
   /** @returns {string} A string representation of this instance for logging/debugging. */
   toString() {
-    const propStr = `${super.toString()}, namespace: ${logValue(
-      this.namespace.name
-    )}, publicKey: "${
+    const propStr = `${super.toString()}, publicKey: "${
       // NOTE: some public keys can have newlines at the end for some reason
       this.publicKey.slice(0, 15).replaceAll('\n', '')
     }..${


### PR DESCRIPTION
This also fixes a bug where Cluster and Machine resources didn't include their
namespace name in their toString debug log output, completes the inheritance
chain, and simplifies/centralizes the code.