### PR TITLE
[CCLEX-178] Add metrics API module with mock API responses

### DIFF
--- a/src/api/__tests__/metricPromMock.js
+++ b/src/api/__tests__/metricPromMock.js
@@ -1,0 +1,181 @@
+//
+// TODO[metrics]: remove these mocks unless useful for tests
+//
+// TEMPORARY mock of Prometheus API responses while we wait for
+//  the authentication issue to be fixed PRODX-28459
+//
+
+import queryString from 'query-string';
+
+/**
+ * [ASYNC] Performs a network request using node-fetch (nearly same API as
+ *  browser fetch()). See https://www.npmjs.com/package/node-fetch
+ *
+ * NOTE: This method does not throw errors on any type of failure. It always
+ *  succeeds and returns an object.
+ *
+ * @param {string} url Fetch URL.
+ * @param {Object} requestOptions Fetch request options.
+ * @param {Object} [options] Additional options.
+ * @param {Array<number>} [options.expectedStatuses] If specified, success is based
+ *  on the inclusion of the status code in this list; otherwise, it's based on
+ *  the 2xx range.
+ * @param {string} [options.extractBodyMethod] Name of the method to call on the
+ *  Fetch Response object in order to extract/parse the response's data/body.
+ *  @see https://developer.mozilla.org/en-US/docs/Web/API/Body for possible values.
+ *  If falsy (other than `undefined`), data is not extracted.
+ * @param {string} [options.errorMessage] Error message to use if the request is
+ *  deemed to have failed (per other options); otherwise, a generated message
+ *  is used, based on response status.
+ * @returns {Promise<Object>} If successful, the object has this shape:
+ *  `{response: Response, expectedStatuses, body: any, url: string}`:
+ *  - response: The Fetch Response object.
+ *  - expectedStatuses: The list provided when the request was initiated.
+ *  - body: The result of calling the `extractBodyMethod` on the Fetch Response.
+ *    If the method was falsy (other than `undefined`), this value is `null`.
+ *  - url: The full URL used for the request.
+ *
+ *  On failure, `{error: string, response: Response|undefined, expectedStatuses}`:
+ *  - error: Error message, either `options.errorMessage` if specified, or generated.
+ *  - response: The Fetch Response object. Undefined if the failure occurred prior
+ *    to fetching data.
+ *  - expectedStatuses: The list provided when the request was initiated.
+ *  - body: If the response was not 200 but it was still possible to extract the
+ *    payload using the `extractBodyMethod`, the extracted body. Sometimes APIs
+ *    return error messages this way. `undefined` otherwise.
+ *
+ *  The key distinguishing factor is that `error` will be non-empty in the error case.
+ */
+export const mockPromRequest = async function (
+  url,
+  { body },
+  { errorMessage, expectedStatuses } = {}
+) {
+  // cause some delay in the response
+  await new Promise((resolve) => setTimeout(resolve, 1000));
+
+  const res = {
+    // fetch response object (only what's necessary)
+    response: {
+      url,
+      status: 200,
+    },
+    url,
+    expectedStatuses,
+  };
+
+  if (!url.match(/\/api\/v1\/query$/)) {
+    res.response.status = 404;
+    res.error = errorMessage || 'Not found';
+    return res;
+  }
+
+  const { query } = queryString.parse(body);
+
+  if (!query) {
+    res.response.status = 400;
+    res.error = errorMessage || 'Invalid request (missing query)';
+    return res;
+  }
+
+  let payload;
+  switch (query) {
+    //// CPU
+
+    case 'avg(rate(node_cpu_seconds_total{mode="idle"}[1m]))':
+      payload = {
+        status: 'success',
+        data: {
+          resultType: 'vector',
+          result: [
+            { metric: {}, value: [1670448022.723, '0.9023333333316258'] },
+          ],
+        },
+      };
+      break;
+
+    case 'avg(rate(node_cpu_seconds_total{mode="iowait"}[1m]))':
+      payload = {
+        status: 'success',
+        data: {
+          resultType: 'vector',
+          result: [
+            { metric: {}, value: [1670449938.009, '0.0011527777777764136'] },
+          ],
+        },
+      };
+      break;
+
+    case 'avg(rate(node_cpu_seconds_total{mode="system"}[1m]))':
+      payload = {
+        status: 'success',
+        data: {
+          resultType: 'vector',
+          result: [
+            { metric: {}, value: [1670449970.229, '0.017895833333406906'] },
+          ],
+        },
+      };
+      break;
+
+    //// MEMORY
+
+    case 'sum(node_memory_MemFree_bytes{job="node-exporter"} + node_memory_Cached_bytes{job="node-exporter"} + node_memory_Buffers_bytes{job="node-exporter"}) + sum(node_memory_SReclaimable_bytes{job="node-exporter"})':
+      payload = {
+        status: 'success',
+        data: {
+          resultType: 'vector',
+          result: [{ metric: {}, value: [1670450077.822, '51638771712'] }],
+        },
+      };
+      break;
+
+    case 'sum(node_memory_MemTotal_bytes{job="node-exporter"})':
+      payload = {
+        status: 'success',
+        data: {
+          resultType: 'vector',
+          result: [{ metric: {}, value: [1670450231.048, '97649057792'] }],
+        },
+      };
+      break;
+
+    //// DISK
+
+    case 'sum(node_filesystem_free_bytes)':
+      payload = {
+        status: 'success',
+        data: {
+          resultType: 'vector',
+          result: [{ metric: {}, value: [1670450993.987, '2739571294208'] }],
+        },
+      };
+      break;
+
+    case 'sum(node_filesystem_size_bytes)':
+      payload = {
+        status: 'success',
+        data: {
+          resultType: 'vector',
+          result: [{ metric: {}, value: [1670450878.897, '4513795284992'] }],
+        },
+      };
+      break;
+
+    //// UNKNOWN
+
+    default:
+      // simulating query syntax error
+      // NOTE: response status is still 200 but body has `error` property
+      payload = {
+        status: 'error',
+        errorType: 'bad_data',
+        error:
+          'invalid parameter "query": 1:30: parse error: unclosed left parenthesis',
+      };
+      break;
+  }
+
+  res.body = payload;
+  return res;
+};

