### PR TITLE
[CCLEX-74] REMOVE kube watches implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,6 @@
     "@types/react-router": "^5.1.19",
     "@typescript-eslint/eslint-plugin": "^4.33.0",
     "@typescript-eslint/parser": "^4.33.0",
-    "abort-controller": "^3.0.0",
     "babel-jest": "^29.3.1",
     "babel-loader": "^9.1.0",
     "babel-plugin-lodash": "^3.3.4",

--- a/src/api/apiConstants.js
+++ b/src/api/apiConstants.js
@@ -108,19 +108,6 @@ export const apiLabels = Object.freeze({
   CLUSTER_NAME: 'cluster.sigs.k8s.io/cluster-name', // machine's associated cluster
 });
 
-// TODO[PRODX-22469]: Remove if we drop watches.
-/**
- * Map of API watch change response document type to value.
- * @type {{ [index: string], string }}
- * @see https://kubernetes.io/docs/reference/using-api/api-concepts/#efficient-detection-of-changes
- */
-export const apiChangeTypes = Object.freeze({
-  ERROR: 'ERROR',
-  ADDED: 'ADDED',
-  MODIFIED: 'MODIFIED',
-  DELETED: 'DELETED',
-});
-
 /**
  * Map of API namespace (status) phases to value.
  * @type {{ [index: string], string }}

--- a/src/api/clients/KubernetesClient.js
+++ b/src/api/clients/KubernetesClient.js
@@ -75,9 +75,6 @@ export class KubernetesClient {
       errorMessage: strings.apiClient.error.failedToGet(resourceType),
       extractBodyMethod: resourceVersion ? 'text' : 'json', // watches respond with multiple JSON documents
       options: {
-        // TODO[PRODX-22469]: A timeout helps, but still, we never get content from the body.
-        //  We just get a timeout error waiting for body content.
-        // timeout: resourceVersion ? 30000 : 0, // milliseconds (0 -> Infinity)
         ...requestOptions,
       },
     });

--- a/src/api/clients/ResourceClient.js
+++ b/src/api/clients/ResourceClient.js
@@ -129,9 +129,6 @@ export class ResourceClient {
       errorMessage: strings.apiClient.error.failedToGetList(resourceType),
       extractBodyMethod: resourceVersion ? 'text' : 'json', // watches respond with multiple JSON documents
       options: {
-        // TODO[PRODX-22469]: A timeout helps, but still, we never get content from the body.
-        //  We just get a timeout error waiting for body content.
-        // timeout: resourceVersion ? 30000 : 0, // milliseconds (0 -> Infinity)
         ...requestOptions,
       },
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2280,13 +2280,6 @@ abab@^2.0.6:
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.6.tgz#41b80f2c871d19686216b82309231cfd3cb3d291"
   integrity sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==
 
-abort-controller@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/abort-controller/-/abort-controller-3.0.0.tgz#eaf54d53b62bae4138e809ca225c8439a6efb392"
-  integrity sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==
-  dependencies:
-    event-target-shim "^5.0.0"
-
 acorn-globals@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-6.0.0.tgz#46cdd39f0f8ff08a876619b55f5ac8a6dc770b45"
@@ -3530,11 +3523,6 @@ esutils@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
-
-event-target-shim@^5.0.0:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
-  integrity sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==
 
 events@^3.2.0:
   version "3.2.0"


### PR DESCRIPTION
It was added last April, but couldn't be enabled and tested because of an issue with Node and extracting the body of the watch payload:

> Disabling watches until a solution can be found to the behavior where a watch
> request's response comes back almost immediately as status 200, but then
> attempting to extract the body with `response.text()` in
> `netUtils.js#tryExtractBody()` NEVER resolves. It just hangs.
>
> I thought this might be similar to this issue: https://github.com/node-fetch/node-fetch/issues/665
> And solution (for node-fetch 2.x): https://github.com/node-fetch/node-fetch#custom-highwatermark
>
> But, alas, that didn't help at all. No clue what's going on. Works great in
> Postman, so clearly, the issue is with how we're handling these types of
> long-poll requests in `netUtil.js#request()`, but not sure what to do.

Based on kube docs, watches expire after 5 minutes (server just doesn't preserve historical record of changes for longer than 5 minutes by default because it's very data-intensive, I presume) and once they expire, the API documentation says a full collection fetch must be performed (i.e. get all data from it) in order to get a new `resourceVersion` and keep watching from there; repeat...

So if watches expire every 5 minutes anyway, we're still doing full pulls every 5 minutes, so the only thing the great complexity of watches buys us is potential finer-grained, more immediate updates in between full fetches, which seems unnecessary.

Watches were never enabled, and we've been doing fine without them. Furthermore, we've discovered that the person using Lens is normally not also the same person using MCC in the browser, so the likelihood that someone will have both open at the same time, expecting near instantaneous updates in Lens in response to changes in MCC, will be very rare. And in that case, they can just use the "Sync now" feature.

Finally, we’re already successfully using the `resourceVersion` associated with individual resources in order to skip some updates and make code more efficient.

So based on all of the above, I don't think it's worth carrying the extra weight of all this untested/untestable/unusable code around in case it _might_ work some day, and also trying to maintain it without being able to test the changes.


### PR Checklist

- [-] New feature or bug fix is mentioned in the `CHANGELOG`.
    - Not added because watches were never used and never announced as a feature.
