### PR TITLE
[CCLEX-166]: Changed timestamp format in 'Synced at' and 'Created at' fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## UNRELEASED
 
-- Changed timestamp format in `Created at` and `Synced at` fields  in all the "View details" entity panels.
+- Changed timestamp format in `Created at` and `Synced at` fields in all the "View details" entity panels.
 
 ## v5.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ChangeLog
 
+## UNRELEASED
+
+- Changed timestamp format in `Created at` and `Synced at` fields  in all the "View details" entity panels.
+
 ## v5.1.0
 
 - Added new `Synced at` field in all the "View details" entity panels showing the last time at which the entity was synced from MCC.

--- a/src/renderer/catalogEntityDetails.js
+++ b/src/renderer/catalogEntityDetails.js
@@ -29,7 +29,7 @@ const getDateValue = (date) => {
   return dateObj.getTime() === 0
     ? unknownValue()
     : `${dayjs(date).fromNow(true)} ago (${dayjs(date).format(
-        'YYYY-MM-DD, HH:mm:ss'
+        'YYYY-MM-DD HH:mm:ss'
       )})`;
 };
 

--- a/src/renderer/catalogEntityDetails.js
+++ b/src/renderer/catalogEntityDetails.js
@@ -28,8 +28,8 @@ const getDateValue = (date) => {
   const dateObj = new Date(date);
   return dateObj.getTime() === 0
     ? unknownValue()
-    : `${dayjs(date).format('MMM DD, YYYY, HH:mm:ss')} (${dayjs(date).fromNow(
-        true
+    : `${dayjs(date).fromNow(true)} ago (${dayjs(date).format(
+        'YYYY-MM-DD, HH:mm:ss'
       )})`;
 };
 


### PR DESCRIPTION
### PR Checklist

Check if done, remove if not applicable:

- [x] New feature or bug fix is mentioned in the `CHANGELOG`.

<img width="712" alt="Screenshot 2022-10-03 at 12 53 42" src="https://user-images.githubusercontent.com/33761040/193550557-4d1a328d-acd0-4d80-9a91-d1b3efaa41b3.png">
