### PR TITLE
[CCLEX-173] Add HealthPanel behind new FEAT_CLUSTER_PAGE_HEALTH_ENABLED flag

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -80,6 +80,7 @@ const globals = {
   DEV_UNSAFE_NO_CERT: 'readonly',
   FEAT_CLUSTER_PAGE_ENABLED: 'readonly',
   FEAT_CLUSTER_PAGE_HISTORY_ENABLED: 'readonly',
+  FEAT_CLUSTER_PAGE_HEALTH_ENABLED: 'readonly',
   fetchMock: 'readonly', // from 'jest-fetch-mock' package
 };
 

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -10,3 +10,4 @@ declare const DEV_ENV: boolean;
 declare const DEV_UNSAFE_NO_CERT: boolean;
 declare const FEAT_CLUSTER_PAGE_ENABLED: boolean;
 declare const FEAT_CLUSTER_PAGE_HISTORY_ENABLED: boolean;
+declare const FEAT_CLUSTER_PAGE_HEALTH_ENABLED: boolean;

--- a/src/renderer/components/ClusterPage/Overview/ClusterOverviewView.js
+++ b/src/renderer/components/ClusterPage/Overview/ClusterOverviewView.js
@@ -6,6 +6,7 @@ import propTypes from 'prop-types';
 import * as strings from '../../../../strings';
 import { ConditionsPanel } from './ConditionsPanel';
 import { SummaryPanel } from './SummaryPanel';
+import { HealthPanel } from './HealthPanel';
 import { PanelTitle } from '../PanelTitle';
 import { DrawerTitleWrapper, PageContainer } from '../clusterPageComponents';
 
@@ -21,6 +22,10 @@ export const ClusterOverviewView = function ({ clusterEntity }) {
   return (
     <PageContainer>
       <SummaryPanel clusterEntity={clusterEntity} />
+
+      {FEAT_CLUSTER_PAGE_HEALTH_ENABLED ? (
+        <HealthPanel clusterEntity={clusterEntity} />
+      ) : null}
 
       <DrawerTitleWrapper>
         <PanelTitle

--- a/src/renderer/components/ClusterPage/Overview/HealthPanel.js
+++ b/src/renderer/components/ClusterPage/Overview/HealthPanel.js
@@ -1,0 +1,9 @@
+import propTypes from 'prop-types';
+
+export const HealthPanel = ({ clusterEntity }) => {
+  return <div>HEALTH of {clusterEntity.metadata.name}</div>;
+};
+
+HealthPanel.propTypes = {
+  clusterEntity: propTypes.object.isRequired,
+};

--- a/tools/scripts/test/testConfigs.mjs
+++ b/tools/scripts/test/testConfigs.mjs
@@ -169,6 +169,9 @@ export const baseConfig = function ({
       globals: {
         DEV_ENV: 'true',
         TEST_ENV: 'true',
+        FEAT_CLUSTER_PAGE_ENABLED: true,
+        FEAT_CLUSTER_PAGE_HISTORY_ENABLED: true,
+        FEAT_CLUSTER_PAGE_HEALTH_ENABLED: true,
       },
       transform: {
         '^.+\\.(t|j)sx?$': 'babel-jest',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,6 +8,8 @@
 // - FEAT_CLUSTER_PAGE_ENABLED: Set to 1 to enable the Cluster Page feature. Disabled by default.
 // - FEAT_CLUSTER_PAGE_HISTORY_ENABLED: Set to 1 to enable the "Cluster Page > Update History" tab.
 //     Disabled by default.
+// - FEAT_CLUSTER_PAGE_HEALTH_ENABLED: Set to 1 to enable the "Cluster Page > Overview > Health" panel.
+//     Disabled by default.
 // - ENTITY_CACHE_VERSION: Version to use when caching entities via the SyncManager to disk with the
 //     SyncStore. Changing this version will result in a forced update of all synced resources
 //     the next time a DataCloud connects and syncs from MCC. Defaults to the
@@ -57,6 +59,9 @@ const plugins = [
     ),
     FEAT_CLUSTER_PAGE_HISTORY_ENABLED: JSON.stringify(
       !!Number(process.env.FEAT_CLUSTER_PAGE_HISTORY_ENABLED)
+    ),
+    FEAT_CLUSTER_PAGE_HEALTH_ENABLED: JSON.stringify(
+      !!Number(process.env.FEAT_CLUSTER_PAGE_HEALTH_ENABLED)
     ),
     'process.env.TARGET': JSON.stringify(buildTarget),
   }),


### PR DESCRIPTION
HealthPanel is empty, just a placeholder.

Set `FEAT_CLUSTER_PAGE_HEALTH_ENABLED=1` on the command line when using `yarn start` to build the extension for local testing.


### PR Checklist

n/a
