### PR TITLE
[CCLEX-179] Add 'Configure trusted hosts' migration dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@
     - When syncing, error messages are surfaced in an error icon next to the status string in the Sync View table. Mouse over for a tooltip containing the error message.
     - Error messages are introspected for two specific cases in order to provide more helpful messages: Untrusted self-signed certificates, and unable to reach the host.
 - Removed the `LEX_CC_UNSAFE_ALLOW_SELFSIGNED_CERTS` Lens startup command line option in favor of the new per-management cluster __trust host__ feature.
+    - 💬 To help users migrate to the new per-management cluster setting, away from the command line, if the flag is set and at least one untrusted management cluster with a secure connection (`https`) is being synced, a temporary "Configure trusted hosts" dialog will appear the first time the SyncView is rendered. This dialog will give the user a chance to trust selected hosts if necessary. Hosts with connection errors will have an error icon with a tooltip announcing the error (helpful to see if it needs to be trusted because of certificate issues).
 - Added keyboard support (i.e. for tab key) to custom tri-state checkbox component used throughout the extension.
+- Restricted the management cluster URL to `http` or `https` protocols when adding new management clusters since that's what we expect for MCC instances.
 
 ## v5.4.0
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Mirantis Container Cloud Lens Extension
+ # Mirantis Container Cloud Lens Extension
 
 ![CI](https://github.com/Mirantis/lens-extension-cc/workflows/CI/badge.svg?branch=master&event=push)
 
@@ -220,7 +220,7 @@ These cluster access tokens are those which are partially configured via the `Us
 
 ✳️ __New in [v5.5.0](CHANGELOG.md#v550)__
 
-By default, the extension does not support management clusters that use self-signed certificates (or certificates that are expired, or not verifiable for whatever reason). They are treated as untrusted hosts for security reasons (because their identity cannot be verified).
+By default, the extension does not support management clusters that use self-signed certificates (or certificates that are expired, or not verifiable for whatever reason) over `HTTPS` connections. They are treated as untrusted hosts for security reasons (because their identity cannot be verified).
 
 > ❗️ Mirantis does not recommend connecting to an unverified host and takes no responsibility whatsoever for any negative consequences that may ensue. The host could be one posing as the real thing, but in actuality, one owned by a threat actor with malicious goals. This extension is [MIT-licensed](./LICENSE). Proceed at your own risk.
 
@@ -237,6 +237,8 @@ To __untrust__ the host, remove the management cluster, and add it again without
 It's not possible to trust a host you've already added on the premise that if a host's certificate becomes invalid, it's a good indication that something might be amis and should be verified/rectified prior to reconnecting. Contact your IT department and ask them to look into the issue before resorting to trusting the host.
 
 If a host had to be trusted when it was added, we're assuming it probably always has to be trusted (e.g. it's an internal, test, or demo system that always uses a self-signed certificate) and there would be no reason to suddenly no longer trust it and require TLS verification. However, if this is something you _frequently_ encounter, please let us know by [opening an issue](https://github.com/Mirantis/lens-extension-cc/issues) and explaining your use case.
+
+> 💬 This option is irrelevant to management clusters using unsecure `HTTP` connections as certificates are involved in the connection handshake.
 
 ## FAQ
 

--- a/__mocks__/@k8slens/extensions.js
+++ b/__mocks__/@k8slens/extensions.js
@@ -198,8 +198,47 @@ class Spinner extends React.Component {
   }
 }
 
-let confirmDialogInstance;
+// @see https://github.com/lensapp/lens/blob/master/packages/core/src/renderer/components/dialog/dialog.tsx
+// NOTE: technically, the real Lens Dialog is stateful, more like the ConfirmDialog mocked below,
+//  but so far, we don't use the stateful aspect of it for our own Modal component that's based
+//  on the Lens Dialog
+class Dialog extends React.Component {
+  constructor(props) {
+    super(props);
+  }
 
+  render() {
+    // NOTE: Lens Dialog does not support 'other props'; they don't apply them anywhere
+    const { children, isOpen, className, modal, pinned, onClose } = this.props;
+    return isOpen ? (
+      <div
+        className={`Dialog flex center${modal ? ' modal' : ''}${
+          pinned ? ' pinned' : ''
+        } ${className}`.trim()}
+        onClick={onClose} // click on overlay closes (also ESC key, but we don't support in mock)
+      >
+        <div className="box">{children}</div>
+      </div>
+    ) : null;
+  }
+}
+
+Dialog.propTypes = {
+  children: childrenPropType,
+  className: propTypes.string,
+  isOpen: propTypes.bool,
+  modal: propTypes.bool,
+  pinned: propTypes.bool,
+  onClose: propTypes.func,
+};
+Dialog.defaultProps = {
+  isOpen: false,
+  modal: false,
+  pinned: false,
+};
+
+// @see https://github.com/lensapp/lens/blob/master/packages/core/src/renderer/components/confirm-dialog/confirm-dialog.tsx
+let confirmDialogInstance;
 class ConfirmDialog extends React.Component {
   constructor(props) {
     super(props);
@@ -527,6 +566,7 @@ export const Renderer = {
     MenuItem,
     Menu,
     MenuActions,
+    Dialog,
     ConfirmDialog,
   },
   Catalog: {

--- a/src/renderer/components/GlobalPage/TrustHostModal.js
+++ b/src/renderer/components/GlobalPage/TrustHostModal.js
@@ -1,0 +1,250 @@
+import { useState, useMemo, useCallback } from 'react';
+import propTypes from 'prop-types';
+import * as rtv from 'rtvjs';
+import { Renderer } from '@k8slens/extensions';
+import styled from '@emotion/styled';
+import { layout } from '../styles';
+import { Modal } from '../Modal/Modal';
+import { Cloud } from '../../../common/Cloud';
+import { openBrowser } from '../../../util/netUtil';
+import { InlineNotice, types as noticeTypes } from '../InlineNotice';
+import {
+  TriStateCheckbox,
+  checkValues,
+} from '../TriStateCheckbox/TriStateCheckbox';
+import { getCloudConnectionError } from '../../rendererUtil';
+import * as strings from '../../../strings';
+
+const { Icon, Tooltip } = Renderer.Component;
+
+//
+// STYLED COMPONENTS
+//
+
+const ConnectionError = styled.div(() => ({
+  marginLeft: layout.grid,
+}));
+
+const StyledCheckList = styled.ul(() => ({
+  display: 'flex',
+  flexDirection: 'column',
+
+  marginTop: layout.pad,
+  padding: layout.pad,
+  backgroundColor: 'var(--settingsBackground)',
+  borderRadius: layout.grid,
+  listStyle: 'none',
+
+  '> li': {
+    display: 'flex',
+    alignItems: 'center',
+    marginBottom: layout.pad,
+  },
+  '> li:last-of-type': {
+    marginBottom: 0,
+  },
+}));
+
+const StyledModal = styled(Modal)(() => ({
+  '.cclex-modal-body': {
+    '[data-cclex-component="InlineNotice"]': {
+      marginBottom: layout.gap,
+    },
+
+    p: {
+      marginBottom: layout.pad,
+
+      a: {
+        color: 'var(--primary)',
+        textDecoration: 'underline',
+      },
+    },
+    'p:last-of-type': {
+      marginBottom: 0,
+    },
+  },
+}));
+
+//
+// COMPONENT
+//
+
+// TODO[CCLEX-196]: DEPRECATED, remove for next major
+export const TrustHostModal = function ({ clouds, onSave, onCancel, onClose }) {
+  //
+  // VERIFY
+  //
+
+  if (DEV_ENV) {
+    // PERFORMANCE: only verify props when they change
+    // eslint-disable-next-line react-hooks/rules-of-hooks -- DEV_ENV never changes at runtime
+    useMemo(
+      function () {
+        // assert some required props in Dev builds (in part because prop-types
+        //  considers an empty string as valid for a required string prop)
+        DEV_ENV &&
+          rtv.verify(
+            { props: { clouds } },
+            {
+              props: {
+                clouds: [
+                  rtv.ARRAY,
+                  {
+                    min: 1,
+                    $: [
+                      rtv.CLASS_OBJECT,
+                      { ctor: Cloud },
+                      (cloud) => {
+                        if (cloud.trustHost) {
+                          throw new Error(
+                            `Cloud "${cloud.cloudUrl}" is already trusted`
+                          );
+                        }
+                      },
+                    ],
+                  },
+                ],
+              },
+            }
+          );
+      },
+      [clouds]
+    );
+  }
+
+  //
+  // STATE
+  //
+
+  const [trustedHosts, setTrustedHosts] = useState(
+    clouds.reduce(
+      (map, cloud) => ({
+        ...map,
+        [cloud.cloudUrl]: cloud.trustHost, // initially should be false for all clouds per VERIFY above
+      }),
+      {}
+    )
+  );
+
+  //
+  // EVENTS
+  //
+
+  const handleNewFeatureClick = useCallback((event) => {
+    if (event.target.tagName === 'A') {
+      event.preventDefault();
+      if (event.target.href.endsWith('#1')) {
+        openBrowser(
+          'https://github.com/Mirantis/lens-extension-cc#trusted-hosts'
+        );
+      }
+    }
+  }, []);
+
+  const handleTrustCloudChange = useCallback(
+    function (event, { checked, data: cloud }) {
+      setTrustedHosts({
+        ...trustedHosts,
+        [cloud.cloudUrl]: checked,
+      });
+    },
+    [trustedHosts]
+  );
+
+  const handleCallClick = useCallback(
+    function (event) {
+      if (typeof onSave === 'function') {
+        onSave(event, { trustedHosts });
+      }
+    },
+    [onSave, trustedHosts]
+  );
+
+  //
+  // EFFECTS
+  //
+
+  //
+  // RENDER
+  //
+
+  return (
+    <StyledModal
+      title={strings.syncView.trustHostModal.title()}
+      callAction={{
+        label: strings.syncView.trustHostModal.callLabel(),
+        onClick: handleCallClick,
+      }}
+      cancelAction={{
+        onClick: onCancel,
+      }}
+      onClose={onClose}
+    >
+      <InlineNotice type={noticeTypes.WARNING}>
+        <p
+          dangerouslySetInnerHTML={{
+            __html: strings.syncView.trustHostModal.deprecationHtml(),
+          }}
+        />
+      </InlineNotice>
+      <p
+        dangerouslySetInnerHTML={{
+          __html: strings.syncView.trustHostModal.newfeatureHtml(),
+        }}
+        onClick={handleNewFeatureClick}
+      />
+      <p
+        dangerouslySetInnerHTML={{
+          __html: strings.syncView.trustHostModal.promptHtml(),
+        }}
+      />
+      <StyledCheckList>
+        {clouds.map((cloud) => (
+          <li key={cloud.name}>
+            <TriStateCheckbox
+              data={cloud}
+              label={`${cloud.name} (${cloud.cloudUrl})`}
+              value={
+                trustedHosts[cloud.cloudUrl]
+                  ? checkValues.CHECKED
+                  : checkValues.UNCHECKED
+              }
+              onChange={handleTrustCloudChange}
+            />
+            {cloud.connectError ? (
+              <ConnectionError>
+                <Icon
+                  id={`${cloud.name}-untrusted-cloud-connection-error`}
+                  material="error"
+                  focusable={false}
+                  interactive={false}
+                  style={{ color: 'var(--colorError)' }}
+                />
+                <Tooltip
+                  targetId={`${cloud.name}-untrusted-cloud-connection-error`}
+                >
+                  {getCloudConnectionError(cloud)}
+                </Tooltip>
+              </ConnectionError>
+            ) : null}
+          </li>
+        ))}
+      </StyledCheckList>
+    </StyledModal>
+  );
+};
+
+TrustHostModal.propTypes = {
+  clouds: propTypes.arrayOf(propTypes.instanceOf(Cloud)), // untrusted clouds
+
+  // Signature: `(event: MouseEvent|KeyboardEvent, info: { trustedHosts: Record<string,true> }) => void`
+  // - `info.trustedHosts`: Map of Cloud URL to `true` for those that should be trusted, `false`
+  //     for those that should not. Empty map if none.
+  onSave: propTypes.func,
+
+  // Signature: `(event: MouseEvent|KeyboardEvent) => void`
+  onCancel: propTypes.func,
+
+  // Signature: `() => void`
+  onClose: propTypes.func,
+};

--- a/src/renderer/components/InlineNotice.js
+++ b/src/renderer/components/InlineNotice.js
@@ -41,7 +41,14 @@ const Container = styled.div(function () {
   };
 });
 
-export const InlineNotice = function ({ type, iconSize, children, ...props }) {
+const displayName = 'InlineNotice';
+
+export const InlineNotice = function ({
+  type,
+  iconSize,
+  children,
+  ...otherProps
+}) {
   let color;
   switch (type) {
     case types.NOTE:
@@ -65,7 +72,12 @@ export const InlineNotice = function ({ type, iconSize, children, ...props }) {
   }
 
   return (
-    <Container type={type} {...props}>
+    <Container
+      {...otherProps}
+      // AFTER other props as picked earlier or not overrideable
+      data-cclex-component={displayName}
+      type={type}
+    >
       <Component.Icon
         material={type}
         smallest={iconSize === iconSizes.SMALL}
@@ -78,6 +90,7 @@ export const InlineNotice = function ({ type, iconSize, children, ...props }) {
   );
 };
 
+InlineNotice.displayName = displayName;
 InlineNotice.propTypes = {
   iconSize: propTypes.oneOf(Object.values(iconSizes)),
   type: propTypes.oneOf(Object.values(types)),
@@ -88,7 +101,6 @@ InlineNotice.propTypes = {
     propTypes.node,
   ]),
 };
-
 InlineNotice.defaultProps = {
   iconSize: iconSizes.NORMAL,
   type: types.INFO,

--- a/src/renderer/components/Modal/Modal.js
+++ b/src/renderer/components/Modal/Modal.js
@@ -1,0 +1,272 @@
+import { useMemo, useCallback } from 'react';
+import { Renderer } from '@k8slens/extensions';
+import propTypes from 'prop-types';
+import styled from '@emotion/styled';
+import * as rtv from 'rtvjs';
+import { layout } from '../styles';
+import * as strings from '../../../strings';
+
+const {
+  Component: { Icon, Button, Dialog },
+} = Renderer;
+
+//
+// STYLED COMPONENTS
+//
+
+const framePadding = layout.gap;
+
+const StyledHeader = styled.header(() => ({
+  // flex child of `StyledFrame`
+  flex: 'none',
+
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+
+  width: '100%',
+  paddingBottom: layout.gap,
+
+  cursor: 'default',
+
+  h3: {
+    color: 'var(--textColorAccent)',
+    fontWeight: 'bold',
+  },
+}));
+
+const StyledBody = styled.div(() => ({
+  // flex child of `StyledFrame`
+  flex: 1,
+
+  display: 'flex',
+  flexDirection: 'column',
+
+  width: '100%',
+
+  overflow: 'auto',
+}));
+
+const StyledFooter = styled.footer(() => ({
+  // flex child of `StyledFrame`
+  flex: 'none',
+
+  display: 'flex',
+  justifyContent: 'flex-end',
+  alignItems: 'center',
+
+  width: '100%',
+  paddingTop: layout.gap,
+
+  '> button': {
+    marginRight: layout.gap,
+  },
+  '> button:last-of-type': {
+    marginRight: 0,
+  },
+}));
+
+const StyledFrame = styled.div(() => ({
+  // flex child of `StyledDialog.box`
+  flex: 1,
+
+  display: 'flex',
+  flexDirection: 'column',
+
+  width: '100%',
+  margin: 0,
+  padding: framePadding,
+}));
+
+const StyledDialog = styled(Dialog)(() => ({
+  '> .box': {
+    display: 'flex',
+    flexDirection: 'column',
+
+    minWidth: 45 * layout.grid,
+    maxWidth: '50vw',
+    minHeight: 200,
+    maxHeight: '85vh',
+
+    backgroundColor: 'var(--secondaryBackground)',
+  },
+}));
+
+//
+// MODAL
+//
+
+const displayName = 'Modal';
+const classPrefix = `cclex-${displayName.toLowerCase()}`;
+
+export const Modal = function ({
+  callAction,
+  cancelAction,
+  className,
+  children,
+  title,
+
+  onClose,
+
+  ...otherProps
+}) {
+  //
+  // PROPS
+  //
+
+  //
+  // VERIFY
+  //
+
+  if (DEV_ENV) {
+    // PERFORMANCE: only verify props when they change
+    // eslint-disable-next-line react-hooks/rules-of-hooks -- DEV_ENV never changes at runtime
+    useMemo(
+      function () {
+        // assert some required props in Dev builds (in part because prop-types
+        //  considers an empty string as valid for a required string prop)
+        DEV_ENV &&
+          rtv.verify(
+            { props: { title } },
+            {
+              props: {
+                title: rtv.STRING,
+              },
+            }
+          );
+      },
+      [title]
+    );
+  }
+
+  //
+  // EVENTS
+  //
+
+  const handleDialogClose = useCallback(
+    function () {
+      if (typeof onClose === 'function') {
+        onClose();
+      }
+    },
+    [onClose]
+  );
+
+  const handleCloseClick = useCallback(
+    function () {
+      if (typeof onClose === 'function') {
+        onClose();
+      }
+    },
+    [onClose]
+  );
+
+  const handleCallClick = useCallback(
+    function (event) {
+      const { onClick } = callAction || {};
+      if (typeof onClick === 'function') {
+        onClick(event);
+      }
+    },
+    [callAction]
+  );
+
+  const handleCancelClick = useCallback(
+    function (event) {
+      const { onClick } = cancelAction || {};
+      if (typeof onClick === 'function') {
+        onClick(event);
+      }
+    },
+    [cancelAction]
+  );
+
+  //
+  // EFFECTS
+  //
+
+  //
+  // RENDER
+  //
+
+  return (
+    <StyledDialog
+      className={className}
+      // NOTE: <Dialog> doesn't support `style` prop
+      data-cclex-component={displayName}
+      isOpen
+      onClose={handleDialogClose}
+    >
+      <StyledFrame
+        {...otherProps}
+        // AFTER other props as not overrideable or picked earlier
+        className={`${classPrefix}-frame`}
+      >
+        <StyledHeader className={`${classPrefix}-header`}>
+          <h3>{title}</h3>
+          <Icon
+            material="close"
+            interactive
+            focusable
+            onClick={handleCloseClick}
+          />
+        </StyledHeader>
+        <StyledBody className={`${classPrefix}-body`}>{children}</StyledBody>
+        <StyledFooter className={`${classPrefix}-footer`}>
+          {cancelAction ? (
+            <Button
+              secondary
+              label={cancelAction.label || strings.modal.defaultCancelLabel()}
+              onClick={handleCancelClick}
+              disabled={cancelAction.disabled}
+            />
+          ) : null}
+          <Button
+            primary
+            label={callAction?.label || strings.modal.defaultCallLabel()}
+            onClick={handleCallClick}
+            disabled={callAction?.disabled}
+          />
+        </StyledFooter>
+      </StyledFrame>
+    </StyledDialog>
+  );
+};
+
+Modal.displayName = displayName;
+Modal.propTypes = {
+  // other props are applied to the FRAME (inside the Lens DIALOG)
+
+  // primary call to action
+  callAction: propTypes.shape({
+    disabled: propTypes.bool,
+    label: propTypes.string, // defaults to 'OK' if not specified
+
+    // Signature: `(event: MouseEvent|KeyboardEvent) => void`
+    onClick: propTypes.func,
+  }),
+
+  // optional secondary cancel action
+  cancelAction: propTypes.shape({
+    disabled: propTypes.bool,
+    label: propTypes.string, // defaults to 'Cancel' if not specified
+
+    // Signature: `(event: MouseEvent|KeyboardEvent) => void`
+    onClick: propTypes.func,
+  }),
+
+  // children are placed in the BODY
+  children: propTypes.oneOfType([
+    propTypes.node,
+    propTypes.arrayOf(propTypes.node),
+  ]),
+  className: propTypes.string, // applied to the DIALOG
+  title: propTypes.string.isRequired,
+
+  //// EVENTS
+
+  // Modal is closed by either clicking outside or pressing ESC key.
+  //
+  // Signature: `() => void`
+  onClose: propTypes.func,
+};

--- a/src/renderer/components/TriStateCheckbox/TriStateCheckbox.js
+++ b/src/renderer/components/TriStateCheckbox/TriStateCheckbox.js
@@ -111,14 +111,15 @@ const toggleValue = function (value) {
 /**
  * Handle an event that should cause the value to be toggled.
  * @param {Event} event Trigger event.
- * @param {{ value: string, onChange: Function }} props Some component props.
+ * @param {{ data: any, value: string, onChange: Function }} props Some component props.
  */
-const handleToggleEvent = function (event, { value, onChange }) {
+const handleToggleEvent = function (event, { data, value, onChange }) {
   const checked = toggleValue(value);
 
   if (typeof onChange === 'function') {
     onChange(event, {
       checked,
+      data,
     });
   }
 };
@@ -126,6 +127,7 @@ const handleToggleEvent = function (event, { value, onChange }) {
 const noop = () => {};
 
 export const TriStateCheckbox = ({
+  data,
   disabled,
   label,
   help,
@@ -149,10 +151,10 @@ export const TriStateCheckbox = ({
   const handleCtrlClick = useCallback(
     function (event) {
       if (!disabled) {
-        handleToggleEvent(event, { value, onChange });
+        handleToggleEvent(event, { data, value, onChange });
       }
     },
-    [disabled, value, onChange]
+    [data, disabled, value, onChange]
   );
 
   const handleLabelClick = useCallback(
@@ -161,11 +163,11 @@ export const TriStateCheckbox = ({
         // NOTE: native HTML checkboxes fire their onClick event whether the user
         //  clicks on the box or the label, and clicking on the label sets focus
         //  to the related <input>, so we do the same here
-        handleToggleEvent(event, { value, onChange });
+        handleToggleEvent(event, { data, value, onChange });
         ctrlRef.current?.focus(); // focus the CTRL, not the hidden FIELD
       }
     },
-    [disabled, value, onChange]
+    [data, disabled, value, onChange]
   );
 
   //
@@ -180,11 +182,11 @@ export const TriStateCheckbox = ({
           // prevent unintentional scrolling when pressing SPACEBAR
           event.preventDefault();
 
-          handleToggleEvent(event, { value, onChange });
+          handleToggleEvent(event, { data, value, onChange });
         }
       }
     },
-    [disabled, value, onChange]
+    [data, disabled, value, onChange]
   );
 
   //
@@ -243,6 +245,7 @@ export const TriStateCheckbox = ({
 
 TriStateCheckbox.displayName = displayName;
 TriStateCheckbox.propTypes = {
+  data: PropTypes.any, // generic data/hint assigned to this checkbox, returned in `onChange`
   disabled: PropTypes.bool,
   label: PropTypes.string.isRequired,
   help: PropTypes.string, // help text, if any
@@ -258,9 +261,10 @@ TriStateCheckbox.propTypes = {
    * ⚠️ The event __will never be__ the `<input type="checkbox">` that serves as the
    *  underlying
    *
-   * Signature: `(event: MouseEvent|KeyboardEvent, info: { checked: boolean }) => void`
+   * Signature: `(event: MouseEvent|KeyboardEvent, info: { checked: boolean, data: any }) => void`
    *
    * - `info.checked`: New checked state/value.
+   * - `info.data`: `data` prop value.
    */
   onChange: PropTypes.func.isRequired,
 };

--- a/src/renderer/components/Wizard/Wizard.js
+++ b/src/renderer/components/Wizard/Wizard.js
@@ -2,7 +2,7 @@
 // Custom Wizard component
 //
 // NOTE: Lens provides a Wizard in
-//  https://github.com/lensapp/lens/blob/master/src/renderer/components/wizard/wizard.tsx
+//  https://github.com/lensapp/lens/tree/master/packages/core/src/renderer/components/wizard
 //  but it doesn't work well, isn't documented, and renders steps horizontally, while
 //  this Wizard renders steps vertically.
 //

--- a/src/renderer/rendererUtil.js
+++ b/src/renderer/rendererUtil.js
@@ -14,6 +14,15 @@ dayjs.extend(dayjsRelativeTimePlugin);
 
 const { Catalog } = Renderer;
 
+// TODO[CCLEX-196]: DEPRECATED, remove for next major
+let skipTlsVerifyFlagWarningShown = false;
+export const getSkipTlsVerifyFlagWarningShown = function () {
+  return skipTlsVerifyFlagWarningShown;
+};
+export const setSkipTlsVerifyFlagWarningShown = function () {
+  skipTlsVerifyFlagWarningShown = true;
+};
+
 /**
  * @returns {Array<Common.Catalog.KubernetesCluster>} List of clusters in the
  *  Lens Catalog.

--- a/src/renderer/store/CloudProvider.js
+++ b/src/renderer/store/CloudProvider.js
@@ -25,7 +25,7 @@ class CloudProviderStore extends ProviderStore {
         { 'CloudProvider.store': this.store },
         {
           'CloudProvider.store': {
-            // map of cloudUrl -> DataCloud instance
+            // map of cloudUrl -> Cloud instance
             clouds: [
               rtv.HASH_MAP,
               { $values: [rtv.CLASS_OBJECT, { ctor: Cloud }] },

--- a/src/strings.ts
+++ b/src/strings.ts
@@ -57,7 +57,8 @@ export const connectionBlock: Dict = {
   },
   trustHost: {
     label: () => 'Trust this host',
-    help: () => 'By trusting this host, TLS verification will be disabled',
+    help: () =>
+      'By trusting this host, TLS verification will be disabled (only applies to secure connections using HTTPS)',
     warning: () =>
       'This is unsafe. Note that untrusting the host in the future will require the management cluster to be removed and re-added without this option.',
   },
@@ -73,7 +74,8 @@ export const connectionBlock: Dict = {
     info: () =>
       "You will be directed to your Management Cluster's login page through your web browser where you should enter your SSO credentials",
     urlAlreadyUsed: () => 'This Management Cluster is already being synced',
-    urlWrongFormat: () => 'Wrong URL format',
+    urlIncorrectFormat: () => 'Incorrect URL format',
+    urlUnsupportedProtocol: () => 'Unsupported protocol: Must be HTTP or HTTPS',
     nameSymbolsAreNotValid: () =>
       'The name cannot contain whitespace or special characters, except for hyphens (-) and underscores (_)',
     nameAlreadyUsed: () =>
@@ -117,6 +119,22 @@ export const syncView: Dict = {
   syncButtonLabel: () => 'Selective sync...',
   connectButtonLabel: () => 'Connect new Management Cluster',
   autoSync: () => 'Auto-sync',
+
+  trustHostModal: {
+    title: () => 'Configure trusted hosts',
+    callLabel: () => 'Save',
+    deprecationHtml: () =>
+      'The command line option <code>LEX_CC_UNSAFE_ALLOW_SELFSIGNED_CERTS</code> was <strong>deprecated</strong> in v5.5.0 and will be removed in the next major release of this extension. <strong>This flag should no longer be used.</strong>',
+    newfeatureHtml: () =>
+      'A new option to <strong>trust the host</strong> is now provided when adding a new management cluster. See <a href="#1">Trusted hosts</a> for details.',
+    promptHtml: () =>
+      'Choose which management clusters should be trusted. If you do nothing, they will be treated as <strong>untrusted</strong> and will fail to connect (e.g. if they use self-signed certificates).',
+  },
+};
+
+export const modal = {
+  defaultCallLabel: () => 'OK',
+  defaultCancelLabel: () => 'Cancel',
 };
 
 export const managementClusters = {

--- a/src/util/netUtil.js
+++ b/src/util/netUtil.js
@@ -138,7 +138,7 @@ export async function request(
       //  otherwise, using `undefined`, the default agent will be used, and if there are
       //  any certificate issues, the request will blocked
       agent:
-        trustHost && url.startsWith('https:') ? trustedUnsafeAgent : undefined,
+        url.startsWith('https:') && trustHost ? trustedUnsafeAgent : undefined,
 
       ...requestOptions,
     });


### PR DESCRIPTION
Since the `LEX_CC_UNSAFE_ALLOW_SELFSIGNED_CERTS` flag has been removed, but users will still be using it after installing v5.5.0, if the flag is set, and the user is syncing at least one untrusted cloud with a secure (https) connection, a special dialog will be displayed showing a checkbox per secure, untrusted cloud, allowing the user an opportunity to trust the clouds that need to be trusted.

This dialog is only shown once per Lens session.

Also added new Modal component, since the Lens Dialog component is not designed to be used on its own, and Lens doesn't provide a generic dialog component like that which was needed.

Also updated the 'Add mgmt cluster' view to disable the 'trust this host' option when the URL is not https, and restricted the mgmt cluster URL to http or https only since those are the protocols we expect for an MCC instance.

### Preview

The dialog that appears on Synciew first render if conditions are met:

<img width="767" alt="Screenshot 2023-02-14 at 5 36 45 PM" src="https://user-images.githubusercontent.com/2855350/218887637-07a09767-2d12-4a1f-944a-ba3cbe4f98fd.png">

### PR Checklist

- [x] New feature or bug fix is mentioned in the `CHANGELOG`.
