### PR TITLE
[CCLEX-184] Fix BYO credentials not visible in Catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## UNRELEASED
 
 - Show `--` instead of the URL if StackLight is disabled and URLs aren’t available in Cluster details view.
+- Fixed bug where BYO Credentials were not listed in the Catalog.
 
 ## v5.2.0
 

--- a/src/api/types/Credential.js
+++ b/src/api/types/Credential.js
@@ -1,5 +1,5 @@
 import * as rtv from 'rtvjs';
-import { merge, pick } from 'lodash';
+import { merge } from 'lodash';
 import { mergeRtvShapes } from '../../util/mergeRtvShapes';
 import { apiCredentialKinds, apiLabels } from '../apiConstants';
 import { NamedResource, namedResourceTs } from './NamedResource';
@@ -27,11 +27,12 @@ export const credentialTs = mergeRtvShapes({}, namedResourceTs, {
     ],
   },
   // NOTE: BYOCredential resources don't have `status` objects for some reason
-  //  so it's effectively made optional by temporarily removing it from the Typeset
-  //  in the Credential class constructor only when the kind is BYO_CREDENTIAL
-  status: {
-    valid: rtv.BOOLEAN,
-  },
+  status: [
+    rtv.OPTIONAL,
+    {
+      valid: rtv.BOOLEAN,
+    },
+  ],
 });
 
 /**
@@ -51,11 +52,7 @@ export class Credential extends NamedResource {
       data,
       namespace,
       cloud,
-      // NOTE: BYOCredential objects do not have a `status` for some reason
-      typeset:
-        data.kind === apiCredentialKinds.BYO_CREDENTIAL
-          ? pick(credentialTs, ['metadata', 'spec'])
-          : credentialTs,
+      typeset: credentialTs,
     });
 
     /** @member {string} region */


### PR DESCRIPTION
This was due to in incorrect expectation for `status.ready` in the kube resource specically for BYO credentials. Other credential types have this object.


### PR Checklist

Check if done, remove if not applicable:

- [x] New feature or bug fix is mentioned in the `CHANGELOG`.
