### PR TITLE
[CCLEX-194] Surface better connection error messages

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -76,6 +76,7 @@ const env = {
 
 const globals = {
   DEV_ENV: 'readonly',
+  TEST_ENV: 'readonly',
   ENTITY_CACHE_VERSION: 'readonly',
   FEAT_CLUSTER_PAGE_HISTORY_ENABLED: 'readonly',
   FEAT_CLUSTER_PAGE_HEALTH_ENABLED: 'readonly',

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
     - ❗️ This works around a [Lens issue](https://github.com/lensapp/lens/issues/6966) whereby dozens/hundreds of login windows can be opened in the default browser if Lens is left running in the background and the short-lived cluster access token expires.
     - See the [docs](README.md#offline-tokens) for more info.
 - Added keyboard support (i.e. for tab key) to custom tri-state checkbox component used throughout the extension.
+- Improved how connection errors are displayed when adding a new management cluster, or when reconnecting to a disconnected management cluster:
+    - When adding, error messages are displayed in an error popup notification which does not auto-dismiss.
+    - When syncing, error messages are surfaced in an error icon next to the status string in the Sync View table. Mouse over for a tooltip containing the error message.
+    - Error messages are introspected for two specific cases in order to provide more helpful messages: Untrusted self-signed certificates, and unable to reach the host.
 
 ## v5.4.0
 

--- a/src/common/DataCloud.js
+++ b/src/common/DataCloud.js
@@ -297,7 +297,7 @@ export class DataCloud extends EventDispatcher {
     //  succession because of CloudStore updates or expired tokens that got refreshed
     this.addEventListener(DATA_CLOUD_EVENTS.FETCH_DATA, this.onFetchData);
 
-    // schedule the initial data load/fetch, afterwhich we'll either start watching or polling
+    // schedule the initial data load/fetch, afterwhich we'll start watching
     this.dispatchEvent(DATA_CLOUD_EVENTS.FETCH_DATA);
 
     ipc.listen(ipcEvents.broadcast.POWER_SUSPEND, () =>

--- a/src/renderer/components/EnhancedTable/EnhancedTableRow.js
+++ b/src/renderer/components/EnhancedTable/EnhancedTableRow.js
@@ -16,6 +16,7 @@ import {
 import { sortNamespaces } from './tableUtil';
 import * as consts from '../../../constants';
 import * as strings from '../../../strings';
+import { getCloudConnectionError } from '../../rendererUtil';
 import { CloudNamespace } from '../../../common/CloudNamespace';
 
 const { Icon, MenuItem, MenuActions, Tooltip } = Renderer.Component;
@@ -106,6 +107,15 @@ const Warning = styled.div`
     pointer-events: all;
   `}
 `;
+
+const ConnectionError = styled.div(() => ({
+  marginLeft: layout.grid,
+}));
+
+const CloudStatus = styled.div(() => ({
+  display: 'flex',
+  alignItems: 'center',
+}));
 
 const expandIconStyles = {
   color: 'var(--textColorPrimary)',
@@ -222,12 +232,38 @@ export const EnhancedTableRow = ({
     if (withCheckboxes) {
       return null;
     }
+
     const cloudMenuItems = getCloudMenuItems(cloud);
     const { cloudStatus, styles } = status;
+
+    let errorIcon;
+    if (cloud.connectError) {
+      const message = getCloudConnectionError(cloud);
+      errorIcon = (
+        <ConnectionError>
+          <Icon
+            id={`${cloud.name}-cloud-connection-error`}
+            material="error"
+            focusable={false}
+            interactive={false}
+            style={{ color: 'var(--colorError)' }}
+          />
+          <Tooltip targetId={`${cloud.name}-cloud-connection-error`}>
+            {message}
+          </Tooltip>
+        </ConnectionError>
+      );
+    }
+
     return (
       <>
         <EnhTableRowCell>{cloud.username}</EnhTableRowCell>
-        <EnhTableRowCell style={styles}>{cloudStatus}</EnhTableRowCell>
+        <EnhTableRowCell style={styles}>
+          <CloudStatus>
+            <span>{cloudStatus}</span>
+            {errorIcon}
+          </CloudStatus>
+        </EnhTableRowCell>
         <EnhTableRowCell isRightAligned>
           <EnhMore>
             <MenuActions>

--- a/src/renderer/components/GlobalPage/AddCloudInstance.js
+++ b/src/renderer/components/GlobalPage/AddCloudInstance.js
@@ -9,7 +9,7 @@ import { DataCloud, DATA_CLOUD_EVENTS } from '../../../common/DataCloud';
 import { IpcRenderer } from '../../IpcRenderer';
 import { Renderer } from '@k8slens/extensions';
 import { normalizeUrl } from '../../../util/netUtil';
-import { addCloudInstance } from '../../../strings';
+import { getCloudConnectionError } from '../../rendererUtil';
 import {
   Cloud,
   CONNECTION_STATUSES,
@@ -106,8 +106,9 @@ export const AddCloudInstance = ({ onAdd, onCancel }) => {
     return () => dataCloud?.destroy();
   }, [dataCloud]);
 
-  const checkConnectionError = () => {
-    Notifications.error(addCloudInstance.connectionError());
+  const checkConnectionError = (newCloud) => {
+    const message = getCloudConnectionError(newCloud);
+    Notifications.error(message, { timeout: 0 }); // require user to dismiss
   };
 
   const handleClusterConnect = async function ({
@@ -138,7 +139,7 @@ export const AddCloudInstance = ({ onAdd, onCancel }) => {
         if (newCloud.status === CONNECTION_STATUSES.CONNECTED) {
           setCloud(newCloud);
         } else {
-          checkConnectionError();
+          checkConnectionError(newCloud);
         }
       }
     };
@@ -153,6 +154,8 @@ export const AddCloudInstance = ({ onAdd, onCancel }) => {
       <MainColumn>
         <ConnectionBlock
           loading={loading}
+          loaded={!!cloud}
+          connectError={cloud?.connectError}
           onClusterConnect={handleClusterConnect}
         />
         {loading ? (

--- a/src/renderer/components/GlobalPage/__tests__/AddCloudInstance.spec.js
+++ b/src/renderer/components/GlobalPage/__tests__/AddCloudInstance.spec.js
@@ -105,8 +105,8 @@ describe('/renderer/components/GlobalPage/AddCloudInstance', () => {
         );
 
         const testUrl = 'https://foo.com/';
-        const inputNameEl = document.getElementById('lecc-cluster-name');
-        const inputUrlEl = document.getElementById('lecc-cluster-url');
+        const inputNameEl = document.getElementById('cclex-cluster-name');
+        const inputUrlEl = document.getElementById('cclex-cluster-url');
 
         await user.type(inputNameEl, testCloudName);
         await user.type(inputUrlEl, testUrl);
@@ -123,7 +123,7 @@ describe('/renderer/components/GlobalPage/AddCloudInstance', () => {
           ).not.toBeInTheDocument();
           expect(
             document.querySelector('.notification.error')
-          ).toHaveTextContent(strings.addCloudInstance.connectionError());
+          ).toHaveTextContent(strings.cloudConnectionErrors.connectionError());
         } else {
           expect(
             screen.getByText(strings.synchronizeBlock.title())

--- a/src/renderer/components/TriStateCheckbox/TriStateCheckbox.js
+++ b/src/renderer/components/TriStateCheckbox/TriStateCheckbox.js
@@ -8,6 +8,8 @@ const { Icon } = Renderer.Component;
 
 const controlWidth = layout.grid * 4; // 16px
 const controlLabelGap = layout.grid * 2.5; // 10px
+const disabledColor = 'var(--textColorDimmed)';
+const checkedColor = 'var(--primary)';
 
 const Wrapper = styled.div(() => ({
   minWidth: 64,
@@ -22,7 +24,7 @@ const ControlPart = styled.div(() => ({
   alignItems: 'center',
 }));
 
-const Control = styled.div(({ isChecked }) => ({
+const Control = styled.div(({ isChecked, disabled }) => ({
   flex: '0 0 auto',
   display: 'flex',
   justifyContent: 'center',
@@ -32,9 +34,10 @@ const Control = styled.div(({ isChecked }) => ({
   borderWidth: 2,
   borderRadius: 2,
   borderStyle: 'solid',
-  borderColor: isChecked ? 'var(--primary)' : 'var(--textColorSecondary)',
-  backgroundColor: isChecked ? 'var(--primary)' : 'transparent',
-  cursor: 'pointer',
+  borderColor: isChecked ? checkedColor : 'var(--textColorSecondary)',
+  backgroundColor: isChecked ? checkedColor : 'transparent',
+  cursor: disabled ? 'default' : 'pointer',
+  opacity: disabled ? '50%' : undefined, // same as what Lens does for a disabled <Button>
 
   ':focus': {
     borderColor: 'var(--colorInfo)',
@@ -51,12 +54,13 @@ const HiddenField = styled.input(() => ({
   display: 'none',
 }));
 
-const Label = styled.label(() => ({
+const Label = styled.label(({ disabled }) => ({
   paddingLeft: controlLabelGap,
-  cursor: 'pointer',
+  cursor: disabled ? 'default' : 'pointer',
   overflowWrap: 'break-word',
   hyphens: 'auto',
   overflow: 'hidden',
+  color: disabled ? disabledColor : undefined, // inherit color when enabled
 }));
 
 const HelpText = styled.p(() => ({
@@ -195,6 +199,7 @@ export const TriStateCheckbox = ({
           className={`${classPrefix}-control`}
           role="checkbox"
           isChecked={value !== checkValues.UNCHECKED}
+          disabled={disabled}
           tabIndex={tab}
           ref={ctrlRef}
           onClick={handleCtrlClick}
@@ -218,7 +223,11 @@ export const TriStateCheckbox = ({
             <Icon material="check" style={iconStyles} />
           )}
         </Control>
-        <Label className={`${classPrefix}-label`} onClick={handleLabelClick}>
+        <Label
+          className={`${classPrefix}-label`}
+          disabled={disabled}
+          onClick={handleLabelClick}
+        >
           {label}
         </Label>
       </ControlPart>

--- a/src/renderer/rendererUtil.js
+++ b/src/renderer/rendererUtil.js
@@ -6,6 +6,7 @@ import { Renderer } from '@k8slens/extensions';
 import dayjs from 'dayjs';
 import dayjsRelativeTimePlugin from 'dayjs/plugin/relativeTime';
 import * as consts from '../constants';
+import * as strings from '../strings';
 
 dayjs.extend(dayjsRelativeTimePlugin);
 
@@ -41,4 +42,23 @@ export const formatDate = (date, includeRelative = true) => {
         'YYYY-MM-DD, HH:mm:ss'
       )})`
     : dayjs(date).format('YYYY-MM-DD, HH:mm:ss');
+};
+
+/**
+ * Generates a user-friendly connection error message based on a Cloud's status.
+ * @param {Cloud} cloud
+ * @returns {string|undefined} Error message; `undefined` if the Cloud isn't in an error state.
+ */
+export const getCloudConnectionError = function (cloud) {
+  let message;
+  if (cloud.connectError) {
+    message = strings.cloudConnectionErrors.connectionError(); // generic error/reconnect message
+    if (cloud.connectError.match(/unable to verify.*certificate/i)) {
+      message = strings.cloudConnectionErrors.untrustedCertificate();
+    } else if (cloud.connectError.match(/getaddrinfo.*ENOTFOUND/i)) {
+      message = strings.cloudConnectionErrors.hostNotFound();
+    }
+  }
+
+  return message;
 };

--- a/src/strings.ts
+++ b/src/strings.ts
@@ -73,6 +73,7 @@ export const connectionBlock: Dict = {
     info: () =>
       "You will be directed to your Management Cluster's login page through your web browser where you should enter your SSO credentials",
     urlAlreadyUsed: () => 'This Management Cluster is already being synced',
+    urlWrongFormat: () => 'Wrong URL format',
     nameSymbolsAreNotValid: () =>
       'The name cannot contain whitespace or special characters, except for hyphens (-) and underscores (_)',
     nameAlreadyUsed: () =>
@@ -80,9 +81,13 @@ export const connectionBlock: Dict = {
   },
 };
 
-export const addCloudInstance = {
+export const cloudConnectionErrors = {
   connectionError: () =>
-    'An error occurred while connecting to the management cluster and retrieving its projects. Click on the Connect button to try again.',
+    'An error occurred while connecting to the management cluster. Check your network connection, make sure your VPN is active (if it is required to access the host), and try connecting again.',
+  hostNotFound: () =>
+    'The management cluster cannot be reached. Check your network connection, make sure your VPN is active (if it is required to access the host), and try connecting again.',
+  untrustedCertificate: () =>
+    'The management cluster appears to be using a self-signed certificate which cannot be verified. See the "Security" section of the documentation for a possible workaround.', // TODO[trustHost]: replace second sentence with, 'If you trust the host, enable the "Trust this host" option and try connecting again.'
 };
 
 export const synchronizeBlock = {


### PR DESCRIPTION
When adding a new mgmt cluster, if a connection error occurs, we now parse it to see if it's a certificate error (self-signed certs), a connection error, or some other unknown error, and display the friendly error message in an error notification popup that sticks to the screen until the user manually dismisses it (instead of having it stay visible only for 1-2 seconds and always be a generic message).

When reconnecting a disconnected mgmt cluster, if there's a connection error, we now show a little error icon next to the "Disconnected" status, with a friendly, more helpful connection error message in a tooltip on hover over the error icon.

Also:
- Added better disabled state support to TriStateCheckbox
- Made sure that Connect button (when adding a new mgmt cluster) remains disabled if any of the required field validators fail


### PR Checklist

Check if done, remove if not applicable:

- [x] New feature or bug fix is mentioned in the `CHANGELOG`.
