### PR TITLE
[CCLEX-183] Handle not having lma; show enabled state in details

### DIFF
--- a/src/api/types/Cluster.js
+++ b/src/api/types/Cluster.js
@@ -391,7 +391,7 @@ export class Cluster extends Node {
         ) {
           const { stacklight: stackLight = {} } =
             data.status.providerStatus.helm.releases;
-          return {
+          const lma = {
             alertaUrl: stackLight.alerta?.url || undefined,
             alertManagerUrl: stackLight.alertmanager?.url || undefined, // yes, different casing...
             grafanaUrl: stackLight.grafana?.url || undefined,
@@ -399,6 +399,15 @@ export class Cluster extends Node {
             prometheusUrl: stackLight.prometheus?.url || undefined,
             telemeterServerUrl: stackLight.telemeterServer?.url || undefined,
           };
+
+          // when StackLight is disabled, we may still have the `stacklight` object, but we
+          //  won't have any of the URLs (a property for each StackLight service, like
+          //  'prometheus', will be fined, but mapped to an empty object instead of
+          //  an object with a 'url' property; e.g. `prometheus: {}` instead of
+          //  `prometheus: { url: 'https://...' }`
+          // if we have at least one URL, assume LMA is enabled and return an object with
+          //  any URLs we might have; otherwise, LMA is disabled, so return `null`
+          return Object.entries(lma).find(([, value]) => !!value) ? lma : null;
         }
 
         return null;

--- a/src/renderer/catalogEntityDetails.js
+++ b/src/renderer/catalogEntityDetails.js
@@ -126,7 +126,7 @@ export const catalogEntityDetails = [
               {props.entity.spec.provider || unknownValue()}
             </DrawerItem>
             <DrawerItem
-              name={strings.catalog.entities.cluster.details.props.mccStatus()}
+              name={strings.catalog.entities.common.details.props.serverStatus()}
             >
               {props.entity.spec.apiStatus || unknownValue()}
             </DrawerItem>
@@ -159,13 +159,20 @@ export const catalogEntityDetails = [
             <DrawerTitle>
               {strings.catalog.entities.cluster.details.props.lma()}
             </DrawerTitle>
+            <DrawerItem
+              name={strings.catalog.entities.cluster.details.props.lmaEnabled()}
+            >
+              {strings.catalog.entities.cluster.details.props.isLmaEnabled(
+                !!props.entity.spec.lma
+              )}
+            </DrawerItem>
 
             <DrawerItem
               name={strings.catalog.entities.cluster.details.props.alertaUrl()}
             >
-              {props.entity.spec.lma.alertaUrl ? (
+              {props.entity.spec.lma?.alertaUrl ? (
                 <a href="#" onClick={handleOpenAlerta}>
-                  {props.entity.spec.lma.alertaUrl}
+                  {props.entity.spec.lma?.alertaUrl}
                 </a>
               ) : (
                 emptyValue()
@@ -175,9 +182,9 @@ export const catalogEntityDetails = [
             <DrawerItem
               name={strings.catalog.entities.cluster.details.props.alertManagerUrl()}
             >
-              {props.entity.spec.lma.alertManagerUrl ? (
+              {props.entity.spec.lma?.alertManagerUrl ? (
                 <a href="#" onClick={handleOpenAlertManager}>
-                  {props.entity.spec.lma.alertManagerUrl}
+                  {props.entity.spec.lma?.alertManagerUrl}
                 </a>
               ) : (
                 emptyValue()
@@ -187,9 +194,9 @@ export const catalogEntityDetails = [
             <DrawerItem
               name={strings.catalog.entities.cluster.details.props.grafanaUrl()}
             >
-              {props.entity.spec.lma.grafanaUrl ? (
+              {props.entity.spec.lma?.grafanaUrl ? (
                 <a href="#" onClick={handleOpenGrafana}>
-                  {props.entity.spec.lma.grafanaUrl}
+                  {props.entity.spec.lma?.grafanaUrl}
                 </a>
               ) : (
                 emptyValue()
@@ -199,9 +206,9 @@ export const catalogEntityDetails = [
             <DrawerItem
               name={strings.catalog.entities.cluster.details.props.kibanaUrl()}
             >
-              {props.entity.spec.lma.kibanaUrl ? (
+              {props.entity.spec.lma?.kibanaUrl ? (
                 <a href="#" onClick={handleOpenKibana}>
-                  {props.entity.spec.lma.kibanaUrl}
+                  {props.entity.spec.lma?.kibanaUrl}
                 </a>
               ) : (
                 emptyValue()
@@ -211,9 +218,9 @@ export const catalogEntityDetails = [
             <DrawerItem
               name={strings.catalog.entities.cluster.details.props.prometheusUrl()}
             >
-              {props.entity.spec.lma.prometheusUrl ? (
+              {props.entity.spec.lma?.prometheusUrl ? (
                 <a href="#" onClick={handleOpenPrometheus}>
-                  {props.entity.spec.lma.prometheusUrl}
+                  {props.entity.spec.lma?.prometheusUrl}
                 </a>
               ) : (
                 emptyValue()
@@ -223,9 +230,9 @@ export const catalogEntityDetails = [
             <DrawerItem
               name={strings.catalog.entities.cluster.details.props.telemeterServerUrl()}
             >
-              {props.entity.spec.lma.telemeterServerUrl ? (
+              {props.entity.spec.lma?.telemeterServerUrl ? (
                 <a href="#" onClick={handleOpenTelemeterServer}>
-                  {props.entity.spec.lma.telemeterServerUrl}
+                  {props.entity.spec.lma?.telemeterServerUrl}
                 </a>
               ) : (
                 emptyValue()
@@ -310,7 +317,7 @@ export const catalogEntityDetails = [
             {props.entity.spec.region || unknownValue()}
           </DrawerItem>
           <DrawerItem
-            name={strings.catalog.entities.credential.details.props.mccStatus()}
+            name={strings.catalog.entities.common.details.props.serverStatus()}
           >
             {strings.catalog.entities.credential.details.info.status(
               props.entity.spec.valid

--- a/src/strings.ts
+++ b/src/strings.ts
@@ -250,12 +250,13 @@ export const catalog: Dict = {
           url: () => 'URL',
           region: () => 'Region',
           provider: () => 'Provider',
-          mccStatus: () => `${mccCodeName} Status`,
           release: () => 'Release',
           managers: () => 'Managers',
           workers: () => 'Workers',
           dashboardUrl: () => `${mkeCodeName} dashboard`,
           lma: () => `${companyName} StackLight`,
+          lmaEnabled: () => 'StackLight enabled',
+          isLmaEnabled: (enabled) => (enabled ? 'Yes' : 'No'),
           alertaUrl: () => 'Alerta',
           alertManagerUrl: () => 'Alert Manager',
           grafanaUrl: () => 'Grafana',
@@ -299,7 +300,6 @@ export const catalog: Dict = {
         props: {
           provider: () => 'Provider',
           region: () => 'Region',
-          mccStatus: () => `${mccCodeName} Status`,
         },
         info: {
           status: (valid) => (valid ? 'Valid' : 'Invalid'),


### PR DESCRIPTION
The `lma` data of a cluster entity will be `null` if the cluster isn't configured with StackLight. The code needs to handle this case.

Also, now that we're not showing/hiding the LMA panel, it seems good to include an 'Enabled: Yes/No' field to indicate whether StackLight is configured on the cluster or not, since it might not be obvious just with the '--' values for URLs. For example, are all the URLs not available because SackLight is disabled, or because those services aren't available for some reason...?


### PR Checklist

- [x] New feature or bug fix is mentioned in the `CHANGELOG`.
    - Already added with #1176 
