### PR TITLE
[CCLEX-186] Add MachineEvent class, include machine events in cluster entities

### DIFF
--- a/src/api/types/MachineEvent.js
+++ b/src/api/types/MachineEvent.js
@@ -1,0 +1,59 @@
+import * as rtv from 'rtvjs';
+import { mergeRtvShapes } from '../../util/mergeRtvShapes';
+import { apiKinds } from '../apiConstants';
+import { ResourceEvent, resourceEventTs } from './ResourceEvent';
+
+/**
+ * Typeset for an MCC API machine event resource.
+ */
+export const machineEventTs = mergeRtvShapes({}, resourceEventTs, {
+  // NOTE: this is not intended to be fully-representative; we only list the properties
+  //  related to what we expect to find in order to create a `MachineEvent` class instance
+
+  involvedObject: {
+    kind: [rtv.STRING, { oneOf: apiKinds.MACHINE }],
+    uid: rtv.STRING, // machine event objects always have a UID
+  },
+});
+
+/**
+ * MCC API cluster event.
+ * @class MachineEvent
+ */
+export class MachineEvent extends ResourceEvent {
+  /**
+   * @constructor
+   * @param {Object} params
+   * @param {Object} params.data Raw data payload from the API.
+   * @param {Namespace} params.namespace Namespace to which the object belongs.
+   * @param {Cloud} params.cloud Reference to the Cloud used to get the data.
+   */
+  constructor({ data, namespace, cloud }) {
+    super({ data, cloud, namespace, typeset: machineEventTs });
+  }
+
+  // NOTE: we don't have toEntity() because we don't show MachineEvents in the Catalog at
+  //  the moment (so we don't have a MachineEventEntity class for them either)
+
+  /**
+   * Converts this API Object into a Catalog Entity Model.
+   * @returns {{ metadata: Object, spec: Object, status: Object }} Catalog Entity Model
+   *  (use to create new Catalog Entity).
+   */
+  toModel() {
+    // for now, there's nothing special we need to add
+    return super.toModel();
+  }
+
+  /** @returns {string} A string representation of this instance for logging/debugging. */
+  toString() {
+    const propStr = `${super.toString()}`;
+
+    if (Object.getPrototypeOf(this).constructor === MachineEvent) {
+      return `{MachineEvent ${propStr}}`;
+    }
+
+    // this is actually an extended class instance, so return only the properties
+    return propStr;
+  }
+}

--- a/src/catalog/catalogEntities.js
+++ b/src/catalog/catalogEntities.js
@@ -256,8 +256,11 @@ export const clusterEntityModelTs = mergeRtvShapes({}, catalogEntityModelTs, {
             lastTimeAt: timestampTs,
             count: rtv.SAFE_INT,
             sourceComponent: rtv.STRING,
-            targetKind: [rtv.STRING, { oneOf: apiKinds.CLUSTER }],
-            targetUid: rtv.STRING, // always expected for a ClusterEvent
+            targetKind: [
+              rtv.STRING,
+              { oneOf: [apiKinds.CLUSTER, apiKinds.MACHINE] },
+            ],
+            targetUid: rtv.STRING, // always expected for a ClusterEvent or MachineEvent
             targetName: rtv.STRING,
             reason: rtv.STRING,
             message: rtv.STRING,

--- a/src/common/DataCloud.js
+++ b/src/common/DataCloud.js
@@ -9,8 +9,8 @@ import {
   fetchLicenses,
   fetchMachines,
   fetchClusters,
-  fetchClusterEvents,
-  fetchClusterUpdates,
+  fetchResourceEvents,
+  fetchResourceUpdates,
 } from '../api/apiFetch';
 import { logger, logValue } from '../util/logger';
 import { EventDispatcher } from './EventDispatcher';
@@ -558,13 +558,13 @@ export class DataCloud extends EventDispatcher {
     let errorsOccurred = false;
     if (!this.preview) {
       // only fetch these if cluster page is enabled
-      let clusterEventResults = {
-        clusterEvents: {},
+      let resEventResults = {
+        resourceEvents: {},
         tokensRefreshed: false,
         errorsOccurred: false,
       };
       if (FEAT_CLUSTER_PAGE_ENABLED) {
-        clusterEventResults = await fetchClusterEvents(
+        resEventResults = await fetchResourceEvents(
           this.cloud,
           fetchedNamespaces
         );
@@ -573,13 +573,13 @@ export class DataCloud extends EventDispatcher {
       // NOTE: for now, we only get updates if Webpack enabled the special flag
       //  since they require MCC v2.22 which adds the expected `status` field
       //  to stage objects
-      let clusterUpdateResults = {
-        clusterUpdates: {},
+      let resUpdateResults = {
+        resourceUpdates: {},
         tokensRefreshed: false,
         errorsOccurred: false,
       };
       if (FEAT_CLUSTER_PAGE_ENABLED && FEAT_CLUSTER_PAGE_UPDATES_ENABLED) {
-        clusterUpdateResults = await fetchClusterUpdates(
+        resUpdateResults = await fetchResourceUpdates(
           this.cloud,
           fetchedNamespaces
         );
@@ -592,10 +592,9 @@ export class DataCloud extends EventDispatcher {
 
       // map all the resources fetched so far into their respective Namespaces
       fetchedNamespaces.forEach((namespace) => {
-        namespace.events =
-          clusterEventResults.clusterEvents[namespace.name] || [];
+        namespace.events = resEventResults.resourceEvents[namespace.name] || [];
         namespace.updates =
-          clusterUpdateResults.clusterUpdates[namespace.name] || [];
+          resUpdateResults.resourceUpdates[namespace.name] || [];
         namespace.sshKeys = keyResults.sshKeys[namespace.name] || [];
         namespace.credentials = credResults.credentials[namespace.name] || [];
         namespace.proxies = proxyResults.proxies[namespace.name] || [];
@@ -604,8 +603,8 @@ export class DataCloud extends EventDispatcher {
 
       errorsOccurred =
         errorsOccurred ||
-        clusterEventResults.errorsOccurred ||
-        clusterUpdateResults.errorsOccurred ||
+        resEventResults.errorsOccurred ||
+        resUpdateResults.errorsOccurred ||
         credResults.errorsOccurred ||
         keyResults.errorsOccurred ||
         proxyResults.errorsOccurred ||


### PR DESCRIPTION
Also renames `apiFetch.fetchClusterEvents()` and `apiFetch.fetchClusterUpdates()`
to be more generic since we're fetching cluster and machine events and updates.

### PR Checklist

n/a (feature not yet published)