### PR TITLE
Add Wizard component for use with Create Cluster wizard

### DIFF
--- a/__mocks__/@k8slens/extensions.js
+++ b/__mocks__/@k8slens/extensions.js
@@ -4,6 +4,7 @@ import React from 'react';
 import propTypes from 'prop-types';
 import ReactSelect, { components } from 'react-select';
 import ReactSelectCreatable from 'react-select/creatable';
+import { cx } from '@emotion/css';
 
 const { Menu: SelectMenu } = components;
 
@@ -251,9 +252,9 @@ export class ConfirmDialog extends React.Component {
   }
 }
 
-const Button = ({ label, primary, ...props }) => {
+const Button = ({ label, primary, waiting, ...props }) => {
   return (
-    <button className={primary ? 'primary' : ''} {...props}>
+    <button className={cx({ primary, waiting })} {...props}>
       {label}
     </button>
   );
@@ -262,14 +263,11 @@ const Button = ({ label, primary, ...props }) => {
 Button.propTypes = {
   label: propTypes.string,
   primary: propTypes.bool,
+  waiting: propTypes.bool,
 };
 
 export const Icon = ({ interactive, smallest, ...props }) => {
-  const classes = [
-    smallest ? 'smallest' : '',
-    interactive ? 'interactive' : '',
-  ];
-  return <i className={classes.join()} {...props} />;
+  return <i className={cx({ smallest, interactive })} {...props} />;
 };
 
 Icon.propTypes = {
@@ -368,6 +366,39 @@ class ExtensionStore extends Singleton {
   }
 }
 
+const createNotification = function (status, message, { timeout = 5000 }) {
+  if (!['ok', 'info', 'error'].includes(status)) {
+    throw new Error(`Mock: Unsupported notification type "${status}"`);
+  }
+
+  const noteEl = document.createElement('div');
+  noteEl.className = `notification ${status}`;
+  noteEl.innerHTML = `
+    <div class="message">${message || ''}</div>
+  `;
+
+  document.body.appendChild(noteEl);
+
+  if (timeout > 0) {
+    setTimeout(() => document.body.removeChild(noteEl), timeout);
+  }
+};
+
+const Notifications = {
+  ok(message, options) {
+    createNotification('ok', message, options);
+  },
+  info(message, options) {
+    createNotification('info', message, options);
+  },
+  shortInfo(message, options) {
+    createNotification('info', message, options);
+  },
+  error(message, options) {
+    createNotification('error', message, options);
+  },
+};
+
 export const Common = {
   Catalog: {
     KubernetesCluster,
@@ -430,9 +461,7 @@ export const Renderer = {
   Component: {
     Select,
     Spinner,
-    Notifications: {
-      error: () => {},
-    },
+    Notifications,
     Button,
     Icon,
     Tooltip,

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "@babel/preset-typescript": "^7.18.6",
     "@emotion/babel-plugin": "^11.9.5",
     "@emotion/core": "^11.0.0",
+    "@emotion/css": "^11.10.0",
     "@emotion/jest": "^11.10.0",
     "@emotion/react": "^11.10.0",
     "@emotion/styled": "^11.10.0",

--- a/src/renderer/components/Wizard/Wizard.js
+++ b/src/renderer/components/Wizard/Wizard.js
@@ -1,0 +1,647 @@
+//
+// Custom Wizard component
+//
+// NOTE: Lens provides a Wizard in
+//  https://github.com/lensapp/lens/blob/master/src/renderer/components/wizard/wizard.tsx
+//  but it doesn't work well, isn't documented, and renders steps horizontally, while
+//  this Wizard renders steps vertically.
+//
+
+import {
+  useState,
+  useRef,
+  useMemo,
+  useCallback,
+  Children,
+  cloneElement,
+} from 'react';
+import { Renderer } from '@k8slens/extensions';
+import propTypes from 'prop-types';
+import styled from '@emotion/styled';
+import * as rtv from 'rtvjs';
+import { layout } from '../styles';
+import { CloseButton } from '../CloseButton/CloseButton';
+import * as strings from '../../../strings';
+
+const {
+  Component: { Button, Notifications },
+} = Renderer;
+
+//
+// Styled Parts
+//
+
+const sectionPad = layout.pad * 3;
+const sectionPadding = {
+  paddingTop: layout.gap * 4,
+  paddingRight: sectionPad / 2,
+  paddingBottom: sectionPad,
+  paddingLeft: sectionPad / 2,
+};
+const leftRightSectionWidth = '15vw';
+const contentBkColor = 'var(--settingsBackground)';
+const overlayBkColor = 'var(--secondaryBackground)'; // also for left section with step list
+
+const RightSection = styled.div(() => ({
+  flex: '1 0 auto', // flex child of Overlay, grows only, slower than LeftSection
+  ...sectionPadding,
+  minWidth: 100,
+  width: leftRightSectionWidth,
+  height: '100%',
+  display: 'flex',
+  backgroundColor: contentBkColor,
+}));
+
+const Footer = styled.div(() => ({
+  flex: 'none', // flex child of MainContent
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  marginTop: layout.grid * 7,
+}));
+
+const StepContainer = styled.div(() => ({
+  flex: '0 1 auto', // flex child of MainContent: can shrink
+
+  // NOTE: no height so that it just fits the content and Footer is tucked up underneath
+  //  it as opposed to always being pushed to the very bottom of the Overlay
+  width: '100%',
+}));
+
+const BackPlaceholder = styled.div(() => ({
+  width: 1,
+  height: 1,
+}));
+
+const Header = styled.div(() => ({
+  flex: 'none', // flex child of MainContent
+  marginBottom: layout.grid * 7,
+}));
+
+const MainSection = styled.div(() => ({
+  flex: '1 1 auto', // flex child of Overlay, variable width
+  ...sectionPadding,
+  paddingLeft: sectionPad, // required for active step bar effect and proper visual left pad from LeftSection
+  minWidth: layout.grid * 162, // 648px
+  height: '100%',
+  display: 'flex',
+  flexDirection: 'column',
+  backgroundColor: contentBkColor,
+}));
+
+const StepListItemLabel = styled.p(() => ({
+  flex: '1 1 auto', // flex child of StepListItem: variable width
+  margin: 0,
+  padding: 0,
+  width: 'min-content',
+}));
+
+const StepListItemNumber = styled.p(() => ({
+  flex: 'none', // flex child of StepListItem: fixed
+  margin: 0,
+  paddingTop: 0,
+  paddingRight: '0.25em', // depend on font size for space between '.' and label
+  paddingBottom: 0,
+  paddingLeft: layout.grid,
+  width: '2em', // approx 2 numbers wide plus '.'
+  textAlign: 'right',
+
+  '&::after': {
+    content: '"."',
+  },
+}));
+
+const StepListItem = styled.div(({ isActive, isVisited, isEnabled }) => ({
+  flex: '0 1 auto', // flex child of StepList: full width
+  backgroundColor: isActive ? contentBkColor : undefined,
+  display: 'flex',
+  alignItems: 'baseline',
+  paddingTop: layout.grid,
+  paddingRight: layout.pad,
+  paddingBottom: layout.grid,
+  paddingLeft: 0,
+  color:
+    isVisited && (isEnabled || isActive)
+      ? 'var(--textColorPrimary)'
+      : 'var(--textColorDimmed)',
+  cursor: isVisited && (isEnabled || isActive) ? 'pointer' : 'default',
+  pointerEvents: isVisited && isEnabled ? undefined : 'none', // no events if active (clicking itself does nothing)
+}));
+
+const StepListFiller = styled.div(() => ({
+  // flex child of StepList: grows to fill void space under items to keep item heights as
+  //  short as possible
+  flex: '1 1 auto',
+
+  width: 1,
+  height: 1,
+}));
+
+const StepList = styled.div(() => ({
+  flex: '0 1 auto', // flex child of StepListContainer
+  display: 'flex',
+  flexDirection: 'column',
+  minWidth: layout.grid * 50,
+}));
+
+const LeftSection = styled.div(() => ({
+  flex: '1 0 auto', // flex child of Overlay, grows only, faster than RightSection
+  ...sectionPadding,
+  paddingRight: 0, // required in order to have effect of active step bar extending to MainSection
+  minWidth: 200,
+  width: leftRightSectionWidth,
+  height: '100%',
+  display: 'flex',
+  justifyContent: 'flex-end',
+}));
+
+const Overlay = styled.div(() => ({
+  position: 'absolute',
+  left: 0,
+  top: 0,
+  right: 0,
+  bottom: 0,
+  display: 'flex',
+  backgroundColor: overlayBkColor,
+  padding: 0,
+
+  'h1, h2, h3': {
+    color: 'var(--textColorAccent)',
+    fontWeight: 'bold',
+  },
+
+  h1: {
+    fontSize: 24,
+  },
+
+  h2: {
+    fontSize: 18,
+  },
+}));
+
+//
+// Component
+//
+
+/**
+ * Determines if a step is reachable. A step is reachable if all previous steps
+ *  are validated and all previous steps enable their Next button.
+ * @param {Object} wizard Wizard state.
+ * @param {number} stepIdx Index of the step.
+ * @returns {boolean} True if enabled; false otherwise.
+ */
+const isStepReachable = function (wizard, stepIdx) {
+  if (stepIdx <= 0) {
+    return true; // first step always accessible
+  }
+
+  const orderedSteps = Object.values(wizard.steps).sort((left, right) => {
+    return left.stepIndex - right.stepIndex;
+  });
+
+  const step = orderedSteps[stepIdx];
+  if (!step.visited) {
+    return false; // must have been visited
+  }
+
+  const prevSteps = orderedSteps.slice(0, stepIdx);
+  return prevSteps.every((s) => s.validated && s.nextEnabled);
+};
+
+export const Wizard = function (props) {
+  //
+  // PROPS
+  //
+
+  const { children, title } = props;
+
+  /* istanbul ignore else -- we don't run tests with the flag disabled */
+  if (DEV_ENV) {
+    // PERFORMANCE: only verify props when they change
+    // eslint-disable-next-line react-hooks/rules-of-hooks -- DEV_ENV never changes at runtime
+    useMemo(
+      function () {
+        rtv.verify(
+          {
+            props: { title, children },
+          },
+          {
+            props: {
+              children: [
+                (v) => {
+                  if (Children.count(v) < 1) {
+                    throw new Error('At least 1 child WizardStep is required');
+                  }
+                },
+              ],
+              title: rtv.STRING,
+            },
+          }
+        );
+      },
+      [title, children]
+    );
+  }
+
+  const childList = Children.toArray(children);
+
+  //
+  // STATE
+  //
+
+  // internal wizard state
+  // @type {{ steps: { [index: string]: { validated: boolean, nextEnabled: boolean, visited: boolean, stepIndex: number } } }}
+  // - steps is a map of step ID to last-reported step state
+  const wizard = useRef({ steps: {} });
+
+  // counter to signal change to wizard state because we're using a ref (that doesn't trigger
+  //  a re-render on change like state does) so that we can have the freedom to update the
+  //  wizard's state in a render pass; if we made `wizard` actual state (via `useState()`),
+  //  we'd end-up in an equally messy situation when looping children on render and looking
+  //  for new children to initialize as steps in `wizard`
+  const [wizardUpdate, setWizardUpdate] = useState(0);
+
+  const [activeStepIdx, setActiveStepIdx] = useState(0);
+  const [backEnabled, setBackEnabled] = useState(false); // we start on first step
+  const [nextEnabled, setNextEnabled] = useState(true);
+  const [nextWaiting, setNextWaiting] = useState(false);
+
+  //
+  // EVENTS
+  //
+
+  // changes the active step to the specified new step, completing the Wizard if the
+  //  new step >= the total step count
+  const changeStep = useCallback(
+    function (newStepIdx) {
+      let nextIdx = -1;
+      let completed = false;
+
+      /* istanbul ignore else -- defensive programming currently cannot be reached */
+      if (newStepIdx !== activeStepIdx) {
+        if (newStepIdx >= childList.length) {
+          completed = true;
+        } else if (newStepIdx > activeStepIdx) {
+          nextIdx = newStepIdx;
+        } else {
+          // must be going backward
+          nextIdx = Math.max(newStepIdx, 0);
+          /* istanbul ignore else -- defensive programming currently cannot be reached */
+          if (nextIdx === activeStepIdx) {
+            nextIdx = -1; // no need to change anything afterall
+          }
+        }
+      }
+
+      if (nextIdx >= 0) {
+        if (nextIdx > activeStepIdx) {
+          // moving forward implies active step is validated
+          const activeChild = childList[activeStepIdx];
+          wizard.current.steps[activeChild.props.id].validated = true;
+        }
+
+        const nextChild = childList[nextIdx];
+        const nextChildState = wizard.current.steps[nextChild.props.id];
+        nextChildState.visited = true;
+
+        setNextEnabled(nextChildState.nextEnabled);
+        setBackEnabled(nextIdx > 0); // disable Back on first step
+        setActiveStepIdx(nextIdx);
+      } /* istanbul ignore else -- defensive programming currently cannot be reached */ else if (
+        completed
+      ) {
+        // completing implies active step is validated (and it can't already be validated,
+        //  otherwise the Wizard would've already completed beforehand
+        const activeChild = childList[activeStepIdx];
+        wizard.current.steps[activeChild.props.id].validated = true;
+        setWizardUpdate(wizardUpdate + 1); // change in step validated state requires re-render now
+
+        const onComplete = props.onComplete;
+        if (typeof onComplete === 'function') {
+          onComplete();
+        }
+      }
+    },
+    [wizardUpdate, activeStepIdx, childList, props.onComplete]
+  );
+
+  // nextIdx is the index of the step where to go on next, which is not necessarily the
+  //  next one in sequence if user is clicking on a forward step they previously visited
+  const navigate = useCallback(
+    function (nextIdx) {
+      if (nextIdx < activeStepIdx) {
+        const onBack = props.onBack;
+        if (typeof onBack === 'function') {
+          // NOTE: Back button is disabled/hidden on first step, so it should not be possible
+          //  to have a situation where `nextIdx` is < 0
+          onBack({ nextIndex: nextIdx });
+        }
+
+        changeStep(nextIdx);
+      } else {
+        const onNext = props.onNext;
+        if (typeof onNext === 'function') {
+          const handleInvalid = () => {
+            const activeChild = childList[activeStepIdx];
+            if (wizard.current.steps[activeChild.props.id].validated) {
+              wizard.current.steps[activeChild.props.id].validated = false;
+              setWizardUpdate(wizardUpdate + 1); // change in step validated state requires re-render now
+            }
+          };
+
+          const child = childList[activeStepIdx];
+          const result = onNext({
+            step: child.props,
+            stepIndex: activeStepIdx,
+            nextIndex: nextIdx >= childList.length ? -1 : nextIdx,
+            isLast: activeStepIdx >= childList.length - 1,
+          });
+
+          if (result instanceof Promise) {
+            setNextWaiting(true);
+            result
+              .then(
+                () => {
+                  changeStep(nextIdx);
+                },
+                (err) => {
+                  // validation failed: stay on current step
+                  handleInvalid();
+                  if (err?.message) {
+                    Notifications.error(err.message, { timeout: 0 }); // require user to dismiss
+                  }
+                }
+              )
+              .finally(() => setNextWaiting(false));
+          } else if (result === undefined || result) {
+            changeStep(nextIdx);
+          } else {
+            // falsy (other than undefined) means invalid: stay on current step
+            handleInvalid();
+          }
+        } else {
+          changeStep(nextIdx);
+        }
+      }
+    },
+    [
+      wizardUpdate,
+      activeStepIdx,
+      changeStep,
+      childList,
+      props.onBack,
+      props.onNext,
+    ]
+  );
+
+  const handleBackClick = useCallback(
+    function () {
+      navigate(activeStepIdx - 1);
+    },
+    [navigate, activeStepIdx]
+  );
+
+  const handleNextClick = useCallback(
+    function () {
+      navigate(activeStepIdx + 1);
+    },
+    [activeStepIdx, navigate]
+  );
+
+  // NOTE: we handle this internally so as not to pass the click event through
+  //  which is what would happen if we put the onCancel prop directly on to
+  //  the CloseButton's onClick handler
+  const handleCancelClick = useCallback(
+    function () {
+      const onCancel = props.onCancel;
+      if (typeof onCancel === 'function') {
+        onCancel();
+      }
+    },
+    [props.onCancel]
+  );
+
+  const handleStepChange = useCallback(
+    function (params) {
+      const { stepIndex, validated, nextEnabled: stepNextEnabled } = params;
+      const child = childList[stepIndex];
+
+      // call consumer's individual Step onChange event handler, if any
+      if (typeof child.props.onChange === 'function') {
+        child.props.onChange(params);
+      }
+
+      // NOTE: allow for some properties NOT to be defined when updating state, effectively
+      //  merging them into current state
+      const stepState = wizard.current.steps[child.props.id];
+
+      if (validated !== undefined && stepState.validated !== validated) {
+        stepState.validated = validated;
+        setWizardUpdate(wizardUpdate + 1); // change in step validated state requires re-render now
+      }
+
+      stepState.nextEnabled = stepNextEnabled ?? stepState.nextEnabled;
+      setNextEnabled(stepState.nextEnabled);
+    },
+    [wizardUpdate, childList]
+  );
+
+  // NOTE: not expecting clicks when item is disabled (not visited or Next is disabled
+  //  and step is ahead of current
+  const handleStepListItemClick = useCallback(
+    function (event) {
+      const stepIndex = parseInt(event.currentTarget.dataset.stepIndex);
+
+      if (activeStepIdx < stepIndex) {
+        // user wants to go forward, which means the step has to be OK with going next
+        navigate(stepIndex);
+      } else {
+        changeStep(stepIndex);
+      }
+    },
+    [activeStepIdx, navigate, changeStep]
+  );
+
+  const handleOverlayKeyDown = useCallback(
+    function (event) {
+      if (event.code === 'Escape') {
+        event.stopPropagation();
+        handleCancelClick();
+      }
+    },
+    [handleCancelClick]
+  );
+
+  //
+  // EFFECTS
+  //
+
+  //
+  // RENDER
+  //
+
+  const { className, lastLabel } = props;
+
+  const nextLabel =
+    activeStepIdx >= childList.length - 1
+      ? lastLabel || strings.wizard.finish()
+      : strings.wizard.next();
+
+  const steps = childList.map((child, stepIndex) => {
+    const {
+      props: { id },
+    } = child;
+
+    wizard.current.steps[id] = {
+      // initial state
+      validated: true, // assume valid unless told otherwise
+      nextEnabled,
+      visited: stepIndex === activeStepIdx,
+
+      // overwrite with existing state if step was already defined
+      ...wizard.current.steps[id],
+
+      stepIndex, // always overwrite existing with new index if number of steps has changed
+    };
+
+    return cloneElement(child, {
+      onChange: handleStepChange,
+      stepIndex,
+    });
+  });
+
+  const activeChild = childList[activeStepIdx];
+  const activeStepState = wizard.current.steps[activeChild.props.id];
+
+  return (
+    <Overlay className={className} onKeyDown={handleOverlayKeyDown}>
+      <LeftSection>
+        <StepList>
+          {steps.map((step, idx) => (
+            <StepListItem
+              key={step.props.stepIndex}
+              isActive={idx === activeStepIdx}
+              isVisited={activeStepState.visited}
+              isEnabled={isStepReachable(wizard.current, idx)}
+              data-step-index={idx}
+              onClick={handleStepListItemClick}
+            >
+              <StepListItemNumber>{idx + 1}</StepListItemNumber>
+              <StepListItemLabel>
+                {step.props.label || step.props.title}
+              </StepListItemLabel>
+            </StepListItem>
+          ))}
+          <StepListFiller />
+        </StepList>
+      </LeftSection>
+      <MainSection>
+        <Header>
+          <h1>{title}</h1>
+        </Header>
+        <StepContainer>{steps[activeStepIdx]}</StepContainer>
+        <Footer>
+          {backEnabled ? (
+            <Button
+              primary
+              label={strings.wizard.back()}
+              onClick={handleBackClick}
+            />
+          ) : (
+            <BackPlaceholder />
+          )}
+          <Button
+            primary
+            label={nextLabel}
+            onClick={handleNextClick}
+            disabled={!nextEnabled || nextWaiting}
+            waiting={nextWaiting}
+          />
+        </Footer>
+      </MainSection>
+      <RightSection>
+        <CloseButton onClick={handleCancelClick} />
+      </RightSection>
+    </Overlay>
+  );
+};
+
+Wizard.propTypes = {
+  /**
+   * Children are expected to be WizardStep components, and there must be at least 1.
+   */
+  children: propTypes.oneOfType([
+    propTypes.node,
+    propTypes.arrayOf(propTypes.node),
+  ]).isRequired,
+
+  /**
+   * Class name for the Overlay.
+   */
+  className: propTypes.string,
+
+  /**
+   * Label for the Next button when the Wizard reaches the last step.
+   *
+   * Default: "Finish"
+   */
+  lastLabel: propTypes.string,
+
+  /**
+   * Wizard title.
+   */
+  title: propTypes.string.isRequired,
+
+  //// EVENTS
+
+  /**
+   * Called if the user clicks the Back button.
+   *
+   * Signature: `(info: { nextIndex: number }) => void`
+   *
+   * - `info.nextIndex`: Index of the step to which the Wizard will navigate backward
+   *     (not necessarily in sequence if the user clicked on a previous step's label
+   *     in the step list).
+   */
+  onBack: propTypes.func,
+
+  /**
+   * Called if the user cancels the Wizard.
+   *
+   * Signature: `() => void`
+   */
+  onCancel: propTypes.func,
+
+  /**
+   * Called when the user exits the Wizard after completing all steps.
+   *
+   * Signature: `() => void`
+   */
+  onComplete: propTypes.func,
+
+  /**
+   * Called when the user clicks on the Next/Finish button.
+   *
+   * Signature: `(info: { step: Object, stepIndex: number, nextIndex: number, isLast: boolean }) => void | boolean | Promise<void>`
+   *
+   * - `info.step`: All props originally given to the current step.
+   * - `info.stepIndex`: Index of the step in the Wizard.
+   * - `info.nextIndex`: Index of the step to which the Wizard will navigate next (not
+   *     necessarily the one immediately following the current step if the user clicked
+   *     on a previous-visited step in the Wizard's step list). If this is the last step,
+   *     this property will be set to `-1` (and `info.isLast` will be `true`).
+   * - `info.isLast`: True if the step identified by `info.stepIndex` (i.e. the current step) is
+   *     the last one and the Wizard will be completed if allowed to go forward; false otherwise.
+   * - Returns: If a promise is returned, the Wizard waits for it to resolve before
+   *     proceeding to the next step or completing the wizard. If nothing or a truthy value
+   *     is returned, the Wizard doesn't wait and proceeds. In either case, the step is considered
+   *     validated. If the promise is rejected or a falsy value (other than `undefined`) is returned,
+   *     the step is considered invalid and the Wizard does not proceed.
+   *     - NOTE: An invalid step means __all__ following steps become inaccessible even if already
+   *         visited.
+   *
+   * NOTE: Use the step's `onChange()` event to signal to the Wizard that the Next
+   *  button should be disabled to prevent the user from moving forward.
+   */
+  onNext: propTypes.func,
+};

--- a/src/renderer/components/Wizard/WizardStep.js
+++ b/src/renderer/components/Wizard/WizardStep.js
@@ -1,0 +1,164 @@
+//
+// Step in a Wizard
+//
+
+import { useMemo } from 'react';
+import propTypes from 'prop-types';
+import styled from '@emotion/styled';
+import * as rtv from 'rtvjs';
+import { layout } from '../styles';
+
+//
+// Styled Parts
+//
+
+const Header = styled.div(() => ({
+  flex: 'none', // flex child of Step
+  marginBottom: layout.grid * 7,
+}));
+
+const Content = styled.div(() => ({
+  flex: '1 1 auto', // flex child of Step
+  overflowX: 'hidden',
+  overflowY: 'auto',
+  width: '100%',
+  height: '100%',
+  display: 'flex',
+  flexDirection: 'column',
+}));
+
+const Step = styled.div(() => ({
+  width: '100%',
+  height: '100%',
+  display: 'flex',
+  flexDirection: 'column',
+}));
+
+//
+// Component
+//
+
+export const WizardStep = function (props) {
+  //
+  // PROPS
+  //
+
+  const { title } = props;
+
+  /* istanbul ignore else -- we don't run tests with the flag disabled */
+  if (DEV_ENV) {
+    // PERFORMANCE: only verify props when they change
+    // eslint-disable-next-line react-hooks/rules-of-hooks -- DEV_ENV never changes at runtime
+    useMemo(
+      function () {
+        rtv.verify(
+          {
+            props: { id: props.id, title },
+          },
+          {
+            props: {
+              id: rtv.STRING,
+              title: rtv.STRING,
+            },
+          }
+        );
+      },
+      [title, props.id]
+    );
+  }
+
+  //
+  // STATE
+  //
+
+  //
+  // EVENTS
+  //
+
+  //
+  // EFFECTS
+  //
+
+  //
+  // RENDER
+  //
+
+  const { className, children } = props;
+
+  return (
+    <Step className={className}>
+      <Header>
+        <h2>{title}</h2>
+      </Header>
+      <Content>{children({ step: props })}</Content>
+    </Step>
+  );
+};
+
+WizardStep.propTypes = {
+  /**
+   * Custom step content to render as a render child.
+   *
+   * The child is expected to call the `onChange` event prop when its valid state changes.
+   *
+   * Signature: `(params: { step }) => React.Element`
+   *
+   * `step`: All props given to this step (original and those set by the Wizard).
+   */
+  children: propTypes.func.isRequired,
+
+  /**
+   * Class name for the Step.
+   */
+  className: propTypes.string,
+
+  /**
+   * Unique ID for this step in the Wizard. Used by the Wizard to track internal state.
+   */
+  id: propTypes.string.isRequired,
+
+  /**
+   * Step label used in the Wizard's step list. Defaults to the `title` if not set or empty.
+   */
+  label: propTypes.string,
+
+  /**
+   * Index of this step in the Wizard. Set (i.e. overridden) by the Wizard.
+   */
+  stepIndex: propTypes.number,
+
+  /**
+   * Step title. Appears above step content.
+   *
+   * NOTE: If the `label` prop isn't specified, the title is also used as the step's
+   *  label in the Wizard's step list.
+   */
+  title: propTypes.string.isRequired,
+
+  //// EVENTS
+
+  /**
+   * Called when this step's validity has changed.
+   *
+   * NOTE: This prop will be set by the Wizard for its handling purposes. The Step is expected
+   *  to call it when its validated state changes or when it needs to control the Next button.
+   *
+   * Signature: `(info: { stepIndex: number, validated?: boolean, nextEnabled?: boolean }) => void`
+   *
+   * - `info.stepIndex`: (__Required__) Value of the step's `stepIndex` prop.
+   * - `info.validated`: (Optional) True if the step has been validated and navigation can move
+   *    forward past this step; false if not. Note that if the Wizard allows moving
+   *    next from this step, this step is implicitly considered validated. Use this primarily
+   *    to _invalidate_ this step if its state changes such that it needs re-validating on next.
+   *    - By default, the Wizard assumes all steps are validated. If a step doesn't have async
+   *        validation on Next, it's best to use `nextEnabled` to control the immediate state
+   *        of the Next button for client-side validations.
+   *    - NOTE: A step should not store its own validated state and use it to control this flag.
+   *        Only set this flag to false if something changes causing the step's data to need to
+   *        be revalidated on Next.
+   *    - NOTE: An invalid step means __all__ following steps become inaccessible even if already
+   *        visited.
+   * - `info.nextEnabled`: (Optional) True if the Next button is enabled; false if not.
+   */
+  onChange: propTypes.func,
+};

--- a/src/renderer/components/Wizard/__tests__/Wizard.spec.js
+++ b/src/renderer/components/Wizard/__tests__/Wizard.spec.js
@@ -1,0 +1,761 @@
+import { useState } from 'react';
+import {
+  render,
+  screen,
+  expectErrorBoundary,
+  act,
+  waitFor,
+} from 'testingUtility';
+import userEvent from '@testing-library/user-event';
+import { WizardStep } from '../WizardStep';
+import { Wizard } from '../Wizard';
+import * as strings from '../../../../strings';
+
+/**
+ * Gets various elements in the rendered Wizard.
+ * @param {Object} [options]
+ * @param {string} [options.lastLabel] Expected label of the Finish button if it's not
+ *  the default.
+ */
+const getParts = ({ lastLabel } = {}) => {
+  const nextEl = screen.queryByRole('button', { name: strings.wizard.next() });
+  const finishEl = screen.queryByRole('button', {
+    name: lastLabel || strings.wizard.finish(),
+  });
+
+  return {
+    backEl: screen.queryByRole('button', { name: strings.wizard.back() }),
+    nextEl,
+    finishEl,
+    forwardEl: nextEl || finishEl, // convenience when not specifically testing for Next vs Finish
+    cancelEl: screen.queryByRole('button', {
+      name: strings.closeButton.label(),
+    }),
+    stepListItems: document.querySelectorAll('[class*="-StepListItem "]'),
+  };
+};
+
+describe('/renderer/components/Wizard/Wizard', () => {
+  const stepTitle = 'Step title';
+  const stepId = 'step-id';
+  const wizardTitle = 'Wizard title';
+
+  let user;
+  let TestWizardStep;
+  let TestWizard;
+
+  beforeEach(() => {
+    user = userEvent.setup();
+
+    // eslint-disable-next-line react/display-name
+    TestWizardStep = (props) => (
+      <WizardStep title={stepTitle} id={stepId} {...props}>
+        {props.children ||
+          (({ step: { stepIndex } }) => (
+            <p data-testid={props.id || stepId}>Step {stepIndex}</p>
+          ))}
+      </WizardStep>
+    );
+
+    // eslint-disable-next-line react/display-name
+    TestWizard = ({ stepCount = 2, ...props }) => {
+      let children = props.children;
+      if (!children) {
+        children = Array.from({ length: stepCount }).map((_, i) => (
+          <TestWizardStep key={i} title={`Title ${i}`} id={`step-${i}`} />
+        ));
+      }
+
+      return (
+        <Wizard title={wizardTitle} id={stepId} {...props}>
+          {children}
+        </Wizard>
+      );
+    };
+  });
+
+  describe('API', () => {
+    describe('props', () => {
+      describe('#children', () => {
+        it('requires at least one child', () => {
+          expectErrorBoundary(
+            <TestWizard stepCount={0} />,
+            'Verification failed: path="/props/children"'
+          );
+        });
+
+        it('calls the render function with step props including those set by Wizard', async () => {
+          const handler = jest.fn();
+
+          render(
+            <TestWizard>
+              <TestWizardStep id={stepId} title={stepTitle}>
+                {handler}
+              </TestWizardStep>
+            </TestWizard>
+          );
+
+          expect(handler).toHaveBeenCalled();
+          expect(handler.mock.calls[0][0]).toEqual({
+            step: {
+              children: handler,
+              title: stepTitle,
+              id: stepId,
+              onChange: handler.mock.calls[0][0].step.onChange, // given by Wizard
+              stepIndex: 0,
+            },
+          });
+          expect(typeof handler.mock.calls[0][0].step.onChange).toBe(
+            'function'
+          );
+        });
+
+        it('handles new children added dynamically', async () => {
+          const handler0 = jest.fn();
+          const handler1 = jest.fn();
+          const handler2 = jest.fn();
+          const stepIds = ['zero', 'one', 'two'];
+          const stepTitles = ['one', 'two', 'three'];
+          const testId = 'add-step';
+
+          const TestContainer = () => {
+            const [added, setAdded] = useState(false);
+
+            return (
+              <>
+                <TestWizard>
+                  <TestWizardStep id={stepIds[0]} title={stepTitles[0]}>
+                    {handler0}
+                  </TestWizardStep>
+                  {added ? (
+                    <TestWizardStep id={stepIds[2]} title={stepTitles[2]}>
+                      {handler2}
+                    </TestWizardStep>
+                  ) : null}
+                  <TestWizardStep id={stepIds[1]} title={stepTitles[1]}>
+                    {handler1}
+                  </TestWizardStep>
+                </TestWizard>
+                <button onClick={() => setAdded(true)} data-testid={testId}>
+                  add
+                </button>
+              </>
+            );
+          };
+
+          render(<TestContainer />);
+
+          expect(handler0).toHaveBeenCalled();
+          expect(handler1).not.toHaveBeenCalled();
+          expect(handler2).not.toHaveBeenCalled();
+          expect(handler0.mock.calls[0][0]).toEqual({
+            step: {
+              children: handler0,
+              title: stepTitles[0],
+              id: stepIds[0],
+              onChange: handler0.mock.calls[0][0].step.onChange, // given by Wizard
+              stepIndex: 0,
+            },
+          });
+          expect(typeof handler0.mock.calls[0][0].step.onChange).toBe(
+            'function'
+          );
+
+          // NEXT
+          await user.click(getParts().nextEl);
+
+          expect(handler1).toHaveBeenCalled();
+          expect(handler2).not.toHaveBeenCalled();
+          expect(handler1.mock.calls[0][0]).toEqual({
+            step: {
+              children: handler1,
+              title: stepTitles[1],
+              id: stepIds[1],
+              onChange: handler1.mock.calls[0][0].step.onChange, // given by Wizard
+              stepIndex: 1,
+            },
+          });
+          expect(typeof handler1.mock.calls[0][0].step.onChange).toBe(
+            'function'
+          );
+
+          // BACK
+          await user.click(getParts().backEl);
+          // ADD STEP in middle
+          await user.click(screen.getByTestId(testId));
+
+          handler0.mockReset();
+          handler1.mockReset();
+
+          expect(handler0).not.toHaveBeenCalled(); // was already rendered
+          expect(handler1).not.toHaveBeenCalled();
+          expect(handler2).not.toHaveBeenCalled();
+
+          await user.click(getParts().nextEl);
+
+          expect(handler2).toHaveBeenCalled();
+          expect(handler1).not.toHaveBeenCalled();
+          expect(handler2.mock.calls[0][0]).toEqual({
+            step: {
+              children: handler2,
+              title: stepTitles[2],
+              id: stepIds[2],
+              onChange: handler2.mock.calls[0][0].step.onChange, // given by Wizard
+              stepIndex: 1,
+            },
+          });
+          expect(typeof handler2.mock.calls[0][0].step.onChange).toBe(
+            'function'
+          );
+
+          await user.click(getParts().nextEl);
+
+          expect(handler1).toHaveBeenCalled();
+          expect(handler1.mock.calls[0][0]).toEqual({
+            step: {
+              children: handler1,
+              title: stepTitles[1],
+              id: stepIds[1],
+              onChange: handler1.mock.calls[0][0].step.onChange, // given by Wizard
+              stepIndex: 2,
+            },
+          });
+          expect(typeof handler1.mock.calls[0][0].step.onChange).toBe(
+            'function'
+          );
+        });
+      });
+
+      describe('#lastLabel', () => {
+        it(`defaults to ${strings.wizard.finish()}`, () => {
+          render(<TestWizard stepCount={1} />);
+
+          expect(getParts().finishEl).toBeInTheDocument();
+        });
+
+        it('sets the label of the last Next button in sequence', () => {
+          const lastLabel = 'foo';
+          render(<TestWizard stepCount={1} lastLabel={lastLabel} />);
+
+          expect(getParts({ lastLabel }).finishEl).toBeInTheDocument();
+        });
+      });
+
+      describe('#title', () => {
+        it('requires a non-empty title', () => {
+          expectErrorBoundary(
+            <TestWizard title="" />,
+            'Verification failed: path="/props/title"'
+          );
+        });
+      });
+    });
+
+    describe('events', () => {
+      describe('#onBack', () => {
+        it('gets called when Back is clicked', async () => {
+          const handler = jest.fn();
+          render(<TestWizard onBack={handler} />);
+
+          expect(handler).not.toHaveBeenCalled();
+
+          await user.click(getParts().nextEl);
+          expect(handler).not.toHaveBeenCalled();
+
+          await user.click(getParts().backEl);
+          expect(handler).toHaveBeenCalledTimes(1);
+          expect(handler.mock.calls[0][0]).toEqual({
+            nextIndex: 0,
+          });
+        });
+      });
+
+      describe('#onCancel', () => {
+        it('gets called when user clicks on ESC button', async () => {
+          const handler = jest.fn();
+          render(<TestWizard onCancel={handler} />);
+
+          expect(handler).not.toHaveBeenCalled();
+
+          await user.click(getParts().cancelEl);
+          expect(handler).toHaveBeenCalledTimes(1);
+        });
+
+        it('gets called when user presses ESC key from anywhere inside Wizard', async () => {
+          const handler = jest.fn();
+          const testId = 'input-id';
+          render(
+            <TestWizard onCancel={handler}>
+              <TestWizardStep>
+                {() => <input type="text" data-testid={testId} />}
+              </TestWizardStep>
+            </TestWizard>
+          );
+
+          expect(handler).not.toHaveBeenCalled();
+
+          const inputEl = screen.getByTestId(testId);
+          inputEl.focus();
+          await user.type(inputEl, '[Escape]');
+          expect(handler).toHaveBeenCalledTimes(1);
+        });
+      });
+
+      describe('#onComplete', () => {
+        it('gets called when user clicks on Finish button', async () => {
+          const handler = jest.fn();
+          render(<TestWizard stepCount={1} onComplete={handler} />);
+
+          expect(handler).not.toHaveBeenCalled();
+
+          await user.click(getParts().finishEl);
+          expect(handler).toHaveBeenCalledTimes(1);
+        });
+      });
+
+      describe('#onNext', () => {
+        [undefined, true].forEach((scenario) => {
+          it(`gets called when user clicks Next and step changes when handler |returns ${scenario}|`, async () => {
+            const handler = jest.fn(() => scenario);
+            render(<TestWizard onNext={handler} />);
+
+            expect(handler).not.toHaveBeenCalled();
+            expect(screen.getByTestId('step-0')).toBeInTheDocument();
+            expect(screen.queryByTestId('step-1')).not.toBeInTheDocument();
+
+            await user.click(getParts().forwardEl);
+            expect(handler).toHaveBeenCalledTimes(1);
+            expect(handler.mock.calls[0][0]).toEqual({
+              step: {
+                id: 'step-0',
+                title: 'Title 0',
+              },
+              stepIndex: 0,
+              nextIndex: 1,
+              isLast: false,
+            });
+
+            expect(getParts().forwardEl).not.toHaveClass('waiting');
+            expect(screen.queryByTestId('step-0')).not.toBeInTheDocument();
+            expect(screen.getByTestId('step-1')).toBeInTheDocument();
+          });
+        });
+
+        it('gets called when user clicks Next and step changes when handler returns promise that resolves', async () => {
+          jest.useFakeTimers();
+          user = userEvent.setup({
+            delay: null, // prevent internal use of setTimeout()
+            advanceTimers(delay) {
+              jest.advanceTimersByTime(delay);
+            },
+          });
+
+          const timeout = 10;
+          const handler = jest.fn(
+            () => new Promise((resolve) => setTimeout(resolve, timeout))
+          );
+          render(<TestWizard onNext={handler} />);
+
+          expect(handler).not.toHaveBeenCalled();
+          expect(screen.getByTestId('step-0')).toBeInTheDocument();
+          expect(screen.queryByTestId('step-1')).not.toBeInTheDocument();
+
+          await user.click(getParts().forwardEl);
+          expect(handler).toHaveBeenCalledTimes(1);
+          expect(getParts().forwardEl).toHaveClass('waiting');
+
+          act(() => jest.advanceTimersByTime(timeout));
+          await waitFor(() =>
+            expect(screen.queryByTestId('step-0')).not.toBeInTheDocument()
+          );
+
+          expect(screen.getByTestId('step-1')).toBeInTheDocument();
+          expect(getParts().forwardEl).not.toHaveClass('waiting');
+
+          jest.useRealTimers();
+        });
+
+        [undefined, new Error('error message')].forEach((scenario) => {
+          it(`gets called when user clicks Next and prevents step changing when handler returns promise that rejects and shows |${
+            scenario ? 'error notification' : 'nothing'
+          }|`, async () => {
+            jest.useFakeTimers();
+            user = userEvent.setup({
+              delay: null, // prevent internal use of setTimeout()
+              advanceTimers(delay) {
+                jest.advanceTimersByTime(delay);
+              },
+            });
+
+            const timeout = 10;
+            const handler = jest.fn(
+              () =>
+                new Promise((resolve, reject) =>
+                  setTimeout(() => reject(scenario), timeout)
+                )
+            );
+            render(<TestWizard onNext={handler} />);
+
+            expect(handler).not.toHaveBeenCalled();
+            expect(screen.getByTestId('step-0')).toBeInTheDocument();
+            expect(screen.queryByTestId('step-1')).not.toBeInTheDocument();
+
+            await user.click(getParts().forwardEl);
+            expect(handler).toHaveBeenCalledTimes(1);
+            expect(getParts().forwardEl).toHaveClass('waiting');
+
+            act(() => jest.advanceTimersByTime(timeout));
+
+            // NOTE: it's important to wait for something after the above call to avoid
+            //  act()-related warnings when the test runs
+            if (scenario) {
+              await screen.findByText(scenario.message);
+              // still on step 0, Next no longer waiting
+              expect(screen.getByTestId('step-0')).toBeInTheDocument();
+              expect(screen.queryByTestId('step-1')).not.toBeInTheDocument();
+              expect(getParts().forwardEl).not.toHaveClass('waiting');
+            } else {
+              // still on step 0, Next no longer waiting
+              await waitFor(() =>
+                expect(getParts().forwardEl).not.toHaveClass('waiting')
+              );
+              expect(screen.getByTestId('step-0')).toBeInTheDocument();
+              expect(screen.queryByTestId('step-1')).not.toBeInTheDocument();
+            }
+
+            jest.useRealTimers();
+          });
+        });
+
+        it('gets called when user clicks Finish on last step', async () => {
+          const nextHandler = jest.fn();
+          const completeHandler = jest.fn();
+          render(
+            <TestWizard
+              stepCount={1}
+              onNext={nextHandler}
+              onComplete={completeHandler}
+            />
+          );
+
+          expect(nextHandler).not.toHaveBeenCalled();
+          expect(completeHandler).not.toHaveBeenCalled();
+          expect(screen.getByTestId('step-0')).toBeInTheDocument();
+
+          await user.click(getParts().finishEl);
+          expect(nextHandler).toHaveBeenCalledTimes(1);
+          expect(nextHandler.mock.calls[0][0]).toEqual({
+            step: {
+              id: 'step-0',
+              title: 'Title 0',
+            },
+            stepIndex: 0,
+            nextIndex: -1,
+            isLast: true,
+          });
+          expect(completeHandler).toHaveBeenCalledTimes(1);
+        });
+
+        it('prevents onComplete from being called on last step if it returns false', async () => {
+          const nextHandler = jest.fn(() => false);
+          const completeHandler = jest.fn();
+          render(
+            <TestWizard
+              stepCount={1}
+              onNext={nextHandler}
+              onComplete={completeHandler}
+            />
+          );
+
+          expect(nextHandler).not.toHaveBeenCalled();
+          expect(completeHandler).not.toHaveBeenCalled();
+          expect(screen.getByTestId('step-0')).toBeInTheDocument();
+
+          await user.click(getParts().finishEl);
+          expect(nextHandler).toHaveBeenCalledTimes(1);
+          expect(nextHandler.mock.calls[0][0]).toEqual({
+            step: {
+              id: 'step-0',
+              title: 'Title 0',
+            },
+            stepIndex: 0,
+            nextIndex: -1,
+            isLast: true,
+          });
+          expect(completeHandler).not.toHaveBeenCalled();
+        });
+      });
+    });
+  });
+
+  describe('navigation control', () => {
+    describe('step list', () => {
+      it('disables future steps until they are visited once', async () => {
+        render(<TestWizard />);
+
+        let { stepListItems, backEl, forwardEl } = getParts();
+        expect(screen.getByTestId('step-0')).toBeInTheDocument();
+        expect(stepListItems).toHaveLength(2);
+        expect(stepListItems[0]).not.toHaveStyleRule('pointerEvents');
+        expect(stepListItems[1]).toHaveStyleRule('pointer-events', 'none');
+
+        await user.click(forwardEl);
+        expect(screen.getByTestId('step-1')).toBeInTheDocument(); // now step 1
+
+        ({ stepListItems, backEl, forwardEl } = getParts());
+        expect(stepListItems).toHaveLength(2);
+        expect(stepListItems[0]).not.toHaveStyleRule('pointerEvents');
+        expect(stepListItems[1]).not.toHaveStyleRule('pointer-events'); // clickable
+
+        await user.click(backEl);
+        expect(screen.getByTestId('step-0')).toBeInTheDocument(); // back on step 0
+
+        ({ stepListItems, backEl, forwardEl } = getParts());
+        expect(stepListItems).toHaveLength(2);
+        expect(stepListItems[0]).not.toHaveStyleRule('pointerEvents');
+        expect(stepListItems[1]).not.toHaveStyleRule('pointer-events'); // clickable
+
+        await user.click(stepListItems[1]);
+        expect(screen.getByTestId('step-1')).toBeInTheDocument(); // now step 1
+      });
+
+      it('disables all future steps after an invalidated step and restores validated state', async () => {
+        let allowNext = true;
+        render(<TestWizard stepCount={4} onNext={() => allowNext} />);
+
+        let { stepListItems, backEl, forwardEl } = getParts();
+        expect(screen.getByTestId('step-0')).toBeInTheDocument();
+        expect(stepListItems).toHaveLength(4);
+        expect(stepListItems[0]).not.toHaveStyleRule('pointerEvents');
+        expect(stepListItems[1]).toHaveStyleRule('pointer-events', 'none'); // not yet visited
+        expect(stepListItems[2]).toHaveStyleRule('pointer-events', 'none'); // no yet visited
+        expect(stepListItems[3]).toHaveStyleRule('pointer-events', 'none'); // no yet visited
+
+        await user.click(forwardEl);
+        expect(screen.getByTestId('step-1')).toBeInTheDocument(); // now step 1
+
+        await user.click(forwardEl);
+        expect(screen.getByTestId('step-2')).toBeInTheDocument(); // now step 2
+
+        await user.click(forwardEl);
+        expect(screen.getByTestId('step-3')).toBeInTheDocument(); // now step 3
+
+        ({ stepListItems, backEl, forwardEl } = getParts());
+        expect(stepListItems).toHaveLength(4);
+        expect(stepListItems[0]).not.toHaveStyleRule('pointerEvents');
+        expect(stepListItems[1]).not.toHaveStyleRule('pointer-events'); // clickable: visited
+        expect(stepListItems[2]).not.toHaveStyleRule('pointer-events'); // clickable: visited
+        expect(stepListItems[3]).not.toHaveStyleRule('pointer-events'); // clickable: visited
+
+        await user.click(backEl);
+        await user.click(backEl);
+        expect(screen.getByTestId('step-1')).toBeInTheDocument(); // back on step 1
+
+        ({ stepListItems, backEl, forwardEl } = getParts());
+        expect(stepListItems).toHaveLength(4);
+        expect(stepListItems[0]).not.toHaveStyleRule('pointerEvents');
+        expect(stepListItems[1]).not.toHaveStyleRule('pointer-events'); // clickable: visited
+        expect(stepListItems[2]).not.toHaveStyleRule('pointer-events'); // clickable: visited
+        expect(stepListItems[3]).not.toHaveStyleRule('pointer-events'); // clickable: visited
+
+        allowNext = false; // cause invalidation when moving to a following step
+
+        await user.click(stepListItems[3]); // clicking any following list item implies onNext()
+        expect(screen.getByTestId('step-1')).toBeInTheDocument(); // still on step 1
+
+        ({ stepListItems, backEl, forwardEl } = getParts());
+        expect(stepListItems).toHaveLength(4);
+        expect(stepListItems[0]).not.toHaveStyleRule('pointerEvents'); // still clickable
+        expect(stepListItems[1]).not.toHaveStyleRule('pointerEvents'); // still clickable
+        expect(stepListItems[2]).toHaveStyleRule('pointer-events', 'none'); // disabled
+        expect(stepListItems[3]).toHaveStyleRule('pointer-events', 'none'); // disabled
+
+        allowNext = true; // allow moving to following steps again
+
+        await user.click(stepListItems[0]); // can still go back to previous validated steps
+        expect(screen.getByTestId('step-0')).toBeInTheDocument(); // back on step 0
+
+        ({ stepListItems, backEl, forwardEl } = getParts());
+        expect(stepListItems).toHaveLength(4);
+        expect(stepListItems[0]).not.toHaveStyleRule('pointerEvents'); // still clickable
+        expect(stepListItems[1]).not.toHaveStyleRule('pointerEvents'); // still clickable
+        expect(stepListItems[2]).toHaveStyleRule('pointer-events', 'none'); // disabled
+        expect(stepListItems[3]).toHaveStyleRule('pointer-events', 'none'); // disabled
+
+        await user.click(forwardEl);
+        expect(screen.getByTestId('step-1')).toBeInTheDocument(); // now on step 1
+
+        ({ stepListItems, backEl, forwardEl } = getParts());
+        expect(stepListItems).toHaveLength(4);
+        expect(stepListItems[0]).not.toHaveStyleRule('pointerEvents'); // still clickable
+        expect(stepListItems[1]).not.toHaveStyleRule('pointerEvents'); // still clickable
+        expect(stepListItems[2]).toHaveStyleRule('pointer-events', 'none'); // disabled
+        expect(stepListItems[3]).toHaveStyleRule('pointer-events', 'none'); // disabled
+
+        await user.click(forwardEl);
+        expect(screen.getByTestId('step-2')).toBeInTheDocument(); // now on step 2
+
+        ({ stepListItems, backEl, forwardEl } = getParts());
+        expect(stepListItems).toHaveLength(4);
+        expect(stepListItems[0]).not.toHaveStyleRule('pointerEvents'); // still clickable
+        expect(stepListItems[1]).not.toHaveStyleRule('pointerEvents'); // still clickable
+        expect(stepListItems[2]).not.toHaveStyleRule('pointer-events'); // now clickable
+        expect(stepListItems[3]).not.toHaveStyleRule('pointer-events'); // still clickable because already visited and validated before
+      });
+    });
+
+    describe('step #onChange use cases', () => {
+      it('calls the step onChange handler if one was specified', async () => {
+        const stepImpl = ({ step: { onChange, stepIndex, id } }) => {
+          // eslint-disable-next-line react-hooks/rules-of-hooks -- stepImpl is a render child which is basically a component
+          const [nextEnabled, setNextEnabled] = useState(true);
+          return (
+            <button
+              data-testid={id}
+              onClick={() => {
+                onChange({ stepIndex, nextEnabled: !nextEnabled });
+                setNextEnabled(!nextEnabled);
+              }}
+            >
+              Step {stepIndex}
+            </button>
+          );
+        };
+        const handler = jest.fn();
+
+        render(
+          <TestWizard>
+            <TestWizardStep title="Title 0" id="step-0" onChange={handler}>
+              {stepImpl}
+            </TestWizardStep>
+          </TestWizard>
+        );
+
+        expect(handler).not.toHaveBeenCalled();
+
+        await user.click(screen.getByTestId('step-0'));
+
+        expect(handler).toHaveBeenCalledTimes(1);
+      });
+
+      ['Next', 'Finish'].forEach((scenario) => {
+        it(`can control enabled state of |${scenario}| button`, async () => {
+          const stepImpl = ({ step: { onChange, stepIndex, id } }) => {
+            // eslint-disable-next-line react-hooks/rules-of-hooks -- stepImpl is a render child which is basically a component
+            const [nextEnabled, setNextEnabled] = useState(true);
+            return (
+              <button
+                data-testid={id}
+                onClick={() => {
+                  onChange({ stepIndex, nextEnabled: !nextEnabled });
+                  setNextEnabled(!nextEnabled);
+                }}
+              >
+                Step {stepIndex}
+              </button>
+            );
+          };
+
+          render(
+            <TestWizard>
+              <TestWizardStep title="Title 0" id="step-0">
+                {stepImpl}
+              </TestWizardStep>
+              <TestWizardStep title="Title 1" id="step-1">
+                {stepImpl}
+              </TestWizardStep>
+            </TestWizard>
+          );
+
+          if (scenario === 'Next') {
+            const { nextEl, finishEl } = getParts();
+            expect(nextEl).toBeInTheDocument();
+            expect(finishEl).not.toBeInTheDocument();
+          } else {
+            await user.click(getParts().forwardEl); // move to last step
+            const { nextEl, finishEl } = getParts();
+            expect(nextEl).not.toBeInTheDocument();
+            expect(finishEl).toBeInTheDocument();
+          }
+
+          expect(getParts().forwardEl).toBeEnabled();
+
+          await user.click(
+            screen.getByTestId(`step-${scenario === 'Next' ? 0 : 1}`)
+          );
+
+          expect(getParts().forwardEl).toBeDisabled();
+
+          await user.click(
+            screen.getByTestId(`step-${scenario === 'Next' ? 0 : 1}`)
+          );
+
+          expect(getParts().forwardEl).toBeEnabled();
+        });
+      });
+
+      it('can control validated state of the step', async () => {
+        const stepImpl = ({ step: { onChange, stepIndex, id } }) => {
+          // eslint-disable-next-line react-hooks/rules-of-hooks -- stepImpl is a render child which is basically a component
+          const [validated, setValidated] = useState(true);
+          return (
+            <button
+              data-testid={id}
+              onClick={() => {
+                onChange({ stepIndex, validated: !validated });
+                setValidated(!validated);
+              }}
+            >
+              Step {stepIndex}
+            </button>
+          );
+        };
+
+        render(
+          <TestWizard>
+            <TestWizardStep title="Title 0" id="step-0">
+              {stepImpl}
+            </TestWizardStep>
+            <TestWizardStep title="Title 1" id="step-1">
+              {stepImpl}
+            </TestWizardStep>
+          </TestWizard>
+        );
+
+        let { forwardEl, backEl, stepListItems } = getParts();
+
+        expect(screen.getByTestId('step-0')).toBeInTheDocument();
+
+        await user.click(forwardEl); // visit last step, implicitly validating step 0
+        expect(stepListItems[0]).not.toHaveStyleRule('pointer-events');
+        expect(stepListItems[1]).not.toHaveStyleRule('pointer-events');
+
+        expect(screen.getByTestId('step-1')).toBeInTheDocument();
+
+        ({ forwardEl, backEl, stepListItems } = getParts());
+
+        await user.click(backEl); // back to first step
+        expect(screen.getByTestId('step-0')).toBeInTheDocument();
+
+        ({ forwardEl, backEl, stepListItems } = getParts());
+        expect(stepListItems[0]).not.toHaveStyleRule('pointer-events');
+        expect(stepListItems[1]).not.toHaveStyleRule('pointer-events');
+
+        // invalidate first step, thereby disabling last step in step list
+        await user.click(screen.getByTestId('step-0'));
+
+        ({ forwardEl, backEl, stepListItems } = getParts());
+        expect(stepListItems[0]).not.toHaveStyleRule('pointer-events');
+        expect(stepListItems[1]).toHaveStyleRule('pointer-events', 'none'); // disabled
+
+        // re-validate first step, thereby enabling last step in step list because
+        //  visited prior
+        await user.click(screen.getByTestId('step-0'));
+
+        ({ forwardEl, backEl, stepListItems } = getParts());
+        expect(stepListItems[0]).not.toHaveStyleRule('pointer-events');
+        expect(stepListItems[1]).not.toHaveStyleRule('pointer-events');
+      });
+    });
+  });
+});

--- a/src/renderer/components/Wizard/__tests__/WizardStep.spec.js
+++ b/src/renderer/components/Wizard/__tests__/WizardStep.spec.js
@@ -1,0 +1,56 @@
+import { render, expectErrorBoundary } from 'testingUtility';
+import { WizardStep } from '../WizardStep';
+
+describe('/renderer/components/Wizard/WizardStep', () => {
+  const title = 'Step title';
+  const id = 'step-id';
+
+  let TestWizardStep;
+
+  beforeEach(() => {
+    // eslint-disable-next-line react/display-name
+    TestWizardStep = (props) => (
+      <WizardStep title={title} id={id} {...props}>
+        {props.children || (() => <p>content</p>)}
+      </WizardStep>
+    );
+  });
+
+  describe('API', () => {
+    describe('props', () => {
+      describe('#children', () => {
+        it('calls the render function with step props', () => {
+          const handler = jest.fn();
+          render(<TestWizardStep>{handler}</TestWizardStep>);
+
+          expect(handler).toHaveBeenCalled();
+          expect(handler.mock.calls[0][0]).toEqual({
+            step: {
+              children: handler,
+              title,
+              id,
+            },
+          });
+        });
+      });
+
+      describe('#id', () => {
+        it('requires a non-empty id', () => {
+          expectErrorBoundary(
+            <TestWizardStep title={title} id="" />,
+            'Verification failed: path="/props/id"'
+          );
+        });
+      });
+
+      describe('#title', () => {
+        it('requires a non-empty title', () => {
+          expectErrorBoundary(
+            <TestWizardStep title="" id={id} />,
+            'Verification failed: path="/props/title"'
+          );
+        });
+      });
+    });
+  });
+});

--- a/src/strings.ts
+++ b/src/strings.ts
@@ -426,3 +426,9 @@ export const contextMenus: Dict = {
     openInBrowser: () => 'Open in browser',
   },
 };
+
+export const wizard: Dict = {
+  back: () => 'Back',
+  next: () => 'Next',
+  finish: () => 'Finish',
+};

--- a/tools/tests/.eslintrc.js
+++ b/tools/tests/.eslintrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+  extends: '../.eslintrc.js',
+  env: {
+    'jest/globals': true,
+  },
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1032,7 +1032,7 @@
     "@babel/helper-validator-option" "^7.18.6"
     "@babel/plugin-transform-typescript" "^7.18.6"
 
-"@babel/runtime@^7.12.0", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.10", "@babel/runtime@^7.16.3", "@babel/runtime@^7.18.3", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.12.0", "@babel/runtime@^7.12.5", "@babel/runtime@^7.16.3", "@babel/runtime@^7.18.3", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
   version "7.18.9"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.18.9.tgz#b4fcfce55db3d2e5e080d2490f608a3b9f407f4a"
   integrity sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==
@@ -1116,7 +1116,7 @@
     source-map "^0.5.7"
     stylis "4.0.13"
 
-"@emotion/cache@^11.10.0", "@emotion/cache@^11.4.0":
+"@emotion/cache@^11.10.0":
   version "11.10.0"
   resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-11.10.0.tgz#9eb9d3245c2c25ae31028d5ff0929987824c77da"
   integrity sha512-3FoUWnDbHWg/pXGCvL46jvpOSJP0xvRZLY8khUcUHGOBcp0S/MCIk+osp84/dby2Ctahw/Ev4KTHWkY3i0g39g==
@@ -1125,6 +1125,17 @@
     "@emotion/sheet" "^1.2.0"
     "@emotion/utils" "^1.2.0"
     "@emotion/weak-memoize" "^0.3.0"
+    stylis "4.0.13"
+
+"@emotion/cache@^11.4.0":
+  version "11.9.3"
+  resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-11.9.3.tgz#96638449f6929fd18062cfe04d79b29b44c0d6cb"
+  integrity sha512-0dgkI/JKlCXa+lEXviaMtGBL0ynpx4osh7rjOXE71q9bIF8G+XhJgvi+wDu0B0IdCVx37BffiwXlN9I3UuzFvg==
+  dependencies:
+    "@emotion/memoize" "^0.7.4"
+    "@emotion/sheet" "^1.1.1"
+    "@emotion/utils" "^1.0.0"
+    "@emotion/weak-memoize" "^0.2.5"
     stylis "4.0.13"
 
 "@emotion/core@^11.0.0":
@@ -1139,6 +1150,17 @@
   dependencies:
     "@emotion/memoize" "^0.8.0"
     stylis "4.0.13"
+
+"@emotion/css@^11.10.0":
+  version "11.10.0"
+  resolved "https://registry.yarnpkg.com/@emotion/css/-/css-11.10.0.tgz#270b4fdf2419e59cb07081d0e9f7940d88b8b443"
+  integrity sha512-dH9f+kSCucc8ilMg0MUA1AemabcyzYpe5EKX24F528PJjD7HyIY/VBNJHxfUdc8l400h2ncAjR6yEDu+DBj2cg==
+  dependencies:
+    "@emotion/babel-plugin" "^11.10.0"
+    "@emotion/cache" "^11.10.0"
+    "@emotion/serialize" "^1.1.0"
+    "@emotion/sheet" "^1.2.0"
+    "@emotion/utils" "^1.2.0"
 
 "@emotion/hash@^0.8.0":
   version "0.8.0"
@@ -1167,11 +1189,6 @@
     chalk "^4.1.0"
     specificity "^0.4.1"
     stylis "4.0.13"
-
-"@emotion/memoize@^0.7.4":
-  version "0.7.5"
-  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.5.tgz#2c40f81449a4e554e9fc6396910ed4843ec2be50"
-  integrity sha512-igX9a37DR2ZPGYtV6suZ6whr8pTFtyHL3K/oLUotxpSVO2ASaprmAe2Dkq7tBo7CRY7MMDrAa9nuQP9/YG8FxQ==
 
 "@emotion/memoize@^0.8.0":
   version "0.8.0"


### PR DESCRIPTION
The Wizard is mostly modeled according to Lens' Preferences Panel,
but with additional control over the step list's functionality,
and back/next/finish buttons.

### Previews

__NOTE:__ The preview is not for the Create Cluster work, it's just for what the Wizard looks like.

<img width="1496" alt="Screen Shot 2022-08-01 at 5 46 06 PM" src="https://user-images.githubusercontent.com/2855350/182261342-a0e2f80b-0eff-435c-b4ce-c3f78bf708db.png">

<img width="1496" alt="Screen Shot 2022-08-01 at 5 59 28 PM" src="https://user-images.githubusercontent.com/2855350/182261348-0c0695bd-fed0-4dbd-8d76-ff0e0f6a60c2.png">
