### PR TITLE
[CCLEX-171] Skip TLS verification in kubeConfigs when requested

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Changed timestamp format in `Created at` and `Synced at` fields in all the "View details" entity panels.
 - Updated Mirantis Container Cloud icon.
+- Fixed bug where setting the [LEX_CC_UNSAFE_ALLOW_SELFSIGNED_CERTS](./README.md#self-signed-certificates) flag on the command line was not reflected in generated cluster kubeConfig files.
 
 ## v5.1.0
 

--- a/README.md
+++ b/README.md
@@ -191,6 +191,10 @@ By default, the extension does not support management clusters that use self-sig
 
 There are some legitimate reasons to use self-signed certificates, however, and it is possible to enable the extension to skip certificate verification by starting Lens from the command line with a special `LEX_CC_UNSAFE_ALLOW_SELFSIGNED_CERTS` flag, where values of `1`, `true`, or `yes` will enable self-signed certificate support.
 
+> ⚠️ Using this flag will also configure generated cluster kubeConfig files to skip TLS verification, and restarting Lens without the flag will not cause those kubeConfig files to be regenerated.
+>
+> To force all kubeConfigs to be regenerated with/without the setting, remove the project to which the cluster belongs from your sync settings, and re-add it. Removing the entire management cluster and re-adding it will also cause all kubeConfigs for all synced clusters belonging to it to be regenerated.
+
 __macOS__
 
 From a Terminal:

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,4 +1,13 @@
+import process from 'process';
 import { deepFreeze } from './util/deepFreeze';
+
+// NOTE: there seems to be a bug with Webpack in that if we use optional chaining (`?.`)
+//  to make this statement more terse, it just removes the `?` instead of (1) leaving
+//  it there like it should (and does for the rest of the code everywhere), or (2)
+//  transpiling it to what we've explicitly used here to get around this issue
+export const skipTlsVerify =
+  process.env.LEX_CC_UNSAFE_ALLOW_SELFSIGNED_CERTS &&
+  process.env.LEX_CC_UNSAFE_ALLOW_SELFSIGNED_CERTS.match(/^(true|yes|1)$/);
 
 // maximum number of projects (inclusive), at which point the warning icon will appear
 //  about potential performance issues

--- a/src/util/netUtil.js
+++ b/src/util/netUtil.js
@@ -1,4 +1,3 @@
-import process from 'process';
 import { get } from 'lodash';
 import nodeFetch from 'node-fetch';
 import https from 'https';
@@ -6,18 +5,12 @@ import { Common } from '@k8slens/extensions';
 import queryString from 'query-string';
 import * as strings from '../strings';
 import { logger } from './logger';
+import { skipTlsVerify } from '../constants';
 
 const { Util } = Common;
 
 let httpsAgent;
-// NOTE: there seems to be a bug with Webpack in that if we use optional chaining (`?.`)
-//  to make this statement more terse, it just removes the `?` instead of (1) leaving
-//  it there like it should (and does for the rest of the code everywhere), or (2)
-//  transpiling it to what we've explicitly used here to get around this issue
-if (
-  process.env.LEX_CC_UNSAFE_ALLOW_SELFSIGNED_CERTS &&
-  process.env.LEX_CC_UNSAFE_ALLOW_SELFSIGNED_CERTS.match(/^(true|yes|1)$/)
-) {
+if (skipTlsVerify) {
   // SECURITY: get around issues with Clouds that have self-signed certificates (typically used
   //  for internal test Clouds of various kinds)
   logger.warn(

--- a/src/util/templates.js
+++ b/src/util/templates.js
@@ -4,6 +4,17 @@
 
 import process from 'process';
 import path from 'path';
+import { logger } from './logger';
+import { skipTlsVerify } from '../constants';
+
+if (skipTlsVerify) {
+  // SECURITY: get around issues with Clouds that have self-signed certificates (typically used
+  //  for internal test Clouds of various kinds)
+  logger.warn(
+    'templates',
+    'Generated cluster kubeConfig files will skip TLS verification: Be careful!'
+  );
+}
 
 /**
  * @returns {string} The absolute path to the `kubelogin` binary for the current OS.
@@ -125,6 +136,7 @@ export const mkKubeConfig = function ({
                   `--oidc-issuer-url=${cluster.idpIssuerUrl}`,
                   `--oidc-client-id=${cluster.idpClientId}`,
                   `--certificate-authority-data=${cluster.idpCertificate}`,
+                  ...(skipTlsVerify ? ['--insecure-skip-tls-verify'] : []),
                 ],
               },
             },


### PR DESCRIPTION
When setting `LEX_CC_UNSAFE_ALLOW_SELFSIGNED_CERTS=1` on the command line to run Lens, we disable TLS verification when making API requests, but we aren't disabling it when Lens attempts to access the cluster to generate a cluster token via the `kube-login` binary.

This fix will disable TLS verification in the kubeConfig also, if the command line flag is set.


### PR Checklist

Check if done, remove if not applicable:

- [x] New feature or bug fix is mentioned in the `CHANGELOG`.
