### PR TITLE
[PRODX-24171]: added tests for Loader component

### DIFF
--- a/__mocks__/@k8slens/extensions.js
+++ b/__mocks__/@k8slens/extensions.js
@@ -136,6 +136,26 @@ class KubernetesCluster {
   }
 }
 
+class Spinner extends React.Component {
+  static defaultProps = {
+    singleColor: true,
+    center: false,
+  };
+
+  render() {
+    const { center, singleColor, ...props } = this.props;
+
+    return (
+      <div
+        {...props}
+        className={`Spinner ${center ? 'center' : ''} ${
+          singleColor ? 'singleColor' : ''
+        }`}
+      />
+    );
+  }
+}
+
 export const Main = {
   K8sApi: {
     KubeObject: null,
@@ -211,6 +231,7 @@ export const Renderer = {
   Ipc,
   Component: {
     Select,
+    Spinner,
     Notifications: {
       error: () => {},
     },

--- a/src/renderer/components/__tests__/Loader.spec.js
+++ b/src/renderer/components/__tests__/Loader.spec.js
@@ -1,0 +1,31 @@
+import { render, screen } from 'testingUtility';
+import { Loader } from '../Loader';
+
+describe('/renderer/components/Loader', () => {
+  it('renders |with| a message', () => {
+    const message = 'test message';
+
+    render(<Loader message={message} />);
+
+    expect(screen.getByText(message)).toBeInTheDocument();
+    expect(
+      screen.getByText(message).parentNode.querySelector('.Spinner')
+    ).toBeInTheDocument();
+  });
+
+  it('renders |with| a message, which contain HTML', () => {
+    const message = 'test message';
+    const messageHtml = `<p>${message}</p>`;
+
+    render(<Loader message={messageHtml} />);
+
+    expect(screen.getByText(message)).toBeInTheDocument();
+  });
+
+  it('renders |without| a message', () => {
+    render(<Loader />);
+
+    expect(screen.queryBySelector('p')).not.toBeInTheDocument();
+    expect(document.querySelector('.Spinner')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
<img width="649" alt="Screenshot 2022-06-22 at 16 16 02" src="https://user-images.githubusercontent.com/33761040/175038652-13352f1d-2d86-46aa-b248-11c9c422b218.png">
I think I covered all UI, and we have no logic here, but I received only 75% coverage of `Branch` column.

UPD: now it covered 100%. Screen attached
<img width="633" alt="Screenshot 2022-06-23 at 01 06 53" src="https://user-images.githubusercontent.com/33761040/175160714-cab4f786-6ba1-43d7-b38b-42549ca3fdfc.png">
