### PR TITLE
[PRODX-22916]: Added onSuspend and onResume events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - The `kubelogin` license is now included alongside the binaries.
 - The Mirantis Kubernetes Engine dashboard URL is now included (and clickable) in the cluster details panel (choose "View details" from the cluster's context menu).
 - The Mirantis StackLight URLs are now included (and clickable) in the cluster details panel, if StackLight is enabled on the cluster.
+- Added detection for power suspend/resume and network offline/online events to auto-stop/resume sync operations.
 
 ## v4.0.0-beta.0
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -122,13 +122,39 @@ export const ipcEvents = deepFreeze({
      */
     CLOUD_FETCHING_CHANGE: 'cloudFetchingChange',
 
-    SUSPEND: 'Main.Power.onSuspend',
-    RESUME: 'Main.Power.onResume',
-  },
+    /**
+     * System power is being suspended.
+     *
+     * Signature: `(event: string) => void`
+     */
+    POWER_SUSPEND: 'powerSuspend',
 
-  network: {
-    OFFLINE_EVENT: 'network:offline',
-    ONLINE_EVENT: 'network:online',
+    /**
+     * System power has been restored.
+     *
+     * Signature: `(event: string) => void`
+     */
+    POWER_RESUME: 'powerResume',
+
+    /**
+     * Network connection has dropped.
+     *
+     * NOTE: This is not 100% reliable because it's not always possible for Electron
+     *  to detect when the network is offline. For example, if the app is running in
+     *  a VM with its virtual network adapter configured to be "always on", yet the
+     *  host's network connection is dropped, the app will appear online when in fact
+     *  it's not.
+     *
+     * Signature: `(event: string) => void`
+     */
+    NETWORK_OFFLINE: 'networkOffline',
+
+    /**
+     * Network connection has been restored.
+     *
+     * Signature: `(event: string) => void`
+     */
+    NETWORK_ONLINE: 'networkOnline',
   },
 
   /** Invoked on the `main` process only. Returns a promise to be awaited. */

--- a/src/constants.js
+++ b/src/constants.js
@@ -121,6 +121,14 @@ export const ipcEvents = deepFreeze({
      * - `fetching`: New fetching state.
      */
     CLOUD_FETCHING_CHANGE: 'cloudFetchingChange',
+
+    SUSPEND: 'Main.Power.onSuspend',
+    RESUME: 'Main.Power.onResume',
+  },
+
+  network: {
+    OFFLINE_EVENT: 'network:offline',
+    ONLINE_EVENT: 'network:online',
   },
 
   /** Invoked on the `main` process only. Returns a promise to be awaited. */

--- a/src/main/IpcMain.js
+++ b/src/main/IpcMain.js
@@ -127,4 +127,14 @@ export class IpcMain extends Main.Ipc {
       fetching
     );
   }
+
+  /** Notifies listeners that power is being suspended. */
+  notifyPowerSuspend() {
+    this.broadcast(ipcEvents.broadcast.POWER_SUSPEND);
+  }
+
+  /** Notifies listeners that power has been restored. */
+  notifyPowerResume() {
+    this.broadcast(ipcEvents.broadcast.POWER_RESUME);
+  }
 }

--- a/src/main/SyncManager.js
+++ b/src/main/SyncManager.js
@@ -80,12 +80,14 @@ const kindToNamespaceProp = kindToSyncStoreProp; // same property names for now
  */
 export class SyncManager extends Singleton {
   /**
-   * @param {LensExtension} extension Extension instance.
-   * @param {Array<CatalogEntity>} catalogSource Registered Lens Catalog source.
-   * @param {IpcMain} ipcMain Singleton instance for sending/receiving messages to/from Renderer.
+   * @param {Object} params
+   * @param {LensExtension} params.extension Extension instance.
+   * @param {Array<CatalogEntity>} params.catalogSource Registered Lens Catalog source.
+   * @param {IpcMain} params.ipcMain Singleton instance for sending/receiving messages
+   *  to/from Renderer.
    * @constructor
    */
-  constructor(extension, catalogSource, ipcMain) {
+  constructor({ extension, catalogSource, ipcMain }) {
     super();
 
     let _dataClouds = {};
@@ -958,7 +960,7 @@ export class SyncManager extends Singleton {
           `Detected new Cloud, creating new DataCloud for it; cloud=${cloud}`
         );
 
-        const dataCloud = new DataCloud(cloud, false, this.ipcMain);
+        const dataCloud = new DataCloud({ cloud, ipc: this.ipcMain });
 
         dataCloud.addEventListener(
           DATA_CLOUD_EVENTS.DATA_UPDATED,
@@ -1311,7 +1313,7 @@ export class SyncManager extends Singleton {
 
     this.ipcMain.capture(
       'info',
-      '.onDataUpdated()',
+      'SyncManager.onDataUpdated()',
       `Done: Updated Catalog and SyncStore for changes in dataCloud=${dataCloud}`
     );
   };

--- a/src/main/SyncManager.js
+++ b/src/main/SyncManager.js
@@ -958,7 +958,7 @@ export class SyncManager extends Singleton {
           `Detected new Cloud, creating new DataCloud for it; cloud=${cloud}`
         );
 
-        const dataCloud = new DataCloud(cloud);
+        const dataCloud = new DataCloud(cloud, false, this.ipcMain);
 
         dataCloud.addEventListener(
           DATA_CLOUD_EVENTS.DATA_UPDATED,
@@ -1311,7 +1311,7 @@ export class SyncManager extends Singleton {
 
     this.ipcMain.capture(
       'info',
-      'SyncManager.onDataUpdated()',
+      '.onDataUpdated()',
       `Done: Updated Catalog and SyncStore for changes in dataCloud=${dataCloud}`
     );
   };

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -39,6 +39,8 @@ export default class ExtensionMain extends Main.LensExtension {
   onActivate() {
     logger.log('ExtensionMain.onActivate()', 'extension activated');
 
+    const ipc = IpcMain.createInstance(this);
+
     // NOTE: an extension can only have ONE registered Catalog Source
     this.addCatalogSource(consts.catalog.source, catalogSource);
 
@@ -49,6 +51,29 @@ export default class ExtensionMain extends Main.LensExtension {
 
     // AFTER load stores
     SyncManager.createInstance(this, catalogSource, IpcMain.getInstance());
+
+    /**
+     * @member {IpcMain} ipcMain I think this parameter should be passed from DataCloud.js
+     */
+    const onSuspend = (ipcMain) => {
+      ipcMain.broadcast(consts.ipcEvents.broadcast.SUSPEND);
+    };
+
+    /**
+     * @member {IpcMain} ipcMain I think this parameter should be passed from DataCloud.js
+     */
+    const onResume = (ipcMain) => {
+      ipcMain.broadcast(consts.ipcEvents.broadcast.RESUME);
+    };
+
+    // Not sure if this listeners should be here (another extension use them in main.ts)
+    ipc.listen(consts.ipcEvents.network.OFFLINE_EVENT, () => {
+      console.log('OFFLINE_EVENT');
+    });
+
+    ipc.listen(consts.ipcEvents.network.ONLINE_EVENT, () => {
+      console.log('ONLINE_EVENT');
+    });
   }
 
   onDeactivate() {

--- a/src/renderer/IpcRenderer.js
+++ b/src/renderer/IpcRenderer.js
@@ -37,4 +37,14 @@ export class IpcRenderer extends Renderer.Ipc {
     super(extension);
     this.listen(ipcEvents.broadcast.LOGGER, this.handleLogger);
   }
+
+  /** Notifies listeners that network connectivity has been dropped. */
+  notifyNetworkOffline() {
+    this.broadcast(ipcEvents.broadcast.NETWORK_OFFLINE);
+  }
+
+  /** Notifies listeners that network connectivity has been restored. */
+  notifyNetworkOnline() {
+    this.broadcast(ipcEvents.broadcast.NETWORK_ONLINE);
+  }
 }

--- a/src/renderer/components/GlobalPage/AddCloudInstance.js
+++ b/src/renderer/components/GlobalPage/AddCloudInstance.js
@@ -61,7 +61,11 @@ export const AddCloudInstance = ({ onAdd, onCancel }) => {
     setLoading(true);
 
     // just use a minimal preview instance since it's throw-away
-    const dc = new DataCloud(cloud, true, IpcRenderer.getInstance());
+    const dc = new DataCloud({
+      cloud,
+      preview: true,
+      ipc: IpcRenderer.getInstance(),
+    });
 
     const loadingListener = () => {
       // when DataCloud loaded, it means it contains all needed data

--- a/src/renderer/components/GlobalPage/AddCloudInstance.js
+++ b/src/renderer/components/GlobalPage/AddCloudInstance.js
@@ -6,6 +6,7 @@ import { ConnectionBlock } from './ConnectionBlock';
 import { SynchronizeBlock } from './SynchronizeBlock';
 import { CloseButton } from '../CloseButton/CloseButton';
 import { DataCloud, DATA_CLOUD_EVENTS } from '../../../common/DataCloud';
+import { IpcRenderer } from '../../IpcRenderer';
 import { Renderer } from '@k8slens/extensions';
 import { normalizeUrl } from '../../../util/netUtil';
 import { addCloudInstance } from '../../../strings';
@@ -60,7 +61,7 @@ export const AddCloudInstance = ({ onAdd, onCancel }) => {
     setLoading(true);
 
     // just use a minimal preview instance since it's throw-away
-    const dc = new DataCloud(cloud, true);
+    const dc = new DataCloud(cloud, true, IpcRenderer.getInstance());
 
     const loadingListener = () => {
       // when DataCloud loaded, it means it contains all needed data

--- a/src/renderer/renderer.tsx
+++ b/src/renderer/renderer.tsx
@@ -204,6 +204,14 @@ export default class ExtensionRenderer extends LensExtension {
   // METHODS
   //
 
+  protected handleNetworkOffline = () => {
+    IpcRenderer.getInstance().notifyNetworkOffline();
+  };
+
+  protected handleNetworkOnline = () => {
+    IpcRenderer.getInstance().notifyNetworkOnline();
+  };
+
   // WARNING: Lens calls this method more often that just when the extension
   //  gets activated. For example, it will call it _again_ if it adds a cluster
   //  page and the cluster page is activated.
@@ -236,6 +244,12 @@ export default class ExtensionRenderer extends LensExtension {
       );
     }
 
+    // NOTE: only the Renderer process has a window in Electron, so we listen here, but
+    //  still ultimately broadcast to all IPC listeners across both threads
+    // @see https://www.electronjs.org/docs/latest/tutorial/online-offline-events
+    window.addEventListener('offline', this.handleNetworkOffline);
+    window.addEventListener('online', this.handleNetworkOnline);
+
     // NOTE: Cluster page menu list must be STATIC. Checking here if the
     //  `Renderer.Catalog.catalogEntities.activeEntity` is an MCC cluster will
     //  not work. Neither will adding a mobx reaction like this
@@ -263,6 +277,9 @@ export default class ExtensionRenderer extends LensExtension {
   }
 
   onDeactivate() {
-    logger.log('ExtensionRenderer.onDeactivate()', 'extension deactivated');
+    logger.log('ExtensionRenderer.onDeactivate()', 'Extension deactivated');
+
+    window.removeEventListener('offline', this.handleNetworkOffline);
+    window.removeEventListener('online', this.handleNetworkOnline);
   }
 }


### PR DESCRIPTION
Adds power suspend/resume and network offline/online detection.

Note that network offline/online detection is not 100% reliable since Lens could be running
in a VM with its network adapter configured to be "always connected", which would result
in false-negatives if the host loses network connectivity (i.e. host goes offline, and we think
we're still connected because we don't receive an "offline" event).

---

I also realized, that we can debug in console IpcMain events. We can see network statuses in console.
<img width="566" alt="Screenshot 2022-05-16 at 14 15 36" src="https://user-images.githubusercontent.com/33761040/168630281-2c4e195b-38b7-457d-b883-aa3992afd83a.png">
