### PR TITLE
Fix broken extension top bar item layout after Lens upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fixed a bug where Catalog Entities wouldn't get updated with new data needed for new features until (if ever) the related API resource would get updated in MCC.
     - From now on, whenever a new extension version is released, fresh data for all synced entities will be fetched the first time the extension runs in Lens.
 - Fixed a bug in mgmt cluster connection status reporting where status feedback was not as immediate as it should have been.
+- Fixed top bar item layout that [broke](https://github.com/lensapp/lens/issues/6658) in Lens version `2022.11.251411-latest`
 
 ## v5.2.1
 

--- a/src/renderer/topBarItems.js
+++ b/src/renderer/topBarItems.js
@@ -11,10 +11,17 @@ const colorHover = 'var(--textColorSecondary)';
 
 const TopBarExtension = styled.div`
   display: flex;
+  justify-content: center;
   align-items: center;
   background-color: var(--layoutTabsBackground);
+  margin: 0;
   padding: ${layout.pad * 0.25}px ${layout.pad * 0.5}px;
   border-radius: 4px;
+  width: 130px;
+
+  > svg {
+    flex: none; // don't let icon resize to fit; keep it size we want
+  }
 `;
 
 const TopBarExtensionTitle = styled.p`


### PR DESCRIPTION
Our own fix for https://github.com/lensapp/lens/issues/6658

Broken:
<img width="174" src="https://user-images.githubusercontent.com/2855350/204357831-c0c59452-64c6-47a3-b6fc-4f5de4fca8b7.png">

Fixed:
<img width="174" alt="image" src="https://user-images.githubusercontent.com/2855350/204363552-900d6b71-7b28-4e07-b66f-4a1888c3a327.png">

### PR Checklist

- [x] New feature or bug fix is mentioned in the `CHANGELOG`.
