### PR TITLE
[PRODX-25977] Add RTV validation to wizard

### DIFF
--- a/src/renderer/components/CreateClusterWizard/ClusterStep.js
+++ b/src/renderer/components/CreateClusterWizard/ClusterStep.js
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import propTypes from 'prop-types';
+import * as rtv from 'rtvjs';
 import { WizardStep } from '../Wizard/WizardStep';
 
 /**
@@ -13,6 +14,9 @@ const getNextEnabled = function (data) {
   return !!cluster; // TODO
 };
 
+// describes this step's expected data structure
+export const clusterStepTs = {};
+
 // eslint-disable-next-line react/prop-types -- doesn't support prop type spread we're using
 export const ClusterStep = function ({ step: { onChange, stepIndex }, data }) {
   //
@@ -24,6 +28,10 @@ export const ClusterStep = function ({ step: { onChange, stepIndex }, data }) {
     data.cluster = {
       // TODO
     };
+  } else {
+    // NOTE: `exactShapes` helps ensure that we know when we've added a new property
+    //  in the code somewhere but didn't add it to the step's RTV typeset
+    DEV_ENV && rtv.verify(data.cluster, clusterStepTs, { exactShapes: true });
   }
 
   //

--- a/src/renderer/components/CreateClusterWizard/CreateClusterWizard.js
+++ b/src/renderer/components/CreateClusterWizard/CreateClusterWizard.js
@@ -1,17 +1,19 @@
 import { useRef, useState, useCallback } from 'react';
 import styled from '@emotion/styled';
 import propTypes from 'prop-types';
+import * as rtv from 'rtvjs';
 import { Wizard } from '../Wizard/Wizard';
 import { WizardStep } from '../Wizard/WizardStep';
 import * as strings from '../../../strings';
 import { layout } from '../styles';
 import { providerTypes } from '../../../constants';
 import { vGap } from './createClusterUtil';
-import { GeneralStep } from './GeneralStep';
+import { GeneralStep, generalStepTs } from './GeneralStep';
 import { ProviderStep } from './ProviderStep';
-import { ClusterStep } from './ClusterStep';
-import { MonitorStep } from './MonitorStep';
-import { NodeStep } from './NodeStep';
+import { ClusterStep, clusterStepTs } from './ClusterStep';
+import { MonitorStep, monitorStepTs } from './MonitorStep';
+import { NodeStep, nodeStepTs } from './NodeStep';
+import { equinixProviderTs } from './EquinixProvider';
 
 const StyledWizard = styled(Wizard)(() => ({
   // generally, inputs have a label above them, and each label+input is separated by
@@ -44,7 +46,7 @@ export const CreateClusterWizard = function ({ onCancel, onComplete }) {
   // STATE
   //
 
-  const data = useRef({}); // data collected in each step
+  const dataRef = useRef({}); // data collected in each step
   const [providerStepTitle, setProviderStepTitle] = useState(
     strings.createClusterWizard.steps.provider.equinix.stepTitle()
   );
@@ -56,13 +58,14 @@ export const CreateClusterWizard = function ({ onCancel, onComplete }) {
   const handleWizardComplete = useCallback(
     function () {
       if (typeof onComplete === 'function') {
-        onComplete({ data: data.current });
+        onComplete({ data: dataRef.current });
       }
     },
     [onComplete]
   );
 
   const handleNext = useCallback(function () {
+    const data = dataRef.current;
     const providerType = data.general?.providerType; // may not be set yet
 
     switch (providerType) {
@@ -73,6 +76,28 @@ export const CreateClusterWizard = function ({ onCancel, onComplete }) {
         break;
       default:
         break; // leave as-is
+    }
+
+    if (DEV_ENV) {
+      const dataTs = {
+        general: data.general ? generalStepTs : undefined,
+        provider: undefined,
+        cluster: data.cluster ? clusterStepTs : undefined,
+        monitor: data.monitor ? monitorStepTs : undefined,
+        node: data.node ? nodeStepTs : undefined,
+      };
+
+      switch (providerType) {
+        case providerTypes.EQUINIX:
+          dataTs.provider = data.provider ? equinixProviderTs : undefined;
+          break;
+        default:
+          break; // leave as-is
+      }
+
+      // NOTE: `exactShapes` helps ensure that we know when we've added a new property
+      //  in the code somewhere but didn't add it to the step's RTV typeset
+      rtv.verify(data, dataTs, { exactShapes: true });
     }
   }, []);
 
@@ -96,34 +121,34 @@ export const CreateClusterWizard = function ({ onCancel, onComplete }) {
         id="general"
         title={strings.createClusterWizard.steps.general.stepTitle()}
       >
-        {({ step }) => <GeneralStep step={step} data={data.current} />}
+        {({ step }) => <GeneralStep step={step} data={dataRef.current} />}
       </WizardStep>
       <WizardStep
         id="provider"
         title={providerStepTitle}
         label={strings.createClusterWizard.steps.provider.stepLabel()}
       >
-        {({ step }) => <ProviderStep step={step} data={data.current} />}
+        {({ step }) => <ProviderStep step={step} data={dataRef.current} />}
       </WizardStep>
       <WizardStep
         id="cluster"
         title={strings.createClusterWizard.steps.cluster.stepTitle()}
       >
-        {({ step }) => <ClusterStep step={step} data={data.current} />}
+        {({ step }) => <ClusterStep step={step} data={dataRef.current} />}
       </WizardStep>
       <WizardStep
         id="monitor"
         title={strings.createClusterWizard.steps.monitor.stepTitle()}
         label={strings.createClusterWizard.steps.monitor.stepLabel()}
       >
-        {({ step }) => <MonitorStep step={step} data={data.current} />}
+        {({ step }) => <MonitorStep step={step} data={dataRef.current} />}
       </WizardStep>
       <WizardStep
         id="node"
         title={strings.createClusterWizard.steps.node.stepTitle()}
         label={strings.createClusterWizard.steps.node.stepLabel()}
       >
-        {({ step }) => <NodeStep step={step} data={data.current} />}
+        {({ step }) => <NodeStep step={step} data={dataRef.current} />}
       </WizardStep>
     </StyledWizard>
   );

--- a/src/renderer/components/CreateClusterWizard/EquinixProvider.js
+++ b/src/renderer/components/CreateClusterWizard/EquinixProvider.js
@@ -1,6 +1,7 @@
 import { useCallback, useState, useEffect } from 'react';
 import propTypes from 'prop-types';
 import { Renderer } from '@k8slens/extensions';
+import * as rtv from 'rtvjs';
 import { WizardStep } from '../Wizard/WizardStep';
 import * as strings from '../../../strings';
 import { RequiredMark } from '../RequiredMark';
@@ -20,6 +21,12 @@ const getNextEnabled = function (data) {
   return !!(provider.facility && provider.vlanId);
 };
 
+// describes this step's expected data structure
+export const equinixProviderTs = {
+  vlanId: [rtv.EXPECTED, rtv.STRING],
+  facility: [rtv.EXPECTED, rtv.STRING],
+};
+
 export const EquinixProvider = function ({
   // eslint-disable-next-line react/prop-types -- doesn't support prop type spread we're using
   step: { onChange, stepIndex },
@@ -32,6 +39,11 @@ export const EquinixProvider = function ({
   if (!data.provider) {
     // initialize step data
     data.provider = { vlanId: null, facility: null };
+  } else {
+    // NOTE: `exactShapes` helps ensure that we know when we've added a new property
+    //  in the code somewhere but didn't add it to the step's RTV typeset
+    DEV_ENV &&
+      rtv.verify(data.provider, equinixProviderTs, { exactShapes: true });
   }
 
   const [facility, setFacility] = useState(data.provider.facility);

--- a/src/renderer/components/CreateClusterWizard/GeneralStep.js
+++ b/src/renderer/components/CreateClusterWizard/GeneralStep.js
@@ -1,6 +1,7 @@
 import { useCallback, useState, useEffect } from 'react';
 import propTypes from 'prop-types';
 import { Renderer } from '@k8slens/extensions';
+import * as rtv from 'rtvjs';
 import { WizardStep } from '../Wizard/WizardStep';
 import { RequiredMark } from '../RequiredMark';
 import { providerTypes } from '../../../constants';
@@ -21,6 +22,16 @@ const getNextEnabled = function (data) {
   return !!(general.clusterName && general.providerType);
 };
 
+// describes this step's expected data structure
+export const generalStepTs = {
+  clusterName: [rtv.EXPECTED, rtv.STRING],
+  providerType: [
+    rtv.EXPECTED,
+    rtv.STRING,
+    { oneOf: Object.values(providerTypes) },
+  ],
+};
+
 // eslint-disable-next-line react/prop-types -- doesn't support prop type spread we're using
 export const GeneralStep = function ({ step: { onChange, stepIndex }, data }) {
   //
@@ -33,6 +44,10 @@ export const GeneralStep = function ({ step: { onChange, stepIndex }, data }) {
       clusterName: null,
       providerType: providerTypes.EQUINIX, // default to most popular
     };
+  } else {
+    // NOTE: `exactShapes` helps ensure that we know when we've added a new property
+    //  in the code somewhere but didn't add it to the step's RTV typeset
+    DEV_ENV && rtv.verify(data.general, generalStepTs, { exactShapes: true });
   }
 
   const [clusterName, setClusterName] = useState(

--- a/src/renderer/components/CreateClusterWizard/MonitorStep.js
+++ b/src/renderer/components/CreateClusterWizard/MonitorStep.js
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import propTypes from 'prop-types';
+import * as rtv from 'rtvjs';
 import { WizardStep } from '../Wizard/WizardStep';
 
 /**
@@ -13,6 +14,9 @@ const getNextEnabled = function (data) {
   return !!monitor; // TODO
 };
 
+// describes this step's expected data structure
+export const monitorStepTs = {};
+
 // eslint-disable-next-line react/prop-types -- doesn't support prop type spread we're using
 export const MonitorStep = function ({ step: { onChange, stepIndex }, data }) {
   //
@@ -24,6 +28,10 @@ export const MonitorStep = function ({ step: { onChange, stepIndex }, data }) {
     data.monitor = {
       // TODO
     };
+  } else {
+    // NOTE: `exactShapes` helps ensure that we know when we've added a new property
+    //  in the code somewhere but didn't add it to the step's RTV typeset
+    DEV_ENV && rtv.verify(data.monitor, monitorStepTs, { exactShapes: true });
   }
 
   //

--- a/src/renderer/components/CreateClusterWizard/NodeStep.js
+++ b/src/renderer/components/CreateClusterWizard/NodeStep.js
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import propTypes from 'prop-types';
+import * as rtv from 'rtvjs';
 import { WizardStep } from '../Wizard/WizardStep';
 
 /**
@@ -13,6 +14,9 @@ const getNextEnabled = function (data) {
   return !!node; // TODO
 };
 
+// describes this step's expected data structure
+export const nodeStepTs = {};
+
 // eslint-disable-next-line react/prop-types -- doesn't support prop type spread we're using
 export const NodeStep = function ({ step: { onChange, stepIndex }, data }) {
   //
@@ -24,6 +28,10 @@ export const NodeStep = function ({ step: { onChange, stepIndex }, data }) {
     data.node = {
       // TODO
     };
+  } else {
+    // NOTE: `exactShapes` helps ensure that we know when we've added a new property
+    //  in the code somewhere but didn't add it to the step's RTV typeset
+    DEV_ENV && rtv.verify(data.node, nodeStepTs, { exactShapes: true });
   }
 
   //


### PR DESCRIPTION
This will help ensure that the data structure the wizard generates
is exactly as we expect it to be.

By using the `exactShapes` option in the verifications, we'll know
if a rogue property was added or removed somewhere in the code and
the data structure has inadvertently changed.