### PR TITLE
[PRODX-25977] Add basic structure for Create Cluster wizard

### DIFF
--- a/__mocks__/@k8slens/extensions.js
+++ b/__mocks__/@k8slens/extensions.js
@@ -200,12 +200,12 @@ class Spinner extends React.Component {
 
 let confirmDialogInstance;
 
-export class ConfirmDialog extends React.Component {
+class ConfirmDialog extends React.Component {
   constructor(props) {
     super(props);
 
     if (confirmDialogInstance) {
-      throw new Error('only one instance expected at any given time');
+      throw new Error('MOCK: only one instance expected at any given time');
     }
     confirmDialogInstance = this;
 
@@ -218,6 +218,12 @@ export class ConfirmDialog extends React.Component {
 
   static open = (props) => {
     const { ok, cancel } = props;
+
+    if (!confirmDialogInstance) {
+      throw new Error(
+        'MOCK: When testing something that uses ConfirmDialog, <ConfirmDialog /> must be rendered alongside the component being rendered with render().\n-> Try `render(<><ConfirmDialog /><ComponentToTest /></>)`'
+      );
+    }
 
     confirmDialogInstance.setState({
       isOpen: true,

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "jest-fetch-mock": "^3.0.3",
     "jest-mock-console": "^2.0.0",
     "jest-transform-stub": "^2.0.0",
+    "lodash": "^4.17.21",
     "mobx": "^6.6.1",
     "mobx-react": "^7.5.2",
     "node-fetch": "^2.6.7",

--- a/src/common/__mocks__/Cloud.js
+++ b/src/common/__mocks__/Cloud.js
@@ -96,7 +96,7 @@ export class Cloud extends EventDispatcher {
     return this.namespaces.filter((ns) => ns.synced);
   }
 
-  update() {
+  update(spec, isFromStore = false) {
     // nothing to do in mock for now
   }
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -18,6 +18,16 @@ const lensEntityGroup = 'entity.k8slens.dev';
 const v1alpha1 = 'v1alpha1';
 const v1alpha2 = 'v1alpha2';
 
+/** Supported mgmt cluster provider types. */
+export const providerTypes = Object.freeze({
+  AWS: 'aws',
+  AZURE: 'azure',
+  BYO: 'byo',
+  EQUINIX: 'equinix',
+  OPENSTACK: 'openstack',
+  VSPHERE: 'vsphere',
+});
+
 /** Catalog-related constants. */
 export const catalog = deepFreeze({
   /**

--- a/src/renderer/components/CreateClusterWizard/ClusterStep.js
+++ b/src/renderer/components/CreateClusterWizard/ClusterStep.js
@@ -1,0 +1,57 @@
+import { useEffect } from 'react';
+import propTypes from 'prop-types';
+import { WizardStep } from '../Wizard/WizardStep';
+
+/**
+ * Determines if the Next button should be enabled for this step.
+ * @param {Object} data Wizard data object.
+ * @returns {boolean} True to enable; false to disable.
+ */
+const getNextEnabled = function (data) {
+  const { cluster } = data;
+
+  return !!cluster; // TODO
+};
+
+// eslint-disable-next-line react/prop-types -- doesn't support prop type spread we're using
+export const ClusterStep = function ({ step: { onChange, stepIndex }, data }) {
+  //
+  // STATE
+  //
+
+  if (!data.cluster) {
+    // initialize step data
+    data.cluster = {
+      // TODO
+    };
+  }
+
+  //
+  // EVENTS
+  //
+
+  //
+  // EFFECTS
+  //
+
+  useEffect(
+    function () {
+      onChange?.({
+        nextEnabled: getNextEnabled(data),
+        stepIndex,
+      });
+    },
+    [data, stepIndex, onChange]
+  );
+
+  //
+  // RENDER
+  //
+
+  return <p>TODO: Cluster settings...</p>;
+};
+
+ClusterStep.propTypes = {
+  step: propTypes.shape({ ...WizardStep.props }).isRequired,
+  data: propTypes.object.isRequired,
+};

--- a/src/renderer/components/CreateClusterWizard/CreateClusterWizard.js
+++ b/src/renderer/components/CreateClusterWizard/CreateClusterWizard.js
@@ -1,0 +1,148 @@
+import { useRef, useState, useCallback } from 'react';
+import styled from '@emotion/styled';
+import propTypes from 'prop-types';
+import { Wizard } from '../Wizard/Wizard';
+import { WizardStep } from '../Wizard/WizardStep';
+import * as strings from '../../../strings';
+import { layout } from '../styles';
+import { providerTypes } from '../../../constants';
+import { vGap } from './createClusterUtil';
+import { GeneralStep } from './GeneralStep';
+import { ProviderStep } from './ProviderStep';
+import { ClusterStep } from './ClusterStep';
+import { MonitorStep } from './MonitorStep';
+import { NodeStep } from './NodeStep';
+
+const StyledWizard = styled(Wizard)(() => ({
+  // generally, inputs have a label above them, and each label+input is separated by
+  //  the same vertical gap
+  label: {
+    textTransform: 'uppercase',
+    fontWeight: 'bold',
+    marginTop: vGap,
+    marginBottom: layout.grid * 2,
+
+    '&:first-of-type': {
+      marginTop: 0,
+    },
+
+    input: {
+      textTransform: 'none',
+    },
+  },
+
+  // Lens Select (based on react-select) has 1px border but seems to use content-box
+  //  instead of border-box, so we have to compensate with left/right padding to be
+  //  sure we see the border on all sides
+  '.Select': {
+    padding: '0 1px 0 1px',
+  },
+}));
+
+export const CreateClusterWizard = function ({ onCancel, onComplete }) {
+  //
+  // STATE
+  //
+
+  const data = useRef({}); // data collected in each step
+  const [providerStepTitle, setProviderStepTitle] = useState(
+    strings.createClusterWizard.steps.provider.equinix.stepTitle()
+  );
+
+  //
+  // EVENTS
+  //
+
+  const handleWizardComplete = useCallback(
+    function () {
+      if (typeof onComplete === 'function') {
+        onComplete({ data: data.current });
+      }
+    },
+    [onComplete]
+  );
+
+  const handleNext = useCallback(function () {
+    const providerType = data.general?.providerType; // may not be set yet
+
+    switch (providerType) {
+      case providerTypes.EQUINIX:
+        setProviderStepTitle(
+          strings.createClusterWizard.steps.provider.equinix.stepTitle()
+        );
+        break;
+      default:
+        break; // leave as-is
+    }
+  }, []);
+
+  //
+  // EFFECTS
+  //
+
+  //
+  // RENDER
+  //
+
+  return (
+    <StyledWizard
+      title={strings.createClusterWizard.title()}
+      lastLabel={strings.createClusterWizard.lastLabel()}
+      onNext={handleNext}
+      onComplete={handleWizardComplete}
+      onCancel={onCancel}
+    >
+      <WizardStep
+        id="general"
+        title={strings.createClusterWizard.steps.general.stepTitle()}
+      >
+        {({ step }) => <GeneralStep step={step} data={data.current} />}
+      </WizardStep>
+      <WizardStep
+        id="provider"
+        title={providerStepTitle}
+        label={strings.createClusterWizard.steps.provider.stepLabel()}
+      >
+        {({ step }) => <ProviderStep step={step} data={data.current} />}
+      </WizardStep>
+      <WizardStep
+        id="cluster"
+        title={strings.createClusterWizard.steps.cluster.stepTitle()}
+      >
+        {({ step }) => <ClusterStep step={step} data={data.current} />}
+      </WizardStep>
+      <WizardStep
+        id="monitor"
+        title={strings.createClusterWizard.steps.monitor.stepTitle()}
+        label={strings.createClusterWizard.steps.monitor.stepLabel()}
+      >
+        {({ step }) => <MonitorStep step={step} data={data.current} />}
+      </WizardStep>
+      <WizardStep
+        id="node"
+        title={strings.createClusterWizard.steps.node.stepTitle()}
+        label={strings.createClusterWizard.steps.node.stepLabel()}
+      >
+        {({ step }) => <NodeStep step={step} data={data.current} />}
+      </WizardStep>
+    </StyledWizard>
+  );
+};
+
+CreateClusterWizard.propTypes = {
+  /**
+   * Called if the Wizard is canceled.
+   *
+   * Signature: `() => void`
+   */
+  onCancel: propTypes.func,
+
+  /**
+   * Called when the user exits the Wizard after completing all steps.
+   *
+   * Signature: `(info: { data }) => void`
+   *
+   * - `info.data`: All data accumulated in the wizard.
+   */
+  onComplete: propTypes.func,
+};

--- a/src/renderer/components/CreateClusterWizard/EquinixProvider.js
+++ b/src/renderer/components/CreateClusterWizard/EquinixProvider.js
@@ -1,0 +1,119 @@
+import { useCallback, useState, useEffect } from 'react';
+import propTypes from 'prop-types';
+import { Renderer } from '@k8slens/extensions';
+import { WizardStep } from '../Wizard/WizardStep';
+import * as strings from '../../../strings';
+import { RequiredMark } from '../RequiredMark';
+
+const {
+  Component: { Input, Select },
+} = Renderer;
+
+/**
+ * Determines if the Next button should be enabled for this step.
+ * @param {Object} data Wizard data object.
+ * @returns {boolean} True to enable; false to disable.
+ */
+const getNextEnabled = function (data) {
+  const { provider } = data;
+
+  return !!(provider.facility && provider.vlanId);
+};
+
+export const EquinixProvider = function ({
+  // eslint-disable-next-line react/prop-types -- doesn't support prop type spread we're using
+  step: { onChange, stepIndex },
+  data,
+}) {
+  //
+  // STATE
+  //
+
+  if (!data.provider) {
+    // initialize step data
+    data.provider = { vlanId: null, facility: null };
+  }
+
+  const [facility, setFacility] = useState(data.provider.facility);
+  const [vlanId, setVlanId] = useState(data.provider.vlanId || '');
+
+  //
+  // EVENTS
+  //
+
+  const handleFacilityChange = useCallback(
+    function (newSelection) {
+      const newValue = newSelection?.value || null;
+      setFacility(newValue);
+      data.provider = { ...data.provider, facility: newValue };
+      onChange?.({ nextEnabled: getNextEnabled(data), stepIndex });
+    },
+    [data, onChange, stepIndex]
+  );
+
+  const handleVlandIdChange = useCallback(
+    function (newValue, event) {
+      setVlanId(newValue);
+      data.provider = { ...data.provider, vlanId: newValue };
+      onChange?.({ nextEnabled: getNextEnabled(data), stepIndex });
+    },
+    [data, onChange, stepIndex]
+  );
+
+  //
+  // EFFECTS
+  //
+
+  useEffect(
+    function () {
+      onChange?.({
+        nextEnabled: getNextEnabled(data),
+        stepIndex,
+      });
+    },
+    [data, stepIndex, onChange]
+  );
+
+  //
+  // RENDER
+  //
+
+  // TODO: may need to get these from the API, or are they known?
+  const facilityOptions = [
+    { value: 'facility1', label: 'Facility 1' },
+    { value: 'facility2', label: 'Facility 2' },
+  ];
+
+  return (
+    <>
+      <label htmlFor="wiz-create-cluster--provider--equinix--facility">
+        {strings.createClusterWizard.steps.provider.equinix.fields.facilityLabel()}
+        <RequiredMark />
+      </label>
+      <Select
+        required
+        isClearable
+        options={facilityOptions}
+        value={facility}
+        onChange={handleFacilityChange}
+      />
+      <label htmlFor="wiz-create-cluster--provider--equinix--vlanId">
+        {strings.createClusterWizard.steps.provider.equinix.fields.vlanIdLabel()}
+        <RequiredMark />
+      </label>
+      <Input
+        type="text"
+        theme="round-black" // borders on all sides, rounded corners
+        value={vlanId}
+        required
+        trim
+        onChange={handleVlandIdChange}
+      />
+    </>
+  );
+};
+
+EquinixProvider.propTypes = {
+  step: propTypes.shape({ ...WizardStep.props }).isRequired,
+  data: propTypes.object.isRequired,
+};

--- a/src/renderer/components/CreateClusterWizard/GeneralStep.js
+++ b/src/renderer/components/CreateClusterWizard/GeneralStep.js
@@ -1,0 +1,103 @@
+import { useCallback, useState, useEffect } from 'react';
+import propTypes from 'prop-types';
+import { Renderer } from '@k8slens/extensions';
+import { WizardStep } from '../Wizard/WizardStep';
+import { RequiredMark } from '../RequiredMark';
+import { providerTypes } from '../../../constants';
+import * as strings from '../../../strings';
+
+const {
+  Component: { Input },
+} = Renderer;
+
+/**
+ * Determines if the Next button should be enabled for this step.
+ * @param {Object} data Wizard data object.
+ * @returns {boolean} True to enable; false to disable.
+ */
+const getNextEnabled = function (data) {
+  const { general } = data;
+
+  return !!(general.clusterName && general.providerType);
+};
+
+// eslint-disable-next-line react/prop-types -- doesn't support prop type spread we're using
+export const GeneralStep = function ({ step: { onChange, stepIndex }, data }) {
+  //
+  // STATE
+  //
+
+  if (!data.general) {
+    // initialize step data
+    data.general = {
+      clusterName: null,
+      providerType: providerTypes.EQUINIX, // default to most popular
+    };
+  }
+
+  const [clusterName, setClusterName] = useState(
+    data.general.clusterName || ''
+  );
+
+  //
+  // EVENTS
+  //
+
+  const handleClusterNameChange = useCallback(
+    function (newValue, event) {
+      setClusterName(newValue);
+      data.general = { ...data.general, clusterName: newValue };
+      onChange?.({ nextEnabled: getNextEnabled(data), stepIndex });
+    },
+    [data, onChange, stepIndex]
+  );
+
+  //
+  // EFFECTS
+  //
+
+  useEffect(
+    function () {
+      onChange?.({
+        nextEnabled: getNextEnabled(data),
+        stepIndex,
+      });
+    },
+    [data, stepIndex, onChange]
+  );
+
+  //
+  // RENDER
+  //
+
+  return (
+    <>
+      <label htmlFor="wiz-create-cluster--general--cluster-name">
+        {strings.createClusterWizard.steps.general.fields.clusterNameLabel()}
+        <RequiredMark />
+      </label>
+      <Input
+        type="text"
+        theme="round-black" // borders on all sides, rounded corners
+        value={clusterName}
+        required
+        trim
+        onChange={handleClusterNameChange}
+      />
+      <h2>{strings.createClusterWizard.steps.general.chooseProvider()}</h2>
+      <p>
+        TODO: Provider tiles with selection based on
+        data.general.providerType...
+      </p>
+      <h2>
+        {strings.createClusterWizard.steps.general.providerRequirements()}
+      </h2>
+      <p>TODO: Checklist...</p>
+    </>
+  );
+};
+
+GeneralStep.propTypes = {
+  step: propTypes.shape({ ...WizardStep.props }).isRequired,
+  data: propTypes.object.isRequired,
+};

--- a/src/renderer/components/CreateClusterWizard/MonitorStep.js
+++ b/src/renderer/components/CreateClusterWizard/MonitorStep.js
@@ -1,0 +1,57 @@
+import { useEffect } from 'react';
+import propTypes from 'prop-types';
+import { WizardStep } from '../Wizard/WizardStep';
+
+/**
+ * Determines if the Next button should be enabled for this step.
+ * @param {Object} data Wizard data object.
+ * @returns {boolean} True to enable; false to disable.
+ */
+const getNextEnabled = function (data) {
+  const { monitor } = data;
+
+  return !!monitor; // TODO
+};
+
+// eslint-disable-next-line react/prop-types -- doesn't support prop type spread we're using
+export const MonitorStep = function ({ step: { onChange, stepIndex }, data }) {
+  //
+  // STATE
+  //
+
+  if (!data.monitor) {
+    // initialize step data
+    data.monitor = {
+      // TODO
+    };
+  }
+
+  //
+  // EVENTS
+  //
+
+  //
+  // EFFECTS
+  //
+
+  useEffect(
+    function () {
+      onChange?.({
+        nextEnabled: getNextEnabled(data),
+        stepIndex,
+      });
+    },
+    [data, stepIndex, onChange]
+  );
+
+  //
+  // RENDER
+  //
+
+  return <p>TODO: Monitor settings...</p>;
+};
+
+MonitorStep.propTypes = {
+  step: propTypes.shape({ ...WizardStep.props }).isRequired,
+  data: propTypes.object.isRequired,
+};

--- a/src/renderer/components/CreateClusterWizard/NodeStep.js
+++ b/src/renderer/components/CreateClusterWizard/NodeStep.js
@@ -1,0 +1,57 @@
+import { useEffect } from 'react';
+import propTypes from 'prop-types';
+import { WizardStep } from '../Wizard/WizardStep';
+
+/**
+ * Determines if the Next button should be enabled for this step.
+ * @param {Object} data Wizard data object.
+ * @returns {boolean} True to enable; false to disable.
+ */
+const getNextEnabled = function (data) {
+  const { node } = data;
+
+  return !!node; // TODO
+};
+
+// eslint-disable-next-line react/prop-types -- doesn't support prop type spread we're using
+export const NodeStep = function ({ step: { onChange, stepIndex }, data }) {
+  //
+  // STATE
+  //
+
+  if (!data.node) {
+    // initialize step data
+    data.node = {
+      // TODO
+    };
+  }
+
+  //
+  // EVENTS
+  //
+
+  //
+  // EFFECTS
+  //
+
+  useEffect(
+    function () {
+      onChange?.({
+        nextEnabled: getNextEnabled(data),
+        stepIndex,
+      });
+    },
+    [data, stepIndex, onChange]
+  );
+
+  //
+  // RENDER
+  //
+
+  return <p>TODO: Node settings...</p>;
+};
+
+NodeStep.propTypes = {
+  step: propTypes.shape({ ...WizardStep.props }).isRequired,
+  data: propTypes.object.isRequired,
+};

--- a/src/renderer/components/CreateClusterWizard/ProviderStep.js
+++ b/src/renderer/components/CreateClusterWizard/ProviderStep.js
@@ -1,0 +1,25 @@
+import propTypes from 'prop-types';
+import { WizardStep } from '../Wizard/WizardStep';
+import { providerTypes } from '../../../constants';
+import { EquinixProvider } from './EquinixProvider';
+
+// eslint-disable-next-line react/prop-types -- doesn't support prop type spread we're using
+export const ProviderStep = function (props) {
+  const {
+    data: {
+      general: { providerType },
+    },
+  } = props;
+
+  switch (providerType) {
+    case providerTypes.EQUINIX:
+      return <EquinixProvider {...props} />;
+    default:
+      throw new Error(`Unsupported provider type "${providerType}"`);
+  }
+};
+
+ProviderStep.propTypes = {
+  step: propTypes.shape({ ...WizardStep.props }).isRequired,
+  data: propTypes.object.isRequired,
+};

--- a/src/renderer/components/CreateClusterWizard/createClusterUtil.js
+++ b/src/renderer/components/CreateClusterWizard/createClusterUtil.js
@@ -1,0 +1,4 @@
+import { layout } from '../styles';
+
+// general vertical gap between everything
+export const vGap = layout.gap * 7; // 28px

--- a/src/renderer/components/EnhancedTable/EnhancedTable.js
+++ b/src/renderer/components/EnhancedTable/EnhancedTable.js
@@ -31,6 +31,8 @@ export const EnhancedTable = ({
   isSelectiveSyncView,
   isSyncStarted,
   getDataToSync,
+  getCloudMenuItems,
+  getNamespaceMenuItems,
 }) => {
   const { path, headCellValue } = getTableData(isSelectiveSyncView);
   const [sortedBy, setSortedBy] = useState(headCellValue.NAME);
@@ -64,6 +66,8 @@ export const EnhancedTable = ({
               withCheckboxes={isSelectiveSyncView}
               isSyncStarted={isSyncStarted}
               getDataToSync={getDataToSync}
+              getCloudMenuItems={getCloudMenuItems}
+              getNamespaceMenuItems={getNamespaceMenuItems}
             />
           );
         })}
@@ -80,9 +84,36 @@ EnhancedTable.propTypes = {
   isSelectiveSyncView: PropTypes.bool,
   isSyncStarted: PropTypes.bool.isRequired,
   getDataToSync: PropTypes.func,
+
+  /**
+   * Called to get context menu items for a given Cloud.
+   *
+   * Signature: `(cloud: Cloud) => Array<{ title: string, disabled?: boolean, onClick: () => void }>`
+   *
+   * - `cloud`: The Cloud for which to get items.
+   * - Returns: Array of objects that describe menu items in the Lens MenuItem component.
+   *     The `title` property becomes the item's `children`, and the rest of the properties
+   *     are props spread onto a `MenuItem` component.
+   */
+  getCloudMenuItems: PropTypes.func,
+
+  /**
+   * Called to get context menu items for a given Namespace in a Cloud.
+   *
+   * Signature: `(cloud: Cloud, namespace: CloudNamespace) => Array<{ title: string, disabled?: boolean, onClick: () => void }>`
+   *
+   * - `cloud`: The Cloud for which to get items.
+   * - `namespace`: A namespace in the `cloud` for which to get items.
+   * - Returns: Array of objects that describe menu items in the Lens MenuItem component.
+   *     The `title` property becomes the item's `children`, and the rest of the properties
+   *     are props spread onto a `MenuItem` component.
+   */
+  getNamespaceMenuItems: PropTypes.func,
 };
 
 EnhancedTable.defaultProps = {
   isSelectiveSyncView: false,
   getDataToSync: null,
+  getCloudMenuItems: () => [],
+  getNamespaceMenuItems: () => [],
 };

--- a/src/renderer/components/EnhancedTable/TableRowListenerWrapper.js
+++ b/src/renderer/components/EnhancedTable/TableRowListenerWrapper.js
@@ -124,4 +124,34 @@ TableRowListenerWrapper.propTypes = {
   withCheckboxes: PropTypes.bool.isRequired,
   isSyncStarted: PropTypes.bool,
   getDataToSync: PropTypes.func,
+
+  /**
+   * Called to get context menu items for a given Cloud.
+   *
+   * Signature: `(cloud: Cloud) => Array<{ title: string, disabled?: boolean, onClick: () => void }>`
+   *
+   * - `cloud`: The Cloud for which to get items.
+   * - Returns: Array of objects that describe menu items in the Lens MenuItem component.
+   *     The `title` property becomes the item's `children`, and the rest of the properties
+   *     are props spread onto a `MenuItem` component.
+   */
+  getCloudMenuItems: PropTypes.func,
+
+  /**
+   * Called to get context menu items for a given Namespace in a Cloud.
+   *
+   * Signature: `(cloud: Cloud, namespace: CloudNamespace) => Array<{ title: string, disabled?: boolean, onClick: () => void }>`
+   *
+   * - `cloud`: The Cloud for which to get items.
+   * - `namespace`: A namespace in the `cloud` for which to get items.
+   * - Returns: Array of objects that describe menu items in the Lens MenuItem component.
+   *     The `title` property becomes the item's `children`, and the rest of the properties
+   *     are props spread onto a `MenuItem` component.
+   */
+  getNamespaceMenuItems: PropTypes.func,
+};
+
+TableRowListenerWrapper.defaultProps = {
+  getCloudMenuItems: () => [],
+  getNamespaceMenuItems: () => [],
 };

--- a/src/renderer/components/EnhancedTable/__tests__/EnhancedTable.spec.js
+++ b/src/renderer/components/EnhancedTable/__tests__/EnhancedTable.spec.js
@@ -17,7 +17,7 @@ describe('/renderer/components/EnhancedTable/EnhancedTable', () => {
 
   beforeEach(() => {
     user = userEvent.setup();
-    mockConsole(); // automatically restored after each test
+    mockConsole(['log', 'info', 'warn']); // automatically restored after each test
 
     IpcRenderer.createInstance(extension);
 

--- a/src/renderer/components/EnhancedTable/__tests__/EnhancedTableRow.spec.js
+++ b/src/renderer/components/EnhancedTable/__tests__/EnhancedTableRow.spec.js
@@ -1,16 +1,11 @@
 import mockConsole from 'jest-mock-console';
-import { render, screen, sleep } from 'testingUtility';
+import { render, screen } from 'testingUtility';
 import userEvent from '@testing-library/user-event';
 import { EnhancedTableRow } from '../EnhancedTableRow';
-import {
-  Cloud,
-  mkCloudJson,
-  CONNECTION_STATUSES,
-} from '../../../../common/Cloud'; // MOCKED
-import { CloudProvider, useClouds } from '../../../store/CloudProvider';
+import { Cloud, CONNECTION_STATUSES } from '../../../../common/Cloud'; // MOCKED
+import { CloudProvider } from '../../../store/CloudProvider';
 import { IpcRenderer } from '../../../IpcRenderer';
 import { CloudStore } from '../../../../store/CloudStore';
-import { ConfirmDialog } from '../../../../../__mocks__/@k8slens/extensions';
 import * as strings from '../../../../strings';
 
 jest.mock('../../../../common/Cloud');
@@ -29,7 +24,7 @@ describe('/renderer/components/EnhancedTable/EnhancedTable', () => {
 
   beforeEach(() => {
     user = userEvent.setup();
-    mockConsole(); // automatically restored after each test
+    mockConsole(['log', 'info', 'warn']); // automatically restored after each test
 
     IpcRenderer.createInstance(extension);
   });
@@ -219,185 +214,6 @@ describe('/renderer/components/EnhancedTable/EnhancedTable', () => {
         screen.getByText(strings.synchronizeBlock.synchronizeFutureProjects())
       );
       expect(warningBlock).toHaveStyle('opacity: 1');
-    });
-  });
-
-  describe('getCloudMenuItems()', () => {
-    let fakeCloudJson,
-      fakeCloudWithoutNamespacesJson,
-      disconnectedFakeCloudJson;
-
-    const Table = () => {
-      const { clouds } = useClouds();
-
-      return (
-        <>
-          <table>
-            <tbody>
-              {Object.values(clouds).map((cloud) => (
-                <EnhancedTableRow
-                  key={cloud.name}
-                  cloud={cloud}
-                  withCheckboxes={false}
-                  isSyncStarted={false}
-                  getDataToSync={() => {}}
-                  namespaces={cloud.namespaces}
-                  status={{
-                    cloudStatus:
-                      strings.connectionStatuses.cloud.disconnected(),
-                    namespaceStatus:
-                      strings.connectionStatuses.namespace.disconnected(),
-                    styles: colorGray,
-                  }}
-                />
-              ))}
-            </tbody>
-          </table>
-        </>
-      );
-    };
-
-    beforeEach(() => {
-      fakeCloudJson = mkCloudJson({
-        name: 'bar',
-        cloudUrl: 'http://bar.com',
-        status: CONNECTION_STATUSES.CONNECTED,
-        syncedProjects: ['bar namespace'],
-        namespaces: [
-          {
-            cloudUrl: 'https://bar.com',
-            clusterCount: 4,
-            credentialCount: 4,
-            licenseCount: 1,
-            machineCount: 12,
-            name: 'bar namespace',
-            proxyCount: 0,
-            sshKeyCount: 2,
-            synced: true,
-          },
-        ],
-      });
-
-      fakeCloudWithoutNamespacesJson = mkCloudJson({
-        name: 'bar',
-        cloudUrl: 'http://bar.com',
-        loaded: true,
-        connected: true,
-        status: CONNECTION_STATUSES.DISCONNECTED,
-        namespaces: [],
-      });
-
-      disconnectedFakeCloudJson = mkCloudJson({
-        name: 'foo',
-        cloudUrl: 'http://foo.com',
-        status: CONNECTION_STATUSES.DISCONNECTED,
-        namespaces: [
-          {
-            cloudUrl: 'https://foo.com',
-            clusterCount: 4,
-            credentialCount: 4,
-            licenseCount: 1,
-            machineCount: 12,
-            name: 'foo namespace',
-            proxyCount: 0,
-            sshKeyCount: 2,
-            synced: false,
-          },
-        ],
-      });
-    });
-
-    it('triggers reconnect cloud action by clicking on "Reconnect" button', async () => {
-      CloudStore.initStore('cloud-store', {
-        clouds: {
-          'http://foo.com': disconnectedFakeCloudJson,
-        },
-      });
-      CloudStore.createInstance().loadExtension(extension);
-
-      render(
-        <CloudProvider>
-          <Table />
-        </CloudProvider>
-      );
-
-      await user.click(screen.getByText('Reconnect'));
-      await sleep(10);
-
-      expect(screen.getByText('http://foo.com')).toBeInTheDocument();
-    });
-
-    it('cloud |without| namespaces: triggers remove cloud action by clicking on "Remove" button', async () => {
-      CloudStore.initStore('cloud-store', {
-        clouds: {
-          'http://bar.com': fakeCloudWithoutNamespacesJson,
-        },
-      });
-      CloudStore.createInstance().loadExtension(extension);
-
-      render(
-        <CloudProvider>
-          <Table />
-        </CloudProvider>
-      );
-
-      await user.click(screen.getByText('Remove'));
-      await sleep(10);
-
-      expect(screen.queryByText('http://bar.com')).not.toBeInTheDocument();
-    });
-
-    it('cloud |with| namespaces: triggers remove cloud action by clicking on "Remove" button', async () => {
-      CloudStore.initStore('cloud-store', {
-        clouds: {
-          'http://bar.com': fakeCloudJson,
-        },
-      });
-      CloudStore.createInstance().loadExtension(extension);
-
-      render(
-        <CloudProvider>
-          <ConfirmDialog />
-          <Table />
-        </CloudProvider>
-      );
-
-      await user.click(screen.getByText('Remove'));
-      await sleep(10);
-
-      await user.click(document.querySelector('.confirm-buttons .ok'));
-      expect(screen.queryByText('http://bar.com')).not.toBeInTheDocument();
-    });
-
-    it('triggers open in browser action by clicking on "Open in browser" button', async () => {
-      const logSpy = jest.spyOn(console, 'log');
-
-      CloudStore.initStore('cloud-store', {
-        clouds: {
-          'http://bar.com': fakeCloudJson,
-        },
-      });
-      CloudStore.createInstance().loadExtension(extension);
-
-      render(
-        <CloudProvider>
-          <Table />
-        </CloudProvider>
-      );
-
-      await user.click(screen.getByText('Open in browser'));
-
-      const searchInMultiDim = (arr, str) => {
-        return (
-          arr.find((t) => {
-            return t.find((i) => i === str);
-          }) && true
-        );
-      };
-
-      expect(
-        searchInMultiDim(logSpy.mock.calls, 'External url: http://bar.com')
-      ).toBe(true);
     });
   });
 });

--- a/src/renderer/components/EnhancedTable/__tests__/TableRowListenerWrapper.spec.js
+++ b/src/renderer/components/EnhancedTable/__tests__/TableRowListenerWrapper.spec.js
@@ -20,7 +20,7 @@ describe('/renderer/components/EnhancedTable/TableRowListenerWrapper', () => {
 
   beforeEach(() => {
     user = userEvent.setup();
-    mockConsole(); // automatically restored after each test
+    mockConsole(['log', 'info', 'warn']); // automatically restored after each test
 
     IpcRenderer.createInstance(extension);
     CloudStore.createInstance().loadExtension(extension);

--- a/src/renderer/components/GlobalPage/ConnectionBlock.js
+++ b/src/renderer/components/GlobalPage/ConnectionBlock.js
@@ -7,6 +7,7 @@ import { layout } from '../styles';
 import { normalizeUrl } from '../../../util/netUtil';
 import { connectionBlock } from '../../../strings';
 import { useClouds } from '../../store/CloudProvider';
+import { RequiredMark } from '../RequiredMark';
 
 const {
   Component: { Input, Button },
@@ -39,11 +40,6 @@ const Field = styled.div(() => ({
 const ButtonWrapper = styled.div(() => ({
   marginTop: layout.gap,
 }));
-
-const RequiredMark = styled.span`
-  color: var(--colorError);
-  margin-left: ${layout.grid}px;
-`;
 
 const mkCloudAlreadySyncedValidator = (clouds) => ({
   message: () => connectionBlock.notice.urlAlreadyUsed(),
@@ -85,7 +81,7 @@ export const ConnectionBlock = ({ loading, handleClusterConnect }) => {
       <Field>
         <label htmlFor="lecc-cluster-name">
           {connectionBlock.clusterName.label()}
-          <RequiredMark>*</RequiredMark>
+          <RequiredMark />
         </label>
         <Input
           type="text"
@@ -103,7 +99,7 @@ export const ConnectionBlock = ({ loading, handleClusterConnect }) => {
       <Field>
         <label htmlFor="lecc-cluster-url">
           {connectionBlock.clusterUrl.label()}
-          <RequiredMark>*</RequiredMark>
+          <RequiredMark />
         </label>
         <Input
           type="url"

--- a/src/renderer/components/GlobalPage/__tests__/GlobalPage.spec.js
+++ b/src/renderer/components/GlobalPage/__tests__/GlobalPage.spec.js
@@ -11,7 +11,7 @@ describe('/renderer/components/GlobalPage/GlobalPage', () => {
   const extension = {};
 
   beforeEach(() => {
-    mockConsole(); // automatically restored after each test
+    mockConsole(['log', 'info', 'warn']); // automatically restored after each test
 
     IpcRenderer.createInstance(extension);
     CloudStore.createInstance().loadExtension(extension);

--- a/src/renderer/components/GlobalPage/__tests__/SyncView-contextMenus.spec.js
+++ b/src/renderer/components/GlobalPage/__tests__/SyncView-contextMenus.spec.js
@@ -1,0 +1,176 @@
+import mockConsole from 'jest-mock-console';
+import { render, screen, sleep } from 'testingUtility';
+import userEvent from '@testing-library/user-event';
+import { Renderer } from '@k8slens/extensions';
+import { CloudProvider } from '../../../store/CloudProvider';
+import { IpcRenderer } from '../../../IpcRenderer';
+import { CloudStore } from '../../../../store/CloudStore';
+import { mkCloudJson, CONNECTION_STATUSES } from '../../../../common/Cloud'; // MOCKED
+import { SyncView } from '../SyncView';
+
+jest.mock('../../../../common/Cloud');
+
+const {
+  Component: { ConfirmDialog },
+} = Renderer;
+
+describe('/renderer/components/GlobalPage/SyncView', () => {
+  const extension = {};
+  let user;
+
+  beforeEach(() => {
+    user = userEvent.setup();
+    mockConsole(['log', 'info', 'warn']); // automatically restored after each test
+
+    IpcRenderer.createInstance(extension);
+  });
+
+  describe('getCloudMenuItems()', () => {
+    let fakeCloudJson;
+    let fakeCloudWithoutNamespacesJson;
+    let disconnectedFakeCloudJson;
+
+    beforeEach(() => {
+      fakeCloudJson = mkCloudJson({
+        name: 'bar',
+        cloudUrl: 'http://bar.com',
+        status: CONNECTION_STATUSES.CONNECTED,
+        syncedProjects: ['bar namespace'],
+        namespaces: [
+          {
+            cloudUrl: 'https://bar.com',
+            clusterCount: 4,
+            credentialCount: 4,
+            licenseCount: 1,
+            machineCount: 12,
+            name: 'bar namespace',
+            proxyCount: 0,
+            sshKeyCount: 2,
+            synced: true,
+          },
+        ],
+      });
+
+      fakeCloudWithoutNamespacesJson = mkCloudJson({
+        name: 'bar',
+        cloudUrl: 'http://bar.com',
+        loaded: true,
+        connected: true,
+        status: CONNECTION_STATUSES.DISCONNECTED,
+        namespaces: [],
+      });
+
+      disconnectedFakeCloudJson = mkCloudJson({
+        name: 'foo',
+        cloudUrl: 'http://foo.com',
+        status: CONNECTION_STATUSES.DISCONNECTED,
+        namespaces: [
+          {
+            cloudUrl: 'https://foo.com',
+            clusterCount: 4,
+            credentialCount: 4,
+            licenseCount: 1,
+            machineCount: 12,
+            name: 'foo namespace',
+            proxyCount: 0,
+            sshKeyCount: 2,
+            synced: false,
+          },
+        ],
+      });
+    });
+
+    it('triggers reconnect cloud action by clicking on "Reconnect" button', async () => {
+      CloudStore.initStore('cloud-store', {
+        clouds: {
+          'http://foo.com': disconnectedFakeCloudJson,
+        },
+      });
+      CloudStore.createInstance().loadExtension(extension);
+
+      render(
+        <CloudProvider>
+          <SyncView />
+        </CloudProvider>
+      );
+
+      await user.click(screen.getByText('Reconnect'));
+      await sleep(10);
+
+      expect(screen.getByText('http://foo.com')).toBeInTheDocument();
+    });
+
+    it('cloud |without| namespaces: triggers remove cloud action by clicking on "Remove" button', async () => {
+      CloudStore.initStore('cloud-store', {
+        clouds: {
+          'http://bar.com': fakeCloudWithoutNamespacesJson,
+        },
+      });
+      CloudStore.createInstance().loadExtension(extension);
+
+      render(
+        <CloudProvider>
+          <SyncView />
+        </CloudProvider>
+      );
+
+      await user.click(screen.getByText('Remove'));
+      await sleep(10);
+
+      expect(screen.queryByText('http://bar.com')).not.toBeInTheDocument();
+    });
+
+    it('cloud |with| namespaces: triggers remove cloud action by clicking on "Remove" button', async () => {
+      CloudStore.initStore('cloud-store', {
+        clouds: {
+          'http://bar.com': fakeCloudJson,
+        },
+      });
+      CloudStore.createInstance().loadExtension(extension);
+
+      render(
+        <CloudProvider>
+          <ConfirmDialog />
+          <SyncView />
+        </CloudProvider>
+      );
+
+      await user.click(screen.getByText('Remove'));
+      await sleep(10);
+
+      await user.click(document.querySelector('.confirm-buttons .ok'));
+      expect(screen.queryByText('http://bar.com')).not.toBeInTheDocument();
+    });
+
+    it('triggers open in browser action by clicking on "Open in browser" button', async () => {
+      const logSpy = jest.spyOn(console, 'log');
+
+      CloudStore.initStore('cloud-store', {
+        clouds: {
+          'http://bar.com': fakeCloudJson,
+        },
+      });
+      CloudStore.createInstance().loadExtension(extension);
+
+      render(
+        <CloudProvider>
+          <SyncView />
+        </CloudProvider>
+      );
+
+      await user.click(screen.getByText('Open in browser'));
+
+      const searchInMultiDim = (arr, str) => {
+        return (
+          arr.find((t) => {
+            return t.find((i) => i === str);
+          }) && true
+        );
+      };
+
+      expect(
+        searchInMultiDim(logSpy.mock.calls, 'External url: http://bar.com')
+      ).toBe(true);
+    });
+  });
+});

--- a/src/renderer/components/GlobalPage/__tests__/SyncView.spec.js
+++ b/src/renderer/components/GlobalPage/__tests__/SyncView.spec.js
@@ -1,11 +1,11 @@
 import mockConsole from 'jest-mock-console';
 import { render, screen } from 'testingUtility';
 import userEvent from '@testing-library/user-event';
-import { SyncView } from '../SyncView';
 import { CloudProvider } from '../../../store/CloudProvider';
 import { IpcRenderer } from '../../../IpcRenderer';
 import { CloudStore } from '../../../../store/CloudStore';
 import * as strings from '../../../../strings';
+import { SyncView } from '../SyncView';
 
 describe('/renderer/components/GlobalPage/SyncView', () => {
   const extension = {};
@@ -13,7 +13,7 @@ describe('/renderer/components/GlobalPage/SyncView', () => {
 
   beforeEach(() => {
     user = userEvent.setup();
-    mockConsole(); // automatically restored after each test
+    mockConsole(['log', 'info', 'warn']); // automatically restored after each test
 
     IpcRenderer.createInstance(extension);
   });
@@ -56,6 +56,7 @@ describe('/renderer/components/GlobalPage/SyncView', () => {
             namespaces: [
               {
                 name: 'namespace 1',
+                cloudUrl: 'https://foo.com',
                 clusterCount: 4,
                 machineCount: 12,
                 sshKeyCount: 2,
@@ -66,6 +67,7 @@ describe('/renderer/components/GlobalPage/SyncView', () => {
               },
               {
                 name: 'namespace 2',
+                cloudUrl: 'https://foo.com',
                 clusterCount: 1,
                 machineCount: 6,
                 sshKeyCount: 9,
@@ -76,6 +78,7 @@ describe('/renderer/components/GlobalPage/SyncView', () => {
               },
               {
                 name: 'namespace 3',
+                cloudUrl: 'https://foo.com',
                 clusterCount: 0,
                 machineCount: 0,
                 sshKeyCount: 0,
@@ -86,6 +89,7 @@ describe('/renderer/components/GlobalPage/SyncView', () => {
               },
               {
                 name: 'namespace 4',
+                cloudUrl: 'https://foo.com',
                 clusterCount: 2,
                 machineCount: 10,
                 sshKeyCount: 3,
@@ -96,6 +100,7 @@ describe('/renderer/components/GlobalPage/SyncView', () => {
               },
               {
                 name: 'namespace 5',
+                cloudUrl: 'https://foo.com',
                 clusterCount: 2,
                 machineCount: 10,
                 sshKeyCount: 1,
@@ -121,7 +126,7 @@ describe('/renderer/components/GlobalPage/SyncView', () => {
       expect(screen.getByText(strings.syncView.title())).toBeInTheDocument();
     });
 
-    it('show ConnectionBlock component by clicking on connect button and close it by clicking on cancel button', async () => {
+    it('shows ConnectionBlock component by clicking on connect button and close it by clicking on cancel button', async () => {
       render(
         <CloudProvider>
           <SyncView />
@@ -139,7 +144,7 @@ describe('/renderer/components/GlobalPage/SyncView', () => {
       expect(screen.queryByText(connectionBlockTitle)).not.toBeInTheDocument();
     });
 
-    it('open Selective Sync view by clicking on syncView button and close it by clicking on cancel button', async () => {
+    it('opens Selective Sync view by clicking on syncView button and close it by clicking on cancel button', async () => {
       render(
         <CloudProvider>
           <SyncView />
@@ -164,7 +169,7 @@ describe('/renderer/components/GlobalPage/SyncView', () => {
       ).not.toBeInTheDocument();
     });
 
-    it('synchronize selected projects', async () => {
+    it('synchronizes selected projects', async () => {
       render(
         <CloudProvider>
           <SyncView />

--- a/src/renderer/components/RequiredMark.js
+++ b/src/renderer/components/RequiredMark.js
@@ -1,0 +1,11 @@
+import styled from '@emotion/styled';
+import { layout } from './styles';
+
+export const RequiredMark = styled.span(() => ({
+  color: 'var(--colorError)',
+  marginLeft: layout.grid,
+
+  '&::before': {
+    content: '"*"',
+  },
+}));

--- a/src/strings.ts
+++ b/src/strings.ts
@@ -424,6 +424,7 @@ export const contextMenus: Dict = {
   },
   namespace: {
     openInBrowser: () => 'Open in browser',
+    createCluster: () => 'Create cluster',
   },
 };
 
@@ -431,4 +432,43 @@ export const wizard: Dict = {
   back: () => 'Back',
   next: () => 'Next',
   finish: () => 'Finish',
+};
+
+export const createClusterWizard: Dict = {
+  title: () => 'Create new cluster',
+  lastLabel: () => 'Create cluster',
+  steps: {
+    general: {
+      stepTitle: () => 'General',
+      chooseProvider: () => 'Choose your provider',
+      providerRequirements: () => 'Provider requirements',
+      fields: {
+        clusterNameLabel: () => 'Cluster name',
+      },
+    },
+    provider: {
+      stepLabel: () => 'Provider', // same for all providers
+      equinix: {
+        stepTitle: () => 'Equinix provider settings',
+        fields: {
+          facilityLabel: () => 'Facility',
+          vlanIdLabel: () => 'VLAN ID',
+        },
+      },
+    },
+    cluster: {
+      stepTitle: () => 'Cluster settings',
+      fields: {},
+    },
+    monitor: {
+      stepTitle: () => 'StackLight monitoring',
+      stepLabel: () => 'Monitoring',
+      fields: {},
+    },
+    node: {
+      stepTitle: () => 'Node pools',
+      stepLabel: () => 'Nodes',
+      fields: {},
+    },
+  },
 };

--- a/tools/tests/testTools.js
+++ b/tools/tests/testTools.js
@@ -48,7 +48,7 @@ export const expectErrorBoundary = function (
 ) {
   // even though we're rendering with an ErrorBoundary instance, React will still
   //  print the error to the console, so we need to eliminate the expected noise
-  const restoreConsole = mockConsole();
+  const restoreConsole = mockConsole(['log', 'info', 'warn']);
 
   const { queryByTestId } = renderer(component);
   expect(queryByTestId(GLOBAL_ERROR_BOUNDARY_TESTID)).toHaveTextContent(text);

--- a/yarn.lock
+++ b/yarn.lock
@@ -5056,7 +5056,7 @@ lodash.truncate@^4.4.2:
   resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
   integrity sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=
 
-lodash@^4.17.10, lodash@^4.17.15:
+lodash@^4.17.10, lodash@^4.17.15, lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==


### PR DESCRIPTION
Defines the steps with placeholders for content and establishes a few patterns
for how we will structure the code.

NOTE: For now, the 'Create cluster' item is only visible in dev builds.
This is so that we can easily work on the feature without making it available
if we need to publish an update, and so we don't need a feature branch.

Also relocates the cloud and namespace menu items from EnhancedTableRow to
the SyncView. EnhancedTableRow is just a component that's used by the view.
The view should be the owner of the menu items that get displayed, as well
as their handlers. In particular, the CreateClusterWizard, hence the change.

Also formally added lodash as a dependency. We were already using it, but
it wasn't declared. It must've been there as a downstream dependency of
babel-lodash.

Also updated all `mockConsole()` calls to only mock logs, infos, and
warnings, excluding errors, so that errors don't go unnoticed, since
sometimes there are errors but tests still succeed, and we shouldn't
have errors.

### Preview

![cluster-wizard-start](https://user-images.githubusercontent.com/2855350/182723702-1eeb3349-c8e7-47c3-ade3-13b4d4885d6d.gif)