--- a/src/api/clients/ApiClient.js
+++ b/src/api/clients/ApiClient.js
@@ -38,18 +38,20 @@ export class ApiClient {
   }
 
   /**
-   * Makes a network request with specified options.
-   * @param {string} endpoint API endpoint. Does NOT begin or end with a slash.
-   * @param {Object} params
-   * @param {Object} [params.options] Request configuration options.
-   * @param {Array<number>} [params.expectedStatuses] List of expected success
-   *  statuses.
-   * @param {string} [params.errorMessage] Error message to use if the request is
+   * Makes a request to the API using the netUtil.js `request()` function.
+   * @param {string} endpoint Subpath from the `apiPrefix`, not starting with a slash.
+   * @param {Object} [options]
+   * @param {Object} [options.options] Additional netUtil.js `request()` options.
+   * @param {Array<number>} [options.expectedStatuses] If specified, success is based
+   *  on the inclusion of the status code in this list; otherwise, it's based on
+   *  the 2xx range.
+   * @param {string} [options.extractBodyMethod] Name of the method to call on the
+   *  Fetch Response object in order to extract/parse the response's data/body.
+   *  @see https://developer.mozilla.org/en-US/docs/Web/API/Body for possible values.
+   *  If falsy (other than `undefined`), data is not extracted. Defaults to 'json'.
+   * @param {string} [options.errorMessage] Error message to use if the request is
    *  deemed to have failed (per other options); otherwise, a generated message
    *  is used, based on response status.
-   * @param {string} [params.extractBodyMethod] Name of a method on a fetch
-   *  response object to call to deserialize/extract/parse data from the response.
-   *  Defaults to "json".
    * @returns {Promise<Object>} See netUtil.request() for response shape.
    */
   request(
@@ -65,7 +67,7 @@ export class ApiClient {
       {
         credentials: 'same-origin',
         ...options,
-        headers: { ...headers, ...((options && options.headers) || {}) },
+        headers: { ...headers, ...(options?.headers || {}) },
       },
       { expectedStatuses, errorMessage, extractBodyMethod }
     );

--- a/src/api/clients/AuthorizationClient.js
+++ b/src/api/clients/AuthorizationClient.js
@@ -23,15 +23,32 @@ export class AuthorizationClient {
     };
   }
 
