### PR TITLE
[CCLEX-186] Add cluster updates to API and cluster entities

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -78,7 +78,8 @@ const globals = {
   DEV_ENV: 'readonly',
   ENTITY_CACHE_VERSION: 'readonly',
   DEV_UNSAFE_NO_CERT: 'readonly',
-  FEAT_CLUSTER_PAGE_ENABLED: 'readonly', // TODO[clusterpage]: remove flag
+  FEAT_CLUSTER_PAGE_ENABLED: 'readonly',
+  FEAT_CLUSTER_PAGE_UPDATES_ENABLED: 'readonly',
   fetchMock: 'readonly', // from 'jest-fetch-mock' package
 };
 

--- a/src/api/apiConstants.js
+++ b/src/api/apiConstants.js
@@ -10,7 +10,12 @@ import { pick } from 'lodash';
  */
 export const apiResourceTypes = Object.freeze({
   CLUSTER: 'clusters',
+  CLUSTER_RELEASE: 'clusterreleases',
+  CLUSTER_DEPLOYMENT_STATUS: 'clusterdeploymentstatuses',
+  CLUSTER_UPGRADE_STATUS: 'clusterupgradestatuses',
   MACHINE: 'machines',
+  // NOTE: for some reason, machines don't seem to have deployment info
+  MACHINE_UPGRADE_STATUS: 'machineupgradestatuses',
   PUBLIC_KEY: 'publickeys', // "SSH keys"
   NAMESPACE: 'namespaces',
   OPENSTACK_CREDENTIAL: 'openstackcredentials',
@@ -21,7 +26,6 @@ export const apiResourceTypes = Object.freeze({
   BYO_CREDENTIAL: 'byocredentials',
   SECRET: 'secrets',
   EVENT: 'events',
-  CLUSTER_RELEASE: 'clusterreleases',
   KAAS_RELEASE: 'kaasreleases',
   OPENSTACK_RESOURCE: 'openstackresources',
   AWS_RESOURCE: 'awsresources',
@@ -33,12 +37,11 @@ export const apiResourceTypes = Object.freeze({
 });
 
 /**
- * Map of credential entity type to name/endpoint used in Kube API calls.
+ * Map of API credential type to name/endpoint used in Kube API calls.
  * @type {Record<string, string>}
  */
 export const apiCredentialTypes = Object.freeze(
   pick(apiResourceTypes, [
-    // NOTE: these are KEYS from the apiResourceTypes map
     'OPENSTACK_CREDENTIAL',
     'AWS_CREDENTIAL',
     'EQUINIX_CREDENTIAL',
@@ -49,13 +52,29 @@ export const apiCredentialTypes = Object.freeze(
 );
 
 /**
+ * Map of API update type to name/endpoint used in Kube API calls.
+ * @type {Record<string, string>}
+ */
+export const apiUpdateTypes = Object.freeze(
+  pick(apiResourceTypes, [
+    'CLUSTER_DEPLOYMENT_STATUS',
+    'CLUSTER_UPGRADE_STATUS',
+    'MACHINE_UPGRADE_STATUS',
+  ])
+);
+
+/**
  * Map of API kind to kube spec `kind` property value in API data objects.
  * @type {Record<string, string>}
  */
 export const apiKinds = Object.freeze({
   NAMESPACE: 'Namespace',
   CLUSTER: 'Cluster',
+  CLUSTER_DEPLOYMENT_STATUS: 'ClusterDeploymentStatus',
+  CLUSTER_UPGRADE_STATUS: 'ClusterUpgradeStatus',
   MACHINE: 'Machine',
+  // NOTE: for some reason, machines don't seem to have deployment info
+  MACHINE_UPGRADE_STATUS: 'MachineUpgradeStatus',
   PUBLIC_KEY: 'PublicKey',
   AWS_CREDENTIAL: 'AWSCredential',
   AZURE_CREDENTIAL: 'AzureCredential',
@@ -74,13 +93,24 @@ export const apiKinds = Object.freeze({
  */
 export const apiCredentialKinds = Object.freeze(
   pick(apiKinds, [
-    // NOTE: these are KEYS from the apiResourceTypes map
     'AWS_CREDENTIAL',
     'AZURE_CREDENTIAL',
     'BYO_CREDENTIAL',
     'EQUINIX_CREDENTIAL',
     'OPENSTACK_CREDENTIAL',
     'VSPHERE_CREDENTIAL',
+  ])
+);
+
+/**
+ * Map of update API kind to kube spec `kind` property value in API data objects.
+ * @type {Record<string, string>}
+ */
+export const apiUpdateKinds = Object.freeze(
+  pick(apiKinds, [
+    'CLUSTER_DEPLOYMENT_STATUS',
+    'CLUSTER_UPGRADE_STATUS',
+    'MACHINE_UPGRADE_STATUS',
   ])
 );
 
@@ -125,4 +155,14 @@ export const apiNamespacePhases = Object.freeze({
 export const apiEventTypes = Object.freeze({
   NORMAL: 'Normal',
   WARNING: 'Warning',
+});
+
+/**
+ * Map of (currently known, but could be more) API resource update statuses.
+ * @type {Record<string, string>}
+ */
+export const apiUpdateStatuses = Object.freeze({
+  SUCCESS: 'Success',
+  IN_PROGRESS: 'InProgress',
+  NOT_STARTED: 'NotStarted',
 });

--- a/src/api/apiConstants.js
+++ b/src/api/apiConstants.js
@@ -14,7 +14,7 @@ export const apiResourceTypes = Object.freeze({
   CLUSTER_DEPLOYMENT_STATUS: 'clusterdeploymentstatuses',
   CLUSTER_UPGRADE_STATUS: 'clusterupgradestatuses',
   MACHINE: 'machines',
-  // NOTE: for some reason, machines don't seem to have deployment info
+  MACHINE_DEPLOYMENT_STATUS: 'machinedeploymentstatuses',
   MACHINE_UPGRADE_STATUS: 'machineupgradestatuses',
   PUBLIC_KEY: 'publickeys', // "SSH keys"
   NAMESPACE: 'namespaces',
@@ -59,6 +59,7 @@ export const apiUpdateTypes = Object.freeze(
   pick(apiResourceTypes, [
     'CLUSTER_DEPLOYMENT_STATUS',
     'CLUSTER_UPGRADE_STATUS',
+    'MACHINE_DEPLOYMENT_STATUS',
     'MACHINE_UPGRADE_STATUS',
   ])
 );
@@ -73,7 +74,7 @@ export const apiKinds = Object.freeze({
   CLUSTER_DEPLOYMENT_STATUS: 'ClusterDeploymentStatus',
   CLUSTER_UPGRADE_STATUS: 'ClusterUpgradeStatus',
   MACHINE: 'Machine',
-  // NOTE: for some reason, machines don't seem to have deployment info
+  MACHINE_DEPLOYMENT_STATUS: 'MachineDeploymentStatus',
   MACHINE_UPGRADE_STATUS: 'MachineUpgradeStatus',
   PUBLIC_KEY: 'PublicKey',
   AWS_CREDENTIAL: 'AWSCredential',
@@ -110,6 +111,7 @@ export const apiUpdateKinds = Object.freeze(
   pick(apiKinds, [
     'CLUSTER_DEPLOYMENT_STATUS',
     'CLUSTER_UPGRADE_STATUS',
+    'MACHINE_DEPLOYMENT_STATUS',
     'MACHINE_UPGRADE_STATUS',
   ])
 );

--- a/src/api/apiFetch.js
+++ b/src/api/apiFetch.js
@@ -20,6 +20,10 @@ import {
   clusterDeploymentTs,
 } from './types/ClusterDeployment';
 import { ClusterUpgrade, clusterUpgradeTs } from './types/ClusterUpgrade';
+import {
+  MachineDeployment,
+  machineDeploymentTs,
+} from './types/MachineDeployment';
 import { MachineUpgrade, machineUpgradeTs } from './types/MachineUpgrade';
 import { logger, logValue } from '../util/logger';
 import {
@@ -378,6 +382,7 @@ export const fetchClusterUpdates = async function (cloud, namespaces) {
     [
       apiResourceTypes.CLUSTER_DEPLOYMENT_STATUS,
       apiResourceTypes.CLUSTER_UPGRADE_STATUS,
+      apiResourceTypes.MACHINE_DEPLOYMENT_STATUS,
       apiResourceTypes.MACHINE_UPGRADE_STATUS,
     ].map((resourceType) =>
       _fetchCollection({
@@ -398,6 +403,12 @@ export const fetchClusterUpdates = async function (cloud, namespaces) {
             // now check if it's a valid cluster upgrade
             const mvvData = rtv.verify(data, clusterUpgradeTs).mvv;
             return new ClusterUpgrade({ data: mvvData, namespace, cloud });
+          }
+
+          if (resourceType === apiResourceTypes.MACHINE_DEPLOYMENT_STATUS) {
+            // now check if it's a valid machine deployment
+            const mvvData = rtv.verify(data, machineDeploymentTs).mvv;
+            return new MachineDeployment({ data: mvvData, namespace, cloud });
           }
 
           // must be a valid machine upgrade

--- a/src/api/apiTypesets.js
+++ b/src/api/apiTypesets.js
@@ -12,3 +12,12 @@ export const nodeConditionTs = {
   ready: rtv.BOOLEAN, // true if component is ready (NOTE: false if maintenance mode is active)
   type: rtv.STRING, // component name, e.g. 'Kubelet', 'Swarm, 'Maintenance', etc.
 };
+
+/**
+ * RTV Typeset for a string that is an ISO8601 timestamp with optional milliseconds since
+ *  we don't always have those.
+ */
+export const timestampTs = [
+  rtv.STRING,
+  { exp: '^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d{3})?Z$' },
+];

--- a/src/api/apiUtil.js
+++ b/src/api/apiUtil.js
@@ -16,6 +16,7 @@ const typeToClient = {
   [apiResourceTypes.CLUSTER_DEPLOYMENT_STATUS]: ResourceClient,
   [apiResourceTypes.CLUSTER_UPGRADE_STATUS]: ResourceClient,
   [apiResourceTypes.MACHINE]: ResourceClient,
+  [apiResourceTypes.MACHINE_DEPLOYMENT_STATUS]: ResourceClient,
   [apiResourceTypes.MACHINE_UPGRADE_STATUS]: ResourceClient,
   [apiResourceTypes.PUBLIC_KEY]: ResourceClient, // SSH keys
   [apiResourceTypes.NAMESPACE]: KubernetesClient,

--- a/src/api/apiUtil.js
+++ b/src/api/apiUtil.js
@@ -12,7 +12,11 @@ import { apiResourceTypes } from './apiConstants';
 
 const typeToClient = {
   [apiResourceTypes.CLUSTER]: ResourceClient,
+  [apiResourceTypes.CLUSTER_RELEASE]: ResourceClient,
+  [apiResourceTypes.CLUSTER_DEPLOYMENT_STATUS]: ResourceClient,
+  [apiResourceTypes.CLUSTER_UPGRADE_STATUS]: ResourceClient,
   [apiResourceTypes.MACHINE]: ResourceClient,
+  [apiResourceTypes.MACHINE_UPGRADE_STATUS]: ResourceClient,
   [apiResourceTypes.PUBLIC_KEY]: ResourceClient, // SSH keys
   [apiResourceTypes.NAMESPACE]: KubernetesClient,
   [apiResourceTypes.CREDENTIAL]: KubernetesClient,
@@ -24,7 +28,6 @@ const typeToClient = {
   [apiResourceTypes.BYO_CREDENTIAL]: ResourceClient,
   [apiResourceTypes.SECRET]: KubernetesClient,
   [apiResourceTypes.EVENT]: KubernetesClient,
-  [apiResourceTypes.CLUSTER_RELEASE]: ResourceClient,
   [apiResourceTypes.KAAS_RELEASE]: ResourceClient,
   [apiResourceTypes.OPENSTACK_RESOURCE]: ResourceClient,
   [apiResourceTypes.AWS_RESOURCE]: ResourceClient,

--- a/src/api/clients/ResourceClient.js
+++ b/src/api/clients/ResourceClient.js
@@ -20,7 +20,10 @@ export class ResourceClient {
   // resource type to '/apis/GROUP/VERSION' prefix
   static typeToApiPrefix = {
     [apiResourceTypes.CLUSTER]: clusterEndpoint,
+    [apiResourceTypes.CLUSTER_DEPLOYMENT_STATUS]: kaasEndpoint,
+    [apiResourceTypes.CLUSTER_UPGRADE_STATUS]: kaasEndpoint,
     [apiResourceTypes.MACHINE]: clusterEndpoint,
+    [apiResourceTypes.MACHINE_UPGRADE_STATUS]: kaasEndpoint,
     [apiResourceTypes.PUBLIC_KEY]: kaasEndpoint, // SSH keys
     [apiResourceTypes.OPENSTACK_CREDENTIAL]: kaasEndpoint,
     [apiResourceTypes.AWS_CREDENTIAL]: kaasEndpoint,

--- a/src/api/clients/ResourceClient.js
+++ b/src/api/clients/ResourceClient.js
@@ -23,6 +23,7 @@ export class ResourceClient {
     [apiResourceTypes.CLUSTER_DEPLOYMENT_STATUS]: kaasEndpoint,
     [apiResourceTypes.CLUSTER_UPGRADE_STATUS]: kaasEndpoint,
     [apiResourceTypes.MACHINE]: clusterEndpoint,
+    [apiResourceTypes.MACHINE_DEPLOYMENT_STATUS]: kaasEndpoint,
     [apiResourceTypes.MACHINE_UPGRADE_STATUS]: kaasEndpoint,
     [apiResourceTypes.PUBLIC_KEY]: kaasEndpoint, // SSH keys
     [apiResourceTypes.OPENSTACK_CREDENTIAL]: kaasEndpoint,

--- a/src/api/types/Cluster.js
+++ b/src/api/types/Cluster.js
@@ -214,8 +214,8 @@ export class Cluster extends Node {
     });
 
     /**
-     * @member {Array<ClusterDeployment|ClusterUpgrade|MachineUpgrade>} updates Updates related
-     *  to this cluster or its machines. Empty list if none.
+     * @member {Array<ClusterDeployment|ClusterUpgrade|MachineDeployment|MachineUpgrade>} updates
+     *  Updates related to this cluster or its machines. Empty list if none.
      */
     Object.defineProperty(this, 'updates', {
       enumerable: true,
@@ -545,8 +545,8 @@ export class Cluster extends Node {
     ];
     _updates = this.namespace.updates.filter((update) =>
       // NOTE: since UIDs are universal, we can be confident that if we have a match,
-      //  the related object will also be a ClusterDeployment, ClusterUpgrade, or
-      //  MachineUpgrade instance
+      //  the related object will also be a ClusterDeployment, ClusterUpgrade, MachineDeployment,
+      //  or MachineUpgrade instance
       uidList.includes(update.targetUid)
     );
   }

--- a/src/api/types/Cluster.js
+++ b/src/api/types/Cluster.js
@@ -166,6 +166,7 @@ export class Cluster extends Node {
     let _workers = [];
     let _sshKeys = [];
     let _events = [];
+    let _updates = [];
     let _credential = null;
     let _proxy = null;
     let _license = null;
@@ -209,6 +210,17 @@ export class Cluster extends Node {
       enumerable: true,
       get() {
         return _events;
+      },
+    });
+
+    /**
+     * @member {Array<ClusterDeployment|ClusterUpgrade|MachineUpgrade>} updates Updates related
+     *  to this cluster or its machines. Empty list if none.
+     */
+    Object.defineProperty(this, 'updates', {
+      enumerable: true,
+      get() {
+        return _updates;
       },
     });
 
@@ -523,6 +535,20 @@ export class Cluster extends Node {
         //  the related object will also be a ClusterEvent instance
         event.targetUid === this.uid
     );
+
+    // NOTE: must be done AFTER finding machines so we can find the machine upgrades
+    //  for this cluster (if any)
+    const uidList = [
+      this.uid,
+      ...this.controllers.map((m) => m.uid),
+      ...this.workers.map((m) => m.uid),
+    ];
+    _updates = this.namespace.updates.filter((update) =>
+      // NOTE: since UIDs are universal, we can be confident that if we have a match,
+      //  the related object will also be a ClusterDeployment, ClusterUpgrade, or
+      //  MachineUpgrade instance
+      uidList.includes(update.targetUid)
+    );
   }
 
   /**
@@ -604,6 +630,7 @@ export class Cluster extends Node {
         dashboardUrl: this.dashboardUrl,
         lma: this.lma,
         events: this.events.map((e) => e.toModel()),
+        updates: this.updates.map((u) => u.toModel()),
       },
       status: {
         // always starts off disconnected as far as Lens is concerned (because it
@@ -629,7 +656,9 @@ export class Cluster extends Node {
       this.configReady
     }, sshKeys: ${logValue(
       this.sshKeys.map((key) => key.name)
-    )}, events: ${logValue(this.events.length)}, credential: ${logValue(
+    )}, events: ${logValue(this.events.length)}, updates: ${logValue(
+      this.updates.length
+    )}, credential: ${logValue(
       this.credential && this.credential.name
     )}, proxy: ${logValue(this.proxy && this.proxy.name)}, license: ${logValue(
       this.license && this.license.name

--- a/src/api/types/ClusterDeployment.js
+++ b/src/api/types/ClusterDeployment.js
@@ -1,26 +1,23 @@
 import * as rtv from 'rtvjs';
 import { mergeRtvShapes } from '../../util/mergeRtvShapes';
 import { apiKinds } from '../apiConstants';
-import { ResourceEvent, resourceEventTs } from './ResourceEvent';
+import { ResourceUpdate, resourceUpdateTs } from './ResourceUpdate';
 
 /**
- * Typeset for an MCC API cluster event resource.
+ * Typeset for an MCC API cluster deployment (i.e. installation) resource.
  */
-export const clusterEventTs = mergeRtvShapes({}, resourceEventTs, {
+export const clusterDeploymentTs = mergeRtvShapes({}, resourceUpdateTs, {
   // NOTE: this is not intended to be fully-representative; we only list the properties
-  //  related to what we expect to find in order to create a `ClusterEvent` class instance
+  //  related to what we expect to find in order to create a `ClusterDeployment` class instance
 
-  involvedObject: {
-    kind: [rtv.STRING, { oneOf: apiKinds.CLUSTER }],
-    uid: rtv.STRING, // cluster event objects always have a UID
-  },
+  kind: [rtv.STRING, { oneOf: apiKinds.CLUSTER_DEPLOYMENT_STATUS }],
 });
 
 /**
- * MCC API cluster event.
- * @class ClusterEvent
+ * MCC API cluster deployment.
+ * @class ClusterDeployment
  */
-export class ClusterEvent extends ResourceEvent {
+export class ClusterDeployment extends ResourceUpdate {
   /**
    * @constructor
    * @param {Object} params
@@ -29,11 +26,11 @@ export class ClusterEvent extends ResourceEvent {
    * @param {Cloud} params.cloud Reference to the Cloud used to get the data.
    */
   constructor({ data, namespace, cloud }) {
-    super({ data, cloud, namespace, typeset: clusterEventTs });
+    super({ data, cloud, namespace, typeset: clusterDeploymentTs });
   }
 
-  // NOTE: we don't have toEntity() because we don't show ClusterEvents in the Catalog at
-  //  the moment (so we don't have a ClusterEventEntity class for them either)
+  // NOTE: we don't have toEntity() because we don't show ClusterDeployments in the Catalog at
+  //  the moment (so we don't have a ClusterDeploymentEntity class for them either)
 
   /**
    * Converts this API Object into a Catalog Entity Model.
@@ -49,8 +46,8 @@ export class ClusterEvent extends ResourceEvent {
   toString() {
     const propStr = `${super.toString()}`;
 
-    if (Object.getPrototypeOf(this).constructor === ClusterEvent) {
-      return `{ClusterEvent ${propStr}}`;
+    if (Object.getPrototypeOf(this).constructor === ClusterDeployment) {
+      return `{ClusterDeployment ${propStr}}`;
     }
 
     // this is actually an extended class instance, so return only the properties

--- a/src/api/types/ClusterUpgrade.js
+++ b/src/api/types/ClusterUpgrade.js
@@ -1,0 +1,90 @@
+import { merge } from 'lodash';
+import * as rtv from 'rtvjs';
+import { logValue } from '../../util/logger';
+import { mergeRtvShapes } from '../../util/mergeRtvShapes';
+import { apiKinds } from '../apiConstants';
+import { ResourceUpdate, resourceUpdateTs } from './ResourceUpdate';
+
+/**
+ * Typeset for an MCC API cluster upgrade resource.
+ */
+export const clusterUpgradeTs = mergeRtvShapes({}, resourceUpdateTs, {
+  // NOTE: this is not intended to be fully-representative; we only list the properties
+  //  related to what we expect to find in order to create a `ClusterUpgrade` class instance
+
+  kind: [rtv.STRING, { oneOf: apiKinds.CLUSTER_UPGRADE_STATUS }],
+  fromRelease: rtv.STRING,
+  toRelease: rtv.STRING,
+});
+
+/**
+ * MCC API cluster deployment.
+ * @class ClusterUpgrade
+ */
+export class ClusterUpgrade extends ResourceUpdate {
+  /**
+   * @constructor
+   * @param {Object} params
+   * @param {Object} params.data Raw data payload from the API.
+   * @param {Namespace} params.namespace Namespace to which the object belongs.
+   * @param {Cloud} params.cloud Reference to the Cloud used to get the data.
+   */
+  constructor({ data, namespace, cloud }) {
+    super({ data, cloud, namespace, typeset: clusterUpgradeTs });
+
+    /**
+     * @readonly
+     * @member {string} fromRelease The original version of the cluster.
+     */
+    Object.defineProperty(this, 'fromRelease', {
+      enumerable: true,
+      get() {
+        return data.fromRelease;
+      },
+    });
+
+    /**
+     * @readonly
+     * @member {string} toRelease The new version of the cluster.
+     */
+    Object.defineProperty(this, 'toRelease', {
+      enumerable: true,
+      get() {
+        return data.toRelease;
+      },
+    });
+  }
+
+  // NOTE: we don't have toEntity() because we don't show ClusterUpgrades in the Catalog at
+  //  the moment (so we don't have a ClusterUpgradeEntity class for them either)
+
+  /**
+   * Converts this API Object into a Catalog Entity Model.
+   * @returns {{ metadata: Object, spec: Object, status: Object }} Catalog Entity Model
+   *  (use to create new Catalog Entity).
+   */
+  toModel() {
+    const model = super.toModel();
+
+    return merge({}, model, {
+      spec: {
+        fromRelease: this.fromRelease,
+        toRelease: this.toRelease,
+      },
+    });
+  }
+
+  /** @returns {string} A string representation of this instance for logging/debugging. */
+  toString() {
+    const propStr = `${super.toString()}, from: ${logValue(
+      this.fromRelease
+    )}, to: ${logValue(this.toRelease)}`;
+
+    if (Object.getPrototypeOf(this).constructor === ClusterUpgrade) {
+      return `{ClusterUpgrade ${propStr}}`;
+    }
+
+    // this is actually an extended class instance, so return only the properties
+    return propStr;
+  }
+}

--- a/src/api/types/MachineDeployment.js
+++ b/src/api/types/MachineDeployment.js
@@ -1,0 +1,56 @@
+import * as rtv from 'rtvjs';
+import { mergeRtvShapes } from '../../util/mergeRtvShapes';
+import { apiKinds } from '../apiConstants';
+import { ResourceUpdate, resourceUpdateTs } from './ResourceUpdate';
+
+/**
+ * Typeset for an MCC API machine deployment (i.e. installation) resource.
+ */
+export const machineDeploymentTs = mergeRtvShapes({}, resourceUpdateTs, {
+  // NOTE: this is not intended to be fully-representative; we only list the properties
+  //  related to what we expect to find in order to create a `MachineDeployment` class instance
+
+  kind: [rtv.STRING, { oneOf: apiKinds.MACHINE_DEPLOYMENT_STATUS }],
+});
+
+/**
+ * MCC API machine deployment.
+ * @class MachineDeployment
+ */
+export class MachineDeployment extends ResourceUpdate {
+  /**
+   * @constructor
+   * @param {Object} params
+   * @param {Object} params.data Raw data payload from the API.
+   * @param {Namespace} params.namespace Namespace to which the object belongs.
+   * @param {Cloud} params.cloud Reference to the Cloud used to get the data.
+   */
+  constructor({ data, namespace, cloud }) {
+    super({ data, cloud, namespace, typeset: machineDeploymentTs });
+  }
+
+  // NOTE: we don't have toEntity() because we don't show MachineDeployments in the Catalog at
+  //  the moment (so we don't have a MachineDeploymentEntity class for them either)
+
+  /**
+   * Converts this API Object into a Catalog Entity Model.
+   * @returns {{ metadata: Object, spec: Object, status: Object }} Catalog Entity Model
+   *  (use to create new Catalog Entity).
+   */
+  toModel() {
+    // for now, there's nothing special we need to add
+    return super.toModel();
+  }
+
+  /** @returns {string} A string representation of this instance for logging/debugging. */
+  toString() {
+    const propStr = `${super.toString()}`;
+
+    if (Object.getPrototypeOf(this).constructor === MachineDeployment) {
+      return `{MachineDeployment ${propStr}}`;
+    }
+
+    // this is actually an extended class instance, so return only the properties
+    return propStr;
+  }
+}

--- a/src/api/types/MachineUpgrade.js
+++ b/src/api/types/MachineUpgrade.js
@@ -1,0 +1,90 @@
+import { merge } from 'lodash';
+import * as rtv from 'rtvjs';
+import { logValue } from '../../util/logger';
+import { mergeRtvShapes } from '../../util/mergeRtvShapes';
+import { apiKinds } from '../apiConstants';
+import { ResourceUpdate, resourceUpdateTs } from './ResourceUpdate';
+
+/**
+ * Typeset for an MCC API machine upgrade resource.
+ */
+export const machineUpgradeTs = mergeRtvShapes({}, resourceUpdateTs, {
+  // NOTE: this is not intended to be fully-representative; we only list the properties
+  //  related to what we expect to find in order to create a `MachineUpgrade` class instance
+
+  kind: [rtv.STRING, { oneOf: apiKinds.MACHINE_UPGRADE_STATUS }],
+  fromRelease: rtv.STRING,
+  toRelease: rtv.STRING,
+});
+
+/**
+ * MCC API machine deployment.
+ * @class MachineUpgrade
+ */
+export class MachineUpgrade extends ResourceUpdate {
+  /**
+   * @constructor
+   * @param {Object} params
+   * @param {Object} params.data Raw data payload from the API.
+   * @param {Namespace} params.namespace Namespace to which the object belongs.
+   * @param {Cloud} params.cloud Reference to the Cloud used to get the data.
+   */
+  constructor({ data, namespace, cloud }) {
+    super({ data, cloud, namespace, typeset: machineUpgradeTs });
+
+    /**
+     * @readonly
+     * @member {string} fromRelease The original version of the machine.
+     */
+    Object.defineProperty(this, 'fromRelease', {
+      enumerable: true,
+      get() {
+        return data.fromRelease;
+      },
+    });
+
+    /**
+     * @readonly
+     * @member {string} toRelease The new version of the machine.
+     */
+    Object.defineProperty(this, 'toRelease', {
+      enumerable: true,
+      get() {
+        return data.toRelease;
+      },
+    });
+  }
+
+  // NOTE: we don't have toEntity() because we don't show MachineUpgrades in the Catalog at
+  //  the moment (so we don't have a MachineUpgradeEntity class for them either)
+
+  /**
+   * Converts this API Object into a Catalog Entity Model.
+   * @returns {{ metadata: Object, spec: Object, status: Object }} Catalog Entity Model
+   *  (use to create new Catalog Entity).
+   */
+  toModel() {
+    const model = super.toModel();
+
+    return merge({}, model, {
+      spec: {
+        fromRelease: this.fromRelease,
+        toRelease: this.toRelease,
+      },
+    });
+  }
+
+  /** @returns {string} A string representation of this instance for logging/debugging. */
+  toString() {
+    const propStr = `${super.toString()}, from: ${logValue(
+      this.fromRelease
+    )}, to: ${logValue(this.toRelease)}`;
+
+    if (Object.getPrototypeOf(this).constructor === MachineUpgrade) {
+      return `{MachineUpgrade ${propStr}}`;
+    }
+
+    // this is actually an extended class instance, so return only the properties
+    return propStr;
+  }
+}

--- a/src/api/types/Resource.js
+++ b/src/api/types/Resource.js
@@ -1,6 +1,7 @@
 import * as rtv from 'rtvjs';
 import * as consts from '../../constants';
 import { Cloud } from '../../common/Cloud';
+import { timestampTs } from '../apiTypesets';
 import { logValue } from '../../util/logger';
 
 /**
@@ -17,8 +18,8 @@ export const resourceTs = {
     uid: rtv.STRING,
     name: rtv.STRING,
     resourceVersion: rtv.STRING,
-    creationTimestamp: rtv.STRING, // ISO8601 timestamp
-    deletionTimestamp: [rtv.OPTIONAL, rtv.STRING], // ISO8601 timestamp; only exists if being deleted
+    creationTimestamp: timestampTs, // ISO8601 timestamp
+    deletionTimestamp: [rtv.OPTIONAL, ...timestampTs], // ISO8601 timestamp; only exists if being deleted
   },
 };
 

--- a/src/api/types/ResourceEvent.js
+++ b/src/api/types/ResourceEvent.js
@@ -45,7 +45,7 @@ export class ResourceEvent extends NamedResource {
    * @param {Cloud} params.cloud Reference to the Cloud used to get the data.
    * @param {rtv.Typeset} params.typeset Typeset for verifying the data.
    */
-  constructor({ data, namespace, cloud, typeset }) {
+  constructor({ data, namespace, cloud, typeset = resourceEventTs }) {
     super({ data, cloud, namespace, typeset });
 
     /**

--- a/src/api/types/ResourceUpdate.js
+++ b/src/api/types/ResourceUpdate.js
@@ -1,0 +1,177 @@
+import { merge, omit } from 'lodash';
+import * as rtv from 'rtvjs';
+import { mergeRtvShapes } from '../../util/mergeRtvShapes';
+import { NamedResource, namedResourceTs } from './NamedResource';
+import { apiKinds } from '../apiConstants';
+import { timestampTs } from '../apiTypesets';
+import { logValue } from '../../util/logger';
+
+/**
+ * Typeset for an MCC API resource update (an update for any type of resource).
+ *
+ * An "update" is a list of statuses that represents an event in history that took
+ *  place on a resource. Typically a cluster deployment or upgrade.
+ */
+export const resourceUpdateTs = mergeRtvShapes({}, namedResourceTs, {
+  // NOTE: this is not intended to be fully-representative; we only list the properties
+  //  related to what we expect to find in order to create a `Credential` class instance
+
+  kind: [
+    rtv.STRING,
+    {
+      oneOf: [
+        apiKinds.CLUSTER_DEPLOYMENT_STATUS,
+        apiKinds.CLUSTER_UPGRADE_STATUS,
+        apiKinds.MACHINE_UPGRADE_STATUS,
+      ],
+    },
+  ],
+
+  metadata: {
+    ownerReferences: [
+      rtv.ARRAY,
+      {
+        min: 1,
+        $: {
+          kind: [rtv.STRING, { oneOf: Object.values(apiKinds) }], // e.g. 'Cluster'
+          name: rtv.STRING,
+          uid: rtv.STRING,
+        },
+      },
+    ],
+  },
+
+  stages: [
+    [
+      {
+        name: rtv.STRING, // short message/phrase/summary, more like a title
+        message: [rtv.OPTIONAL, rtv.STRING], // detailed message, if any
+
+        // TODO[cluster-updates]: add this when release
+        // status: rtv.STRING, // status code like 'Success', 'InProgress', 'NotStarted'
+
+        // ISO8601, not provided unless stage is done (successfully or has been attempted
+        //  at least once)
+        timestamp: [rtv.OPTIONAL, ...timestampTs],
+      },
+    ],
+  ],
+});
+
+/**
+ * Update for any type of MCC API namespaced resource.
+ * @class ResourceUpdate
+ */
+export class ResourceUpdate extends NamedResource {
+  /**
+   * @constructor
+   * @param {Object} params
+   * @param {Object} params.data Raw data payload from the API.
+   * @param {Namespace} params.namespace Namespace to which the object belongs.
+   * @param {Cloud} params.cloud Reference to the Cloud used to get the data.
+   * @param {rtv.Typeset} params.typeset Typeset for verifying the data.
+   */
+  constructor({ data, namespace, cloud, typeset = resourceUpdateTs }) {
+    super({ data, cloud, namespace, typeset });
+
+    /**
+     * @readonly
+     * @member {string} targetKind API kind of the resource to which this update pertains.
+     *  Will be one of the `apiKinds` enum values.
+     */
+    Object.defineProperty(this, 'targetKind', {
+      enumerable: true,
+      get() {
+        return data.metadata.ownerReferences[0].kind;
+      },
+    });
+
+    /**
+     * @readonly
+     * @member {string} targetUid UID of the resource to which this update pertains.
+     */
+    Object.defineProperty(this, 'targetUid', {
+      enumerable: true,
+      get() {
+        return data.metadata.ownerReferences[0].uid;
+      },
+    });
+
+    /**
+     * @readonly
+     * @member {string} targetName Name of the resource to which this update pertains.
+     */
+    Object.defineProperty(this, 'targetName', {
+      enumerable: true,
+      get() {
+        return data.metadata.ownerReferences[0].name;
+      },
+    });
+
+    /**
+     * @readonly
+     * @member {Array<{ name: string, message?: string, status: string, time: Date }>} stages
+     *  List of objects describing each stage of the update.
+     */
+    Object.defineProperty(this, 'stages', {
+      enumerable: true,
+      get() {
+        return data.stages.map((stage) => ({
+          name: stage.name,
+          message: stage.message || null,
+
+          // TODO[cluster-updates]: should just be this when published
+          // status: stage.status,
+          // for now, we rely on success + timestamp
+          status: stage.timestamp
+            ? stage.success || stage.success === undefined
+              ? 'Success'
+              : 'InProgress'
+            : 'NotStarted',
+
+          time: stage.timestamp ? new Date(stage.timestamp) : null,
+        }));
+      },
+    });
+  }
+
+  /**
+   * Converts this API Object into a Catalog Entity Model.
+   * @returns {{ metadata: Object, spec: Object, status: Object }} Catalog Entity Model
+   *  (use to create new Catalog Entity).
+   */
+  toModel() {
+    const model = super.toModel();
+
+    return merge({}, model, {
+      spec: {
+        targetKind: this.targetKind,
+        targetUid: this.targetUid,
+        targetName: this.targetName,
+        stages: this.stages.map((stage) => ({
+          ...omit(stage, 'time'),
+          timeAt: stage.time.toISOString(),
+        })),
+      },
+      status: {
+        phase: 'available',
+      },
+    });
+  }
+
+  /** @returns {string} A string representation of this instance for logging/debugging. */
+  toString() {
+    const propStr = `${super.toString()}, targetKind: ${logValue(
+      this.targetKind
+    )}, targetName: ${logValue(this.targetName)}, targetUid: ${logValue(
+      this.targetUid
+    )}, stages: ${this.stages.length}`;
+
+    if (Object.getPrototypeOf(this).constructor === ResourceUpdate) {
+      return `{ResourceUpdate ${propStr}}`;
+    }
+
+    // this is actually an extended class instance, so return only the properties
+    return propStr;
+  }
+}

--- a/src/api/types/ResourceUpdate.js
+++ b/src/api/types/ResourceUpdate.js
@@ -22,6 +22,7 @@ export const resourceUpdateTs = mergeRtvShapes({}, namedResourceTs, {
       oneOf: [
         apiKinds.CLUSTER_DEPLOYMENT_STATUS,
         apiKinds.CLUSTER_UPGRADE_STATUS,
+        apiKinds.MACHINE_DEPLOYMENT_STATUS,
         apiKinds.MACHINE_UPGRADE_STATUS,
       ],
     },
@@ -33,7 +34,7 @@ export const resourceUpdateTs = mergeRtvShapes({}, namedResourceTs, {
       {
         min: 1,
         $: {
-          kind: [rtv.STRING, { oneOf: Object.values(apiKinds) }], // e.g. 'Cluster'
+          kind: [rtv.STRING, { oneOf: [apiKinds.CLUSTER, apiKinds.MACHINE] }], // e.g. 'Cluster'
           name: rtv.STRING,
           uid: rtv.STRING,
         },

--- a/src/catalog/catalogEntities.js
+++ b/src/catalog/catalogEntities.js
@@ -12,7 +12,6 @@ import {
   apiKinds,
   apiCredentialKinds,
   apiEventTypes,
-  apiUpdateKinds,
 } from '../api/apiConstants';
 import { timestampTs } from '../api/apiTypesets';
 

--- a/src/catalog/catalogEntities.js
+++ b/src/catalog/catalogEntities.js
@@ -12,7 +12,9 @@ import {
   apiKinds,
   apiCredentialKinds,
   apiEventTypes,
+  apiUpdateKinds,
 } from '../api/apiConstants';
+import { timestampTs } from '../api/apiTypesets';
 
 const {
   Catalog: { CatalogEntity, KubernetesCluster },
@@ -42,15 +44,6 @@ export const entityLabels = Object.freeze({
   /** Associated License name, if any. */
   LICENSE: 'license',
 });
-
-/**
- * RTV Typeset for a string that is an ISO8601 timestamp with optional milliseconds since
- *  we don't always have those.
- */
-const iso8601DateTs = [
-  rtv.STRING,
-  { exp: '^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d{3})?Z$' },
-];
 
 /**
  * Typeset representing the required labels for all entity types.
@@ -113,7 +106,7 @@ export const catalogEntityModelTs = {
   spec: {
     // ISO-8601 timestamp (e.g. 2022-03-04T21:33:27.716Z), milliseconds are optional
     //  (MCC API doesn't return milliseconds, so we don't always expect them)
-    createdAt: iso8601DateTs,
+    createdAt: timestampTs,
   },
 
   // all entities must have a status with a phase based on Common.Types.CatalogEntityStatus
@@ -261,7 +254,7 @@ export const clusterEntityModelTs = mergeRtvShapes({}, catalogEntityModelTs, {
         mergeRtvShapes({}, catalogEntityModelTs, {
           spec: {
             type: [rtv.STRING, { oneOf: Object.values(apiEventTypes) }],
-            lastTimeAt: iso8601DateTs,
+            lastTimeAt: timestampTs,
             count: rtv.SAFE_INT,
             sourceComponent: rtv.STRING,
             targetKind: [rtv.STRING, { oneOf: apiKinds.CLUSTER }],
@@ -269,6 +262,30 @@ export const clusterEntityModelTs = mergeRtvShapes({}, catalogEntityModelTs, {
             targetName: rtv.STRING,
             reason: rtv.STRING,
             message: rtv.STRING,
+          },
+        }),
+      ],
+    ],
+    updates: [
+      rtv.OPTIONAL, // optional for backward compatibility
+      [
+        mergeRtvShapes({}, catalogEntityModelTs, {
+          spec: {
+            fromRelease: [rtv.OPTIONAL, rtv.STRING], // only if upgrade status
+            toRelease: [rtv.OPTIONAL, rtv.STRING], // only if upgrade status
+            stages: [
+              [
+                {
+                  name: rtv.STRING,
+                  message: [rtv.EXPECTED, rtv.STRING],
+                  status: rtv.STRING,
+                  timeAt: [rtv.EXPECTED, ...timestampTs],
+                },
+              ],
+            ],
+            targetKind: [rtv.STRING, { oneOf: Object.values(apiUpdateKinds) }],
+            targetUid: rtv.STRING, // always expected for a ClusterEvent
+            targetName: rtv.STRING,
           },
         }),
       ],
@@ -409,51 +426,55 @@ export const entityHasChanged = function (entity, resourceOrModel) {
     resOrMod.resourceVersion
       ? resOrMod.cacheVersion
       : resOrMod.metadata.cacheVersion;
-  const getResOrModEvents = (resOrMod) =>
-    resOrMod.resourceVersion ? resOrMod.events : resOrMod.spec.events;
+  const getResOrModObjects = (resOrMod, listName) =>
+    resOrMod.resourceVersion ? resOrMod[listName] : resOrMod.spec[listName];
 
   let changed =
     entity.metadata.resourceVersion !== getResOrModVersion(resourceOrModel) ||
     entity.metadata.cacheVersion !== getResOrModCache(resourceOrModel);
 
-  if (!changed) {
-    // check to see if it's a cluster with updated events
-    if (entity instanceof KubernetesCluster) {
-      // if event list lengths are difference, there was a change
-      changed =
-        entity.spec.events.length !== getResOrModEvents(resourceOrModel).length;
+  // check to see if it's a cluster with updated events or updates
+  if (!changed && entity instanceof KubernetesCluster) {
+    changed = ['events', 'updates'].some((listName) => {
+      // if list lengths are difference, there was a change
+      let modified =
+        entity.spec[listName].length !==
+        getResOrModObjects(resourceOrModel, listName).length;
 
-      // otherwise, see if at least one event from the entity differs from an event in the
+      // otherwise, see if at least one object from the entity differs from an object in the
       //  resource/model
-      changed =
-        changed ||
-        entity.spec.events.some((entityEvent) => {
-          const resOrModEvent = getResOrModEvents(resourceOrModel).find(
-            (e) => getResOrModUid(e) === entityEvent.metadata.uid
-          );
+      modified =
+        modified ||
+        entity.spec[listName].some((entityObj) => {
+          const resOrModObj = getResOrModObjects(
+            resourceOrModel,
+            listName
+          ).find((e) => getResOrModUid(e) === entityObj.metadata.uid);
           return (
-            !resOrModEvent ||
-            getResOrModVersion(resOrModEvent) !==
-              entityEvent.metadata.resourceVersion
+            !resOrModObj ||
+            getResOrModVersion(resOrModObj) !==
+              entityObj.metadata.resourceVersion
           );
         });
 
       // and in case the lists are the same length but objects have changed internally, we have
-      //  to also see if at least one event from the resource/model differs from an event in
+      //  to also see if at least one object from the resource/model differs from an object in
       //  the entity
-      changed =
-        changed ||
-        getResOrModEvents(resourceOrModel).some((resOrModEvent) => {
-          const entityEvent = entity.spec.events.find(
-            (e) => e.metadata.uid === getResOrModUid(resOrModEvent)
+      modified =
+        modified ||
+        getResOrModObjects(resourceOrModel, listName).some((resOrModObj) => {
+          const entityObj = entity.spec[listName].find(
+            (e) => e.metadata.uid === getResOrModUid(resOrModObj)
           );
           return (
-            !entityEvent ||
-            entityEvent.metadata.resourceVersion !==
-              getResOrModVersion(resOrModEvent)
+            !entityObj ||
+            entityObj.metadata.resourceVersion !==
+              getResOrModVersion(resOrModObj)
           );
         });
-    }
+
+      return modified;
+    });
   }
 
   return changed;

--- a/src/catalog/catalogEntities.js
+++ b/src/catalog/catalogEntities.js
@@ -283,8 +283,11 @@ export const clusterEntityModelTs = mergeRtvShapes({}, catalogEntityModelTs, {
                 },
               ],
             ],
-            targetKind: [rtv.STRING, { oneOf: Object.values(apiUpdateKinds) }],
-            targetUid: rtv.STRING, // always expected for a ClusterEvent
+            targetKind: [
+              rtv.STRING,
+              { oneOf: [apiKinds.CLUSTER, apiKinds.MACHINE] },
+            ],
+            targetUid: rtv.STRING,
             targetName: rtv.STRING,
           },
         }),

--- a/src/common/CloudConfig.js
+++ b/src/common/CloudConfig.js
@@ -92,7 +92,10 @@ export class CloudConfig {
 
     switch (resourceType) {
       case apiResourceTypes.CLUSTER: // fall-through
+      case apiResourceTypes.CLUSTER_DEPLOYMENT_STATUS: // fall-through
+      case apiResourceTypes.CLUSTER_UPGRADE_STATUS: // fall-through
       case apiResourceTypes.MACHINE: // fall-through
+      case apiResourceTypes.MACHINE_UPGRADE_STATUS: // fall-through
       case apiResourceTypes.PUBLIC_KEY: // fall-through
       case apiResourceTypes.NAMESPACE: // fall-through
       case apiResourceTypes.SECRET: // fall-through

--- a/src/common/CloudConfig.js
+++ b/src/common/CloudConfig.js
@@ -95,6 +95,7 @@ export class CloudConfig {
       case apiResourceTypes.CLUSTER_DEPLOYMENT_STATUS: // fall-through
       case apiResourceTypes.CLUSTER_UPGRADE_STATUS: // fall-through
       case apiResourceTypes.MACHINE: // fall-through
+      case apiResourceTypes.MACHINE_DEPLOYMENT_STATUS: // fall-through
       case apiResourceTypes.MACHINE_UPGRADE_STATUS: // fall-through
       case apiResourceTypes.PUBLIC_KEY: // fall-through
       case apiResourceTypes.NAMESPACE: // fall-through

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -9,3 +9,4 @@
 declare const DEV_ENV: boolean;
 declare const DEV_UNSAFE_NO_CERT: boolean;
 declare const FEAT_CLUSTER_PAGE_ENABLED: boolean;
+declare const FEAT_CLUSTER_PAGE_UPDATES_ENABLED: boolean;

--- a/src/main/SyncManager.js
+++ b/src/main/SyncManager.js
@@ -728,7 +728,7 @@ export class SyncManager extends Singleton {
                 catEntity.metadata.cacheVersion
               )} -> ${logValue(
                 cluster.cacheVersion
-              )}) (cluster events may also have changed)`
+              )}) (cluster events/updates may also have changed)`
             );
 
             if (this.updateEntity(catEntity, model)) {
@@ -1058,7 +1058,7 @@ export class SyncManager extends Singleton {
                 entity.metadata.cacheVersion
               )} -> ${logValue(model.metadata.cacheVersion)})${
                 model.metadata.kind === apiKinds.CLUSTER
-                  ? ' (cluster events may also have changed)'
+                  ? ' (cluster events/updates may also have changed)'
                   : ''
               }`
             );

--- a/src/renderer/renderer.tsx
+++ b/src/renderer/renderer.tsx
@@ -10,7 +10,7 @@ import * as consts from '../constants';
 import {
   ROUTE_SYNC_VIEW,
   ROUTE_CLUSTER_OVERVIEW,
-  ROUTE_CLUSTER_PERFORMANCE,
+  ROUTE_CLUSTER_UPDATES,
   ROUTE_CLUSTER_EVENTS,
   ROUTE_CLUSTER_DETAILS,
 } from '../routes';
@@ -40,7 +40,8 @@ const {
 const logger: any = loggerUtil; // get around TS compiler's complaining
 const CLUSTER_PAGE_ID = 'mcc-cluster-page';
 
-declare const FEAT_CLUSTER_PAGE_ENABLED: any; // TODO[clusterpage]: remove
+declare const FEAT_CLUSTER_PAGE_ENABLED: any;
+declare const FEAT_CLUSTER_PAGE_UPDATES_ENABLED: any;
 
 export default class ExtensionRenderer extends LensExtension {
   //
@@ -70,17 +71,21 @@ export default class ExtensionRenderer extends LensExtension {
       },
     },
     {
-      id: ROUTE_CLUSTER_PERFORMANCE,
-      components: {
-        Page: () => <p>PERFORMANCE</p>,
-      },
-    },
-    {
       id: ROUTE_CLUSTER_EVENTS,
       components: {
         Page: () => <p>EVENTS</p>,
       },
     },
+    ...(FEAT_CLUSTER_PAGE_UPDATES_ENABLED
+      ? [
+          {
+            id: ROUTE_CLUSTER_UPDATES,
+            components: {
+              Page: () => <p>UPDATES</p>,
+            },
+          },
+        ]
+      : []),
     {
       id: ROUTE_CLUSTER_DETAILS,
       components: {
@@ -323,7 +328,6 @@ export default class ExtensionRenderer extends LensExtension {
     //  (which should now be deprecated, I think). See
     //  https://github.com/lensapp/lens/issues/4591#issuecomment-1275204032
     //
-    // TODO[clusterpage]: remove flag
     if (FEAT_CLUSTER_PAGE_ENABLED) {
       this.clusterPageMenus = [
         {
@@ -351,20 +355,24 @@ export default class ExtensionRenderer extends LensExtension {
         },
         {
           parentId: CLUSTER_PAGE_ID,
-          target: { pageId: ROUTE_CLUSTER_PERFORMANCE },
-          title: strings.clusterPage.menuItems.performance(),
-          components: {
-            Icon: null,
-          },
-        },
-        {
-          parentId: CLUSTER_PAGE_ID,
           target: { pageId: ROUTE_CLUSTER_EVENTS },
           title: strings.clusterPage.menuItems.events(),
           components: {
             Icon: null,
           },
         },
+        ...(FEAT_CLUSTER_PAGE_UPDATES_ENABLED
+          ? [
+              {
+                parentId: CLUSTER_PAGE_ID,
+                target: { pageId: ROUTE_CLUSTER_UPDATES },
+                title: strings.clusterPage.menuItems.updates(),
+                components: {
+                  Icon: null,
+                },
+              },
+            ]
+          : []),
         {
           parentId: CLUSTER_PAGE_ID,
           target: { pageId: ROUTE_CLUSTER_DETAILS },

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1,5 +1,5 @@
 export const ROUTE_SYNC_VIEW = '/cc-sync-view';
 export const ROUTE_CLUSTER_OVERVIEW = '/cc-cluster-overview';
-export const ROUTE_CLUSTER_PERFORMANCE = '/cc-cluster-performance';
 export const ROUTE_CLUSTER_EVENTS = '/cc-cluster-events';
+export const ROUTE_CLUSTER_UPDATES = '/cc-cluster-updates';
 export const ROUTE_CLUSTER_DETAILS = '/cc-cluster-details';

--- a/src/strings.ts
+++ b/src/strings.ts
@@ -344,8 +344,8 @@ export const clusterPage: Dict = {
   menuItems: {
     group: () => mccShortName,
     overview: () => 'Overview',
-    performance: () => 'Performance',
     events: () => 'Events',
+    updates: () => 'Updates',
     details: () => 'Details',
   },
   common: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,6 +6,8 @@
 // - DEV_UNSAFE_NO_CERT: Set to 'thisisunsafe' to disable TLS certificate verification
 //     on MCC instances.
 // - FEAT_CLUSTER_PAGE_ENABLED: Set to 1 to enable the Cluster Page feature. Disabled by default.
+// - FEAT_CLUSTER_PAGE_UPDATES_ENABLED: Set to 1 to enable the "Cluster Page > Update History" tab.
+//     Disabled by default.
 // - ENTITY_CACHE_VERSION: Version to use when caching entities via the SyncManager to disk with the
 //     SyncStore. Changing this version will result in a forced update of all synced resources
 //     the next time a DataCloud connects and syncs from MCC. Defaults to the
@@ -52,6 +54,9 @@ const plugins = [
     ),
     FEAT_CLUSTER_PAGE_ENABLED: JSON.stringify(
       !!Number(process.env.FEAT_CLUSTER_PAGE_ENABLED)
+    ),
+    FEAT_CLUSTER_PAGE_UPDATES_ENABLED: JSON.stringify(
+      !!Number(process.env.FEAT_CLUSTER_PAGE_UPDATES_ENABLED)
     ),
     'process.env.TARGET': JSON.stringify(buildTarget),
   }),


### PR DESCRIPTION
This adds an `updates` property on Cluster objects and cluster entities containing cluster/machine deployment/upgrade history, if available.

It also renames the 'Performance' tab to 'Updates' since we won't have a Performance tab anymore, but we're adding the Updates tab.

Since we need MCC v2.22 to get the new `stages[].status` field in `ClusterDeploymentStatus`, `ClusterUpgradeStatus`, `MachineDeploymentStatus`, and `MachineUpgradeStatus`, fetching updates is behind a new Webpack-enabled `FEAT_CLUSTER_PAGE_UPDATES_ENABLED` switch which can be set on the command line to opt in to seeing the Updates tab when running in Dev mode (or building Prod with the flag).


### PR Checklist

n/a (nothing new for the user, and no new data synced unless cluster page feature is enabled)
