### PR TITLE
[PRODX-23850] Expose MKE and StackLight URLs in cluster details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ⚠️ This is an early release build and is not fully tested.
 
 - The `kubelogin` license is now included alongside the binaries.
+- The Mirantis Kubernetes Engine dashboard URL is now included (and clickable) in the cluster details panel (choose "View details" from the cluster's context menu).
+- The Mirantis StackLight URLs are now included (and clickable) in the cluster details panel, if StackLight is enabled on the cluster.
 
 ## v4.0.0-beta.0
 

--- a/src/catalog/catalogEntities.js
+++ b/src/catalog/catalogEntities.js
@@ -204,6 +204,18 @@ export const clusterEntityModelTs = mergeRtvShapes({}, catalogEntityModelTs, {
     region: rtv.STRING,
     provider: rtv.STRING,
     currentVersion: rtv.STRING,
+    dashboardUrl: rtv.STRING,
+    lma: [
+      rtv.EXPECTED, // could be null, or an object
+      {
+        alertaUrl: [rtv.OPTIONAL, rtv.STRING],
+        alertManagerUrl: [rtv.OPTIONAL, rtv.STRING],
+        grafanaUrl: [rtv.OPTIONAL, rtv.STRING],
+        kibanaUrl: [rtv.OPTIONAL, rtv.STRING],
+        prometheusUrl: [rtv.OPTIONAL, rtv.STRING],
+        telemeterServerUrl: [rtv.OPTIONAL, rtv.STRING],
+      },
+    ],
   },
 
   // based on Lens `KubernetesClusterStatus` type

--- a/src/common/DataCloud.js
+++ b/src/common/DataCloud.js
@@ -207,9 +207,13 @@ const _deserializeCollection = function (
       } catch (err) {
         logger.warn(
           'DataCloud._deserializeCollection()',
-          `Ignoring "${resourceType}" resource type ${idx}${
-            namespace ? ` from namespace=${logValue(namespace.name)}` : ''
-          }: Could not be deserialized, error="${getErrorMessage(err)}"`,
+          `Ignoring ${logValue(
+            resourceType
+          )} resource index=${idx}: Could not be deserialized; name=${logValue(
+            data?.metadata?.name
+          )}; namespace=${logValue(namespace.name)}; error="${getErrorMessage(
+            err
+          )}"`,
           err
         );
         return undefined;

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,10 +1,16 @@
 import { deepFreeze } from './util/deepFreeze';
 
+// maximum number of projects (inclusive), at which point the warning icon will appear
+//  about potential performance issues
+export const projectsCountBeforeWarning = 10;
+
+export const companyName = 'Mirantis';
 export const mccPascalName = 'Mcc'; // PascalCase, for prefixing with other names
 export const mccCodeName = mccPascalName.toUpperCase();
 export const mccShortName = 'Container Cloud';
-export const mccFullName = `Mirantis ${mccShortName}`;
-export const projectsCountBeforeWarning = 10; // The maximum number of projects, after which the warning icon will appear
+export const mccFullName = `${companyName} ${mccShortName}`;
+
+export const mkeCodeName = 'MKE';
 
 const mccEntityGroup = `entity.${mccCodeName}.dev`.toLowerCase();
 const lensCatalogGroup = 'catalog.k8slens.dev';

--- a/src/renderer/catalogEntityDetails.tsx
+++ b/src/renderer/catalogEntityDetails.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { Common, Renderer } from '@k8slens/extensions';
 import dayjs from 'dayjs';
 import dayjsRelativeTimePlugin from 'dayjs/plugin/relativeTime';
@@ -9,6 +9,7 @@ import { LicenseEntity } from '../catalog/LicenseEntity';
 import { LensKubernetesCluster } from '../catalog/catalogEntityTypes';
 import * as strings from '../strings';
 import * as consts from '../constants';
+import { openBrowser } from '../util/netUtil';
 
 dayjs.extend(dayjsRelativeTimePlugin);
 
@@ -46,69 +47,200 @@ export const catalogEntityDetails = [
       `${consts.catalog.entities.kubeCluster.group}/${consts.catalog.entities.kubeCluster.versions.v1alpha1}`,
     ],
     components: {
-      Details: (props: CatalogEntityDetailsProps<LensKubernetesCluster>) => (
-        <>
-          <DrawerTitle
-            title={strings.catalog.entities.common.details.title()}
-          />
-          <DrawerItem
-            name={strings.catalog.entities.common.details.props.uid()}
-          >
-            {props.entity.metadata.uid || unknownValue()}
-          </DrawerItem>
-          <DrawerItem
-            name={strings.catalog.entities.common.details.props.dateCreated()}
-          >
-            {getCreatedValue(props.entity.spec.createdAt)}
-          </DrawerItem>
-          <DrawerItem
-            name={strings.catalog.entities.cluster.details.props.managementCluster()}
-          >
-            {strings.catalog.entities.cluster.details.props.isManagementCluster(
-              props.entity.spec.isMgmtCluster
-            ) || unknownValue()}
-          </DrawerItem>
-          {props.entity.spec.isMgmtCluster && (
-            <>
-              <DrawerItem
-                name={strings.catalog.entities.cluster.details.props.url()}
-              >
-                {props.entity.metadata.cloudUrl || unknownValue()}
-              </DrawerItem>
-            </>
-          )}
-          <DrawerItem
-            name={strings.catalog.entities.cluster.details.props.region()}
-          >
-            {props.entity.spec.region || unknownValue()}
-          </DrawerItem>
-          <DrawerItem
-            name={strings.catalog.entities.cluster.details.props.provider()}
-          >
-            {props.entity.spec.provider || unknownValue()}
-          </DrawerItem>
-          <DrawerItem
-            name={strings.catalog.entities.cluster.details.props.mccStatus()}
-          >
-            {props.entity.spec.apiStatus || unknownValue()}
-          </DrawerItem>
-          <DrawerItem
-            name={strings.catalog.entities.cluster.details.props.release()}
-          >
-            {props.entity.spec.currentVersion || unknownValue()}
-          </DrawerItem>
-          <DrawerItem
-            name={strings.catalog.entities.cluster.details.props.managers()}
-          >
-            {props.entity.spec.controllerCount ?? unknownValue()}
-          </DrawerItem>
-          <DrawerItem
-            name={strings.catalog.entities.cluster.details.props.workers()}
-          >
-            {props.entity.spec.workerCount ?? unknownValue()}
-          </DrawerItem>
-        </>
-      ),
+      Details: (props: CatalogEntityDetailsProps<LensKubernetesCluster>) => {
+        const handleOpenDashboard = useCallback(
+          (event) => {
+            event.preventDefault();
+            openBrowser(props.entity.spec.dashboardUrl);
+          },
+          [props.entity.spec.dashboardUrl]
+        );
+
+        const handleOpenAlerta = useCallback(
+          (event) => {
+            event.preventDefault();
+            openBrowser(props.entity.spec.lma.alertaUrl);
+          },
+          [props.entity.spec.lma?.alertaUrl]
+        );
+        const handleOpenAlertManager = useCallback(
+          (event) => {
+            event.preventDefault();
+            openBrowser(props.entity.spec.lma.alertManagerUrl);
+          },
+          [props.entity.spec.lma?.alertManagerUrl]
+        );
+        const handleOpenGrafana = useCallback(
+          (event) => {
+            event.preventDefault();
+            openBrowser(props.entity.spec.lma.grafanaUrl);
+          },
+          [props.entity.spec.lma?.grafanaUrl]
+        );
+        const handleOpenKibana = useCallback(
+          (event) => {
+            event.preventDefault();
+            openBrowser(props.entity.spec.lma.kibanaUrl);
+          },
+          [props.entity.spec.lma?.kibanaUrl]
+        );
+        const handleOpenPrometheus = useCallback(
+          (event) => {
+            event.preventDefault();
+            openBrowser(props.entity.spec.lma.prometheusUrl);
+          },
+          [props.entity.spec.lma?.prometheusUrl]
+        );
+        const handleOpenTelemeterServer = useCallback(
+          (event) => {
+            event.preventDefault();
+            openBrowser(props.entity.spec.lma.telemeterServerUrl);
+          },
+          [props.entity.spec.lma?.telemeterServerUrl]
+        );
+
+        return (
+          <>
+            <DrawerTitle
+              title={strings.catalog.entities.common.details.title()}
+            />
+            <DrawerItem
+              name={strings.catalog.entities.common.details.props.uid()}
+            >
+              {props.entity.metadata.uid || unknownValue()}
+            </DrawerItem>
+            <DrawerItem
+              name={strings.catalog.entities.common.details.props.dateCreated()}
+            >
+              {getCreatedValue(props.entity.spec.createdAt)}
+            </DrawerItem>
+            <DrawerItem
+              name={strings.catalog.entities.cluster.details.props.managementCluster()}
+            >
+              {strings.catalog.entities.cluster.details.props.isManagementCluster(
+                props.entity.spec.isMgmtCluster
+              ) || unknownValue()}
+            </DrawerItem>
+            {props.entity.spec.isMgmtCluster && (
+              <>
+                <DrawerItem
+                  name={strings.catalog.entities.cluster.details.props.url()}
+                >
+                  {props.entity.metadata.cloudUrl || unknownValue()}
+                </DrawerItem>
+              </>
+            )}
+            <DrawerItem
+              name={strings.catalog.entities.cluster.details.props.region()}
+            >
+              {props.entity.spec.region || unknownValue()}
+            </DrawerItem>
+            <DrawerItem
+              name={strings.catalog.entities.cluster.details.props.provider()}
+            >
+              {props.entity.spec.provider || unknownValue()}
+            </DrawerItem>
+            <DrawerItem
+              name={strings.catalog.entities.cluster.details.props.mccStatus()}
+            >
+              {props.entity.spec.apiStatus || unknownValue()}
+            </DrawerItem>
+            <DrawerItem
+              name={strings.catalog.entities.cluster.details.props.release()}
+            >
+              {props.entity.spec.currentVersion || unknownValue()}
+            </DrawerItem>
+            <DrawerItem
+              name={strings.catalog.entities.cluster.details.props.managers()}
+            >
+              {props.entity.spec.controllerCount ?? unknownValue()}
+            </DrawerItem>
+            <DrawerItem
+              name={strings.catalog.entities.cluster.details.props.workers()}
+            >
+              {props.entity.spec.workerCount ?? unknownValue()}
+            </DrawerItem>
+            <DrawerItem
+              name={strings.catalog.entities.cluster.details.props.dashboardUrl()}
+            >
+              {props.entity.spec.dashboardUrl ? (
+                <a href="#" onClick={handleOpenDashboard}>
+                  {props.entity.spec.dashboardUrl}
+                </a>
+              ) : (
+                unknownValue()
+              )}
+            </DrawerItem>
+            {Object.keys(props.entity.spec.lma || {}).length > 0 ? (
+              <>
+                <DrawerTitle
+                  title={strings.catalog.entities.cluster.details.props.lma()}
+                />
+
+                {props.entity.spec.lma.alertaUrl ? (
+                  <DrawerItem
+                    name={strings.catalog.entities.cluster.details.props.alertaUrl()}
+                  >
+                    <a href="#" onClick={handleOpenAlerta}>
+                      {props.entity.spec.lma.alertaUrl}
+                    </a>
+                  </DrawerItem>
+                ) : null}
+
+                {props.entity.spec.lma.alertManagerUrl ? (
+                  <DrawerItem
+                    name={strings.catalog.entities.cluster.details.props.alertManagerUrl()}
+                  >
+                    <a href="#" onClick={handleOpenAlertManager}>
+                      {props.entity.spec.lma.alertManagerUrl}
+                    </a>
+                  </DrawerItem>
+                ) : null}
+
+                {props.entity.spec.lma.grafanaUrl ? (
+                  <DrawerItem
+                    name={strings.catalog.entities.cluster.details.props.grafanaUrl()}
+                  >
+                    <a href="#" onClick={handleOpenGrafana}>
+                      {props.entity.spec.lma.grafanaUrl}
+                    </a>
+                  </DrawerItem>
+                ) : null}
+
+                {props.entity.spec.lma.kibanaUrl ? (
+                  <DrawerItem
+                    name={strings.catalog.entities.cluster.details.props.kibanaUrl()}
+                  >
+                    <a href="#" onClick={handleOpenKibana}>
+                      {props.entity.spec.lma.kibanaUrl}
+                    </a>
+                  </DrawerItem>
+                ) : null}
+
+                {props.entity.spec.lma.prometheusUrl ? (
+                  <DrawerItem
+                    name={strings.catalog.entities.cluster.details.props.prometheusUrl()}
+                  >
+                    <a href="#" onClick={handleOpenPrometheus}>
+                      {props.entity.spec.lma.prometheusUrl}
+                    </a>
+                  </DrawerItem>
+                ) : null}
+
+                {props.entity.spec.lma.telemeterServerUrl ? (
+                  <DrawerItem
+                    name={strings.catalog.entities.cluster.details.props.telemeterServerUrl()}
+                  >
+                    <a href="#" onClick={handleOpenTelemeterServer}>
+                      {props.entity.spec.lma.telemeterServerUrl}
+                    </a>
+                  </DrawerItem>
+                ) : null}
+              </>
+            ) : null}
+          </>
+        );
+      },
     },
   },
   {

--- a/src/strings.ts
+++ b/src/strings.ts
@@ -7,7 +7,13 @@
 //
 
 import pkg from '../package.json';
-import { mccCodeName, mccShortName, mccFullName } from './constants';
+import {
+  companyName,
+  mccCodeName,
+  mccShortName,
+  mccFullName,
+  mkeCodeName,
+} from './constants';
 
 export type Prop = (...tokens: any[]) => string;
 
@@ -248,10 +254,18 @@ export const catalog: Dict = {
           url: () => 'URL',
           region: () => 'Region',
           provider: () => 'Provider',
-          mccStatus: () => 'MCC Status',
+          mccStatus: () => `${mccCodeName} Status`,
           release: () => 'Release',
           managers: () => 'Managers',
           workers: () => 'Workers',
+          dashboardUrl: () => `${mkeCodeName} dashboard`,
+          lma: () => `${companyName} StackLight`,
+          alertaUrl: () => 'Alerta',
+          alertManagerUrl: () => 'Alert Manager',
+          grafanaUrl: () => 'Grafana',
+          kibanaUrl: () => 'Kibana',
+          prometheusUrl: () => 'Prometheus',
+          telemeterServerUrl: () => 'Telemeter Server',
         },
       },
     },
@@ -289,7 +303,7 @@ export const catalog: Dict = {
         props: {
           provider: () => 'Provider',
           region: () => 'Region',
-          mccStatus: () => 'MCC Status',
+          mccStatus: () => `${mccCodeName} Status`,
         },
         info: {
           status: (valid) => (valid ? 'Valid' : 'Invalid'),

--- a/test/mocks/mockExtCloud.js
+++ b/test/mocks/mockExtCloud.js
@@ -40,7 +40,7 @@ export const mockDataCloud = {
           idpClientId: 'id',
           apiCertificate:
             'testsertificate==',
-          ucpUrl: 'https://123.12.123.1:1234',
+          dashboardUrl: 'https://123.12.123.1:1234',
           provider: 'provider-1',
           region: 'region-eu',
         },
@@ -67,7 +67,7 @@ export const mockDataCloud = {
           idpClientId: 'id',
           apiCertificate:
             'testsertificate==',
-          ucpUrl: 'https://123.12.123.1:1234',
+          dashboardUrl: 'https://123.12.123.1:1234',
           provider: 'provider-1',
           region: 'region-eu',
         },
@@ -120,7 +120,7 @@ export const mockDataCloud2 = {
           idpClientId: 'id',
           apiCertificate:
             'testsertificate==',
-          ucpUrl: 'https://123.12.123.1:1234',
+          dashboardUrl: 'https://123.12.123.1:1234',
           provider: 'provider-1',
           region: 'region-eu',
         },
@@ -147,7 +147,7 @@ export const mockDataCloud2 = {
           idpClientId: 'id',
           apiCertificate:
             'testsertificate==',
-          ucpUrl: 'https://123.12.123.1:1234',
+          dashboardUrl: 'https://123.12.123.1:1234',
           provider: 'provider-1',
           region: 'region-eu',
         },


### PR DESCRIPTION
StackLight URLs are only displayed if StackLight is enabled and
endpoints are available, and only the available endpoints are
displayed.

The MKE dashboard URL is always displayed since that is always
available.

All URLs are clickable and open in the user's default browser.

### Previews

#### WITH URLS

<img width="721" alt="Screen Shot 2022-05-06 at 1 43 51 PM" src="https://user-images.githubusercontent.com/2855350/167206172-ed6798aa-5827-471e-9c24-f5d1483155da.png">

#### WITHOUT URLS

<img width="722" alt="Screen Shot 2022-05-06 at 2 32 21 PM" src="https://user-images.githubusercontent.com/2855350/167206196-4d9ec750-103e-4f99-b588-5efc9784c93c.png">