-  request(url, { options = {}, expectedStatuses = [200], errorMessage }) {
+  /**
+   * Makes a request to the API using the netUtil.js `request()` function.
+   * @param {string} endpoint Subpath from the `apiPrefix`, not starting with a slash.
+   * @param {Object} [options]
+   * @param {Object} [options.options] Additional netUtil.js `request()` options.
+   * @param {Array<number>} [options.expectedStatuses] If specified, success is based
+   *  on the inclusion of the status code in this list; otherwise, it's based on
+   *  the 2xx range.
+   * @param {string} [options.extractBodyMethod] Name of the method to call on the
+   *  Fetch Response object in order to extract/parse the response's data/body.
+   *  @see https://developer.mozilla.org/en-US/docs/Web/API/Body for possible values.
+   *  If falsy (other than `undefined`), data is not extracted. Defaults to 'json'.
+   * @param {string} [options.errorMessage] Error message to use if the request is
+   *  deemed to have failed (per other options); otherwise, a generated message
+   *  is used, based on response status.
+   * @returns {Promise<Object>} See netUtil.request() for response shape.
+   */
+  request(endpoint, { options = {}, expectedStatuses = [200], errorMessage }) {
     return request(
-      `${this.baseUrl}/${AuthorizationClient.apiPrefix}/${url}`,
+      `${this.baseUrl}/${AuthorizationClient.apiPrefix}/${endpoint}`,
       {
         credentials: 'same-origin',
         ...options,
         headers: {
           ...this.headers,
-          ...((options && options.headers) || {}),
+          ...(options?.headers || {}),
         },
       },
       { expectedStatuses, errorMessage }

--- a/src/api/clients/KubernetesClient.js
+++ b/src/api/clients/KubernetesClient.js
@@ -26,18 +26,35 @@ export class KubernetesClient {
     };
   }
 
+  /**
+   * Makes a request to the API using the netUtil.js `request()` function.
+   * @param {string} endpoint Subpath from the `apiPrefix`, not starting with a slash.
+   * @param {Object} [options]
+   * @param {Object} [options.options] Additional netUtil.js `request()` options.
+   * @param {Array<number>} [options.expectedStatuses] If specified, success is based
+   *  on the inclusion of the status code in this list; otherwise, it's based on
+   *  the 2xx range.
+   * @param {string} [options.extractBodyMethod] Name of the method to call on the
+   *  Fetch Response object in order to extract/parse the response's data/body.
+   *  @see https://developer.mozilla.org/en-US/docs/Web/API/Body for possible values.
+   *  If falsy (other than `undefined`), data is not extracted. Defaults to 'json'.
+   * @param {string} [options.errorMessage] Error message to use if the request is
+   *  deemed to have failed (per other options); otherwise, a generated message
+   *  is used, based on response status.
+   * @returns {Promise<Object>} See netUtil.request() for response shape.
+   */
   request(
-    url,
+    endpoint,
     { options = {}, expectedStatuses = [200], errorMessage, extractBodyMethod }
   ) {
     return request(
-      `${this.baseUrl}/${KubernetesClient.apiPrefix}/${url}`,
+      `${this.baseUrl}/${KubernetesClient.apiPrefix}/${endpoint}`,
       {
         credentials: 'same-origin',
         ...options,
         headers: {
           ...this.headers,
-          ...((options && options.headers) || {}),
+          ...(options?.headers || {}),
         },
       },
       { expectedStatuses, errorMessage, extractBodyMethod }

--- a/src/api/clients/ResourceClient.js
+++ b/src/api/clients/ResourceClient.js
@@ -64,18 +64,35 @@ export class ResourceClient {
     };
   }
 
+  /**
+   * Makes a request to the API using the netUtil.js `request()` function.
+   * @param {string} endpoint Subpath from the `apiPrefix`, not starting with a slash.
+   * @param {Object} [options]
+   * @param {Object} [options.options] Additional netUtil.js `request()` options.
+   * @param {Array<number>} [options.expectedStatuses] If specified, success is based
+   *  on the inclusion of the status code in this list; otherwise, it's based on
+   *  the 2xx range.
+   * @param {string} [options.extractBodyMethod] Name of the method to call on the
+   *  Fetch Response object in order to extract/parse the response's data/body.
+   *  @see https://developer.mozilla.org/en-US/docs/Web/API/Body for possible values.
+   *  If falsy (other than `undefined`), data is not extracted. Defaults to 'json'.
+   * @param {string} [options.errorMessage] Error message to use if the request is
+   *  deemed to have failed (per other options); otherwise, a generated message
+   *  is used, based on response status.
+   * @returns {Promise<Object>} See netUtil.request() for response shape.
+   */
   request(
-    url,
+    endpoint,
     { options = {}, expectedStatuses = [200], errorMessage, extractBodyMethod }
   ) {
     return request(
-      `${this.baseUrl}/${this.apiPrefix}/${url}`,
+      `${this.baseUrl}/${this.apiPrefix}/${endpoint}`,
       {
         credentials: 'same-origin',
         ...options,
         headers: {
           ...this.headers,
-          ...((options && options.headers) || {}),
+          ...(options?.headers || {}),
         },
       },
       { expectedStatuses, errorMessage, extractBodyMethod }

--- a/src/api/metricApi.js
+++ b/src/api/metricApi.js
@@ -1,0 +1,344 @@
+//
+// Functions for making Cloud metric requests via the Prometheus endpoint
+//
+
+import queryString from 'query-string';
+import { cloudRefresh } from './apiUtil';
+import { logger, logValue } from '../util/logger';
+// TODO[metrics]: will need `import { request } from '../util/netUtil';` here
+import { Cloud } from '../common/Cloud';
+import * as strings from '../strings';
+import { mockPromRequest } from './__tests__/metricPromMock'; // TODO[metrics]: stop using mocks
+
+/**
+ * @typedef PromInstantQueryParams
+ * @property {string|number} [time] Time at which metric is sought. Either seconds since
+ *  the epoch, or ISO8601 timestamp. Defaults to "now", local time.
+ * @property {number} [timeout] Evaluation timeout. Defaults to the query timeout configured
+ *  on the server.
+ */
+
+/**
+ * @private
+ * Makes an authenticated request to the Prometheus API using the given Cloud.
+ * @param {Object} options
+ * @param {Cloud} options.cloud An Cloud object. NOTE: This instance will be UPDATED
+ *  with new tokens if the token is expired and successfully refreshed.
+ * @param {string} options.promUrl Prometheus URL for the Cloud.
+ * @param {string} options.endpoint Subpath from the API endpoint (e.g. method to call, 'query',
+ *  'query_range', etc.).
+ * @param {Record<string, string>} [options.params] Query parameters.
+ * @param {{ expectedStatuses?: Array<number>, extractBodyMethod?: string, errorMessage?: string }} [options.requestOptions]
+ *  Options for the `request()` function itself. See JSDocs on that function for more info.
+ * @param {Record<string, any>} [options.fetchOptions] Options for the underlying `fetch()` call
+ *  that `request()` will make. NOTE: `method` and `body` will be ignored.
+ * @returns {Promise<ApiSuccessResponse|ApiErrorResponse>}
+ */
+const _promRequest = async function ({
+  cloud,
+  promUrl,
+  endpoint,
+  params = {},
+  requestOptions,
+  fetchOptions,
+}) {
+  if (!cloud || !(cloud instanceof Cloud)) {
+    throw new Error('cloud parameter must be a Cloud instance');
+  }
+
+  let tokensRefreshed = false;
+
+  // NOTE: it's useless to fetch if we don't have a token, or we can't refresh it
+  if (!cloud.connected) {
+    return {
+      cloud,
+      tokensRefreshed,
+      error: strings.metricApi.error.noTokens(),
+      status: 400,
+    };
+  }
+
+  const baseUrl = promUrl.replace(/\/$/, ''); // remove end slash if any
+  const apiPrefix = 'api/v1';
+
+  const makeRequest = function () {
+    // NOTE: since `cloud.token` might get refreshed (and so change), we have to define
+    //  the headers everytime we run this internal function
+    const headers = {
+      Accept: 'application/json',
+      'Content-Type': 'application/x-www-form-urlencoded',
+      Authorization: `Bearer ${cloud.token}`,
+    };
+
+    // TODO[metrics]: replace `mockPromRequest` with just request() from '../util/netUtil'
+    return mockPromRequest(
+      `${baseUrl}/${apiPrefix}/${endpoint}`,
+      {
+        credentials: 'same-origin',
+        ...fetchOptions,
+        headers: {
+          ...headers,
+          ...(fetchOptions?.headers || {}),
+        },
+
+        // NOTE: it's not required to put everything in a form URL-encoded body,
+        //  but it's best in order to support queries of unknown lengths that might
+        //  exceed server-side URL character limits
+        method: 'POST',
+        body: queryString.stringify(params),
+      },
+      Object.assign({ expectedStatuses: [200] }, requestOptions)
+    );
+  };
+
+  // the first attempt to fetch
+  let { response, error, body, url } = await makeRequest();
+  let path = url?.replace(`${cloud.cloudUrl}/`, '');
+
+  if (response?.status === 401) {
+    // assume token is expired, try to refresh
+    logger.log(
+      'metricApi._cloudRequest()',
+      `Request failed (tokens expired); url=${logValue(
+        response.url
+      )}; cloud=${logValue(cloud.cloudUrl)}`
+    );
+    tokensRefreshed = await cloudRefresh(cloud);
+    if (!tokensRefreshed) {
+      return { cloud, tokensRefreshed, url, error, status: 401 };
+    }
+
+    // try to fetch again with updated token
+    ({ response, error, body, url } = await makeRequest());
+    path = url?.replace(`${cloud.cloudUrl}/`, '');
+  } else if (!error && body?.status === 'error') {
+    // check for Prometheus-reported error
+    error = body.error;
+  }
+
+  return {
+    cloud,
+    body,
+    tokensRefreshed, // may have been refreshed and _then_ error occurred, so always include
+    error,
+    status: response?.status ?? 0,
+    url,
+    path,
+  };
+};
+
+/**
+ * Executes an instance query (one that returns a single metric).
+ * @param {Cloud} cloud Cloud object for the mgmt cluster on which Prometheus is available.
+ *  NOTE: This instance will be UPDATED with new tokens if the token is expired and successfully
+ *  refreshed.
+ * @param {string} promUrl Prometheus service URL in the `cloud`.
+ * @param {string} query PromQL instant query to execute.
+ * @param {PromInstantQueryParams} [params] Query parameters.
+ * @returns {Promise<ApiSuccessResponse|ApiErrorResponse>}
+ */
+export const instantQuery = async function (
+  cloud,
+  promUrl,
+  query,
+  params = {}
+) {
+  const queryParams = Object.assign({ time: Date.now() }, params, { query });
+  return _promRequest({
+    cloud,
+    promUrl,
+    endpoint: 'query',
+    params: queryParams,
+    requestOptions: {
+      errorMessage: strings.metricApi.error.instantQueryFailure(),
+    },
+  });
+};
+
+/**
+ * Gets all CPU usage metrics.
+ * @param {PromInstantQueryParams} [params] Query parameters.
+ * @returns {Promise<{ idlePct: number, ioPct: number, systemPct: number, usagePct }>}
+ *  Idle, I/O, system, and usage % as a number from 0 to 1.
+ */
+export const getCpuMetrics = async function (cloud, promUrl, params) {
+  const time = Date.now(); // make sure all queries use the same timestamp
+  const queryParams = { time, ...params };
+
+  const promises = [
+    // idle % (usage is `1 - idle` so we just need to get idle time)
+    instantQuery(
+      cloud,
+      promUrl,
+      'avg(rate(node_cpu_seconds_total{mode="idle"}[1m]))',
+      queryParams
+    ),
+    // I/O %
+    instantQuery(
+      cloud,
+      promUrl,
+      'avg(rate(node_cpu_seconds_total{mode="iowait"}[1m]))',
+      queryParams
+    ),
+    // system/kernel %
+    instantQuery(
+      cloud,
+      promUrl,
+      'avg(rate(node_cpu_seconds_total{mode="system"}[1m]))',
+      queryParams
+    ),
+  ];
+
+  let results;
+  try {
+    results = await Promise.all(promises);
+  } catch (err) {
+    throw new Error(`Failed to get cpu usage: ${logValue(err)}`);
+  }
+
+  const errors = results.filter((r) => !!r.error);
+  if (errors.length > 0) {
+    throw new Error(
+      `Failed to get cpu usage data due to ${errors.length} errors: [${errors
+        .map((e) => logValue(e.error))
+        .join(', ')}]`
+    );
+  }
+
+  const [idleRes, ioRes, systemRes] = results;
+
+  try {
+    const stats = {
+      idlePct: idleRes.body.data.result[0].value[1],
+      ioPct: ioRes.body.data.result[0].value[1],
+      systemPct: systemRes.body.data.result[0].value[1],
+    };
+
+    return {
+      ...stats,
+      usagePct: 1 - stats.idlePct,
+    };
+  } catch (err) {
+    throw new Error(`Failed to parse cpu usage data: ${logValue(err)}`);
+  }
+};
+
+/**
+ * Gets all Memory usage metrics.
+ * @param {PromInstantQueryParams} [params] Query parameters.
+ * @returns {Promise<{ availableByte: number, capacityByte: number, allocatedByte: number }>}
+ *  Available, capacity, and allocated memory in bytes.
+ */
+export const getMemoryMetrics = async function (cloud, promUrl, params) {
+  const time = Date.now(); // make sure all queries use the same timestamp
+  const queryParams = { time, ...params };
+
+  const promises = [
+    // available bytes
+    instantQuery(
+      cloud,
+      promUrl,
+      'sum(node_memory_MemFree_bytes{job="node-exporter"} + node_memory_Cached_bytes{job="node-exporter"} + node_memory_Buffers_bytes{job="node-exporter"}) + sum(node_memory_SReclaimable_bytes{job="node-exporter"})',
+      queryParams
+    ),
+    // capacity bytes
+    instantQuery(
+      cloud,
+      promUrl,
+      'sum(node_memory_MemTotal_bytes{job="node-exporter"})',
+      queryParams
+    ),
+  ];
+
+  let results;
+  try {
+    results = await Promise.all(promises);
+  } catch (err) {
+    throw new Error(`Failed to get memory usage: ${logValue(err)}`);
+  }
+
+  const errors = results.filter((r) => !!r.error);
+  if (errors.length > 0) {
+    throw new Error(
+      `Failed to get memory usage data due to ${errors.length} errors: [${errors
+        .map((e) => logValue(e.error))
+        .join(', ')}]`
+    );
+  }
+
+  const [availableRes, capacityRes] = results;
+
+  try {
+    const stats = {
+      availableByte: availableRes.body.data.result[0].value[1],
+      capacityByte: capacityRes.body.data.result[0].value[1],
+    };
+
+    return {
+      ...stats,
+      allocatedByte: stats.capacityByte - stats.availableByte,
+    };
+  } catch (err) {
+    throw new Error(`Failed to parse memory usage data: ${logValue(err)}`);
+  }
+};
+
+/**
+ * Gets all Disk usage metrics.
+ * @param {PromInstantQueryParams} [params] Query parameters.
+ * @returns {Promise<{ availableByte: number, capacityByte: number, usedByte: number }>}
+ *  Available, capacity, and used storage in bytes.
+ */
+export const getDiskMetrics = async function (cloud, promUrl, params) {
+  const time = Date.now(); // make sure all queries use the same timestamp
+  const queryParams = { time, ...params };
+
+  const promises = [
+    // available bytes
+    instantQuery(
+      cloud,
+      promUrl,
+      'sum(node_filesystem_free_bytes)',
+      queryParams
+    ),
+    // capacity bytes
+    instantQuery(
+      cloud,
+      promUrl,
+      'sum(node_filesystem_size_bytes)',
+      queryParams
+    ),
+  ];
+
+  let results;
+  try {
+    results = await Promise.all(promises);
+  } catch (err) {
+    throw new Error(`Failed to get disk usage: ${logValue(err)}`);
+  }
+
+  const errors = results.filter((r) => !!r.error);
+  if (errors.length > 0) {
+    throw new Error(
+      `Failed to get disk usage data due to ${errors.length} errors: [${errors
+        .map((e) => logValue(e.error))
+        .join(', ')}]`
+    );
+  }
+
+  const [availableRes, capacityRes] = results;
+
+  try {
+    const stats = {
+      availableByte: availableRes.body.data.result[0].value[1],
+      capacityByte: capacityRes.body.data.result[0].value[1],
+    };
+
+    return {
+      ...stats,
+      usedByte: stats.capacityByte - stats.availableByte,
+    };
+  } catch (err) {
+    throw new Error(`Failed to parse disk usage data: ${logValue(err)}`);
+  }
+};

--- a/src/renderer/renderer.tsx
+++ b/src/renderer/renderer.tsx
@@ -209,7 +209,7 @@ export default class ExtensionRenderer extends LensExtension {
 
     // OPEN IN BROWSER
     ctx.menuItems.push({
-      title: strings.catalog.entities.cluster.contextMenu.browserOpen.title(),
+      title: strings.catalog.entities.common.contextMenu.browserOpen.title(),
       icon: 'launch',
       onClick: async () => {
         openBrowser(generateEntityUrl(entity));

--- a/src/strings.ts
+++ b/src/strings.ts
@@ -137,6 +137,13 @@ export const apiUtil: Dict = {
   },
 };
 
+export const metricApi: Dict = {
+  error: {
+    noTokens: apiUtil.error.noTokens,
+    instantQueryFailure: () => 'Failed to execute instant query',
+  },
+};
+
 export const netUtil: Dict = {
   error: {
     requestFailed: (url = 'unknown', error) =>
@@ -150,6 +157,7 @@ export const netUtil: Dict = {
     responseCode: (status = -1) => `Server response code: ${status}`,
     invalidBrowserUrl: (url) =>
       `Cannot open URL in browser (must be http/s): "${url}"`,
+    unauthorized: () => 'Unauthorized',
   },
 };
 
@@ -236,9 +244,6 @@ export const catalog: Dict = {
       contextMenu: {
         settings: {
           title: () => 'Settings',
-        },
-        browserOpen: {
-          title: () => 'Open in browser',
         },
       },
 


### PR DESCRIPTION
Since we're blocked on PRODX-28459 in terms of accessing the Prometheus API on a given cluster (cloud), this commit includes a `./__tests__/metricPromMock.js` module that currently takes care of fulfilling Prometheus API requests made by the new metricApi.js module.

The metricApi.js module seeks to abstract the details of calling the Prometheus API by exposing high level functions like `getCpuMetrics()`, `getMemoryMetrics()`, and `getDiskMetrics()` which, internally, execute multiple Prometheus queries in order to gather the necessary data.

We should be able to build the Health panel based on this module and the fake data for now until we can get rid of the mock layer and reach Prometheus directly.

### Example

Here's some sample code that calls each of the methods and prints the results to the console. Each result is an object with 3 or 4 properties depending on the method called.

```javascript
testMetrics = async (event, cloudUrl) => {
  const dc = this.dataClouds[cloudUrl];
  const promUrl =
    'https://a3f5c7cc1fc794891a8e86d6f29a8fe7-616423632.us-east-2.elb.amazonaws.com';

  try {
    const metrics = await getCpuMetrics(dc.cloud, promUrl);
    console.log(metrics);
  } catch (err) {
    console.error(err.message);
  }

  try {
    const metrics = await getMemoryMetrics(dc.cloud, promUrl);
    console.log(metrics);
  } catch (err) {
    console.error(err.message);
  }

  try {
    const metrics = await getDiskMetrics(dc.cloud, promUrl);
    console.log(metrics);
  } catch (err) {
    console.error(err.message);
  }
};
```

### PR Checklist

n/a
