### PR TITLE
[CCLEX-188] Add MCC release info to all Catalog entities

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
     "react-select": "^5.7.0",
     "rtvjs": "^4.1.0",
     "run-script-os": "^1.1.6",
+    "semver": "^7.3.8",
     "ts-loader": "^9.4.2",
     "typescript": "^4.9.5",
     "webpack": "^5.75.0",

--- a/src/api/apiConstants.js
+++ b/src/api/apiConstants.js
@@ -86,6 +86,8 @@ export const apiKinds = Object.freeze({
   RHEL_LICENSE: 'RHELLicense',
   PROXY: 'Proxy',
   EVENT: 'Event', // cluster events
+  KAAS_RELEASE_LIST: 'KaaSReleaseList', // list of `KAAS_RELEASE` objects in `items` root property
+  KAAS_RELEASE: 'KaaSRelease', // info about a released version of MCC
 });
 
 /**

--- a/src/api/apiUtil.js
+++ b/src/api/apiUtil.js
@@ -173,13 +173,21 @@ export async function cloudLogout(cloud) {
  * @param {Object} options
  * @param {Cloud} options.cloud An Cloud object. NOTE: This instance will be UPDATED
  *  with new tokens if the token is expired and successfully refreshed.
- * @param {string} options.method Name of the method to call on the `resourceType`.
- * @param {string} options.resourceType One of the keys (i.e. API resource types) from
- *  the `typeToClient` map. This is the API resource type on which to call the `method`.
+ * @param {string} options.resourceType A value from the `apiResourceTypes` enum. This type must
+ *  also be a key in the `typeToClient` map, determining the connection client on which the `method`
+ *  will ultimately be called.
+ * @param {'get'|'list'|'listAll'|'create'|'update'|'delete'|'reviewRules'|'nsAccess'} [options.method]
+ *  Name of the method to call on the `resourceType`. ⚠️ __Not all resource types support the
+ *  same methods.__ Request will fail if method isn't supported.
  * @param {Object} [options.args] Optional arguments for the `method` on the `resourceType`.
  * @returns {Promise<ApiSuccessResponse|ApiErrorResponse>}
  */
-export async function cloudRequest({ cloud, method, resourceType, args }) {
+export async function cloudRequest({
+  cloud,
+  resourceType,
+  method = 'get',
+  args,
+}) {
   if (!cloud || !(cloud instanceof Cloud)) {
     throw new Error('cloud parameter must be a Cloud instance');
   }

--- a/src/api/clients/AuthorizationClient.js
+++ b/src/api/clients/AuthorizationClient.js
@@ -86,6 +86,60 @@ export class AuthorizationClient {
     );
   }
 
+  get() {
+    return Promise.resolve({
+      error: 'Method "get" not supported on AuthorizationClient',
+      response: undefined,
+      expectedStatuses: [],
+      body: undefined,
+    });
+  }
+
+  list() {
+    return Promise.resolve({
+      error: 'Method "list" not supported on AuthorizationClient',
+      response: undefined,
+      expectedStatuses: [],
+      body: undefined,
+    });
+  }
+
+  listAll() {
+    return Promise.resolve({
+      error: 'Method "listAll" not supported on AuthorizationClient',
+      response: undefined,
+      expectedStatuses: [],
+      body: undefined,
+    });
+  }
+
+  create() {
+    return Promise.resolve({
+      error: 'Method "create" not supported on AuthorizationClient',
+      response: undefined,
+      expectedStatuses: [],
+      body: undefined,
+    });
+  }
+
+  update() {
+    return Promise.resolve({
+      error: 'Method "update" not supported on AuthorizationClient',
+      response: undefined,
+      expectedStatuses: [],
+      body: undefined,
+    });
+  }
+
+  delete() {
+    return Promise.resolve({
+      error: 'Method "delete" not supported on AuthorizationClient',
+      response: undefined,
+      expectedStatuses: [],
+      body: undefined,
+    });
+  }
+
   reviewRules(_, { namespaceName }) {
     return this.request('selfsubjectrulesreviews', {
       options: {

--- a/src/api/clients/KubernetesClient.js
+++ b/src/api/clients/KubernetesClient.js
@@ -87,17 +87,27 @@ export class KubernetesClient {
     );
   }
 
+  get() {
+    return Promise.resolve({
+      error: 'Method "get" not supported on KubernetesClient',
+      response: undefined,
+      expectedStatuses: [],
+      body: undefined,
+    });
+  }
+
   /**
    * List resources within a given namespace.
    * @param {string} resourceType
    * @param {Object} options
-   * @param {string} options.namespaceName
+   * @param {string} options.namespaceName Required.
    * @param {number} [options.limit] To limit the number of items fetched.
    * @param {string} [options.resourceVersion] If specified, establishes a __watch__ on the
    *  __collection__, from that version on (to get change notifications via long-poll).
-   *  NOTE: This is __not__ related to `options.resourceName`.
+   *  NOTE: This is __not__ related to a specific resource, but to the collection as a whole.
    * @param {any} [options.requestOptions] Any remaining properties in the `options` object are
    *  passed down to the raw request as node-fetch options.
+   * @returns {Promise<Object>} See netUtil.request() for response shape.
    */
   list(
     resourceType,
@@ -123,6 +133,21 @@ export class KubernetesClient {
     });
   }
 
+  listAll() {
+    return Promise.resolve({
+      error: 'Method "listAll" not supported on KubernetesClient',
+      response: undefined,
+      expectedStatuses: [],
+      body: undefined,
+    });
+  }
+
+  /**
+   * @param {string} resourceType
+   * @param {Object} options
+   * @param {string} options.namespaceName Required.
+   * @param {Object} options.spec JSON payload.
+   */
   create(resourceType, { namespaceName, spec } = {}) {
     const url = {
       [apiResourceTypes.NAMESPACE]: resourceType,
@@ -137,16 +162,49 @@ export class KubernetesClient {
     });
   }
 
-  delete(resourceType, { namespaceName, name } = {}) {
+  update() {
+    return Promise.resolve({
+      error: 'Method "update" not supported on KubernetesClient',
+      response: undefined,
+      expectedStatuses: [],
+      body: undefined,
+    });
+  }
+
+  /**
+   * @param {string} resourceType
+   * @param {Object} options
+   * @param {string} options.namespaceName Required.
+   * @param {string} options.resourceName
+   */
+  delete(resourceType, { namespaceName, resourceName } = {}) {
     const url = {
-      [apiResourceTypes.NAMESPACE]: `${resourceType}/${name}`,
-      [apiResourceTypes.SECRET]: `${apiResourceTypes.NAMESPACE}/${namespaceName}/${resourceType}/${name}`,
+      [apiResourceTypes.NAMESPACE]: `${resourceType}/${resourceName}`,
+      [apiResourceTypes.SECRET]: `${apiResourceTypes.NAMESPACE}/${namespaceName}/${resourceType}/${resourceName}`,
     };
     return this.request(url[resourceType], {
       options: { method: 'DELETE' },
       errorMessage: strings.apiClient.error.failedToDelete(
-        `${logValue(resourceType)} "${name}"`
+        `${logValue(resourceType)} "${resourceName}"`
       ),
+    });
+  }
+
+  reviewRules() {
+    return Promise.resolve({
+      error: 'Method "reviewRules" not supported on KubernetesClient',
+      response: undefined,
+      expectedStatuses: [],
+      body: undefined,
+    });
+  }
+
+  nsAccess() {
+    return Promise.resolve({
+      error: 'Method "nsAccess" not supported on KubernetesClient',
+      response: undefined,
+      expectedStatuses: [],
+      body: undefined,
     });
   }
 }

--- a/src/api/clients/ResourceClient.js
+++ b/src/api/clients/ResourceClient.js
@@ -120,9 +120,20 @@ export class ResourceClient {
     );
   }
 
-  get(resourceType, { namespaceName, resourceName } = {}) {
+  /**
+   * Get a single resource.
+   * @param {string} resourceType
+   * @param {Object} options
+   * @param {string} [options.namespaceName] Namespace name, if any.
+   * @param {string} [options.resourceName] Resource name, if any.
+   * @param {Record<string,any>} [options.filters] Query parameters, if any.
+   * @returns {Promise<Object>} See netUtil.request() for response shape.
+   */
+  get(resourceType, { namespaceName, resourceName, filters } = {}) {
     return this.request(
-      `${namespacePrefix(namespaceName)}${resourceType}/${resourceName}`,
+      `${namespacePrefix(namespaceName)}${resourceType}${
+        resourceName ? `/${resourceName}` : ''
+      }${buildQueryString(filters)}`,
       {
         errorMessage: strings.apiClient.error.failedToGet(resourceType),
       }
@@ -130,10 +141,10 @@ export class ResourceClient {
   }
 
   /**
-   * List resources within a given namespace.
+   * List resources optionally within a given namespace.
    * @param {string} resourceType Value from the `apiResourceTypes` enum.
    * @param {Object} options
-   * @param {string} options.namespaceName
+   * @param {string} [options.namespaceName]
    * @param {number} [options.limit] To limit the number of items fetched.
    * @param {string} [options.resourceVersion] If specified, establishes a __watch__ on the
    *  __collection__, from that version on (to get change notifications via long-poll).
@@ -144,6 +155,7 @@ export class ResourceClient {
    *  Ignored if `resourceName` is falsy. Value from the `apiResourceTypes` enum.
    * @param {any} [options.requestOptions] Any remaining properties in the `options` object are
    *  passed down to the raw request as node-fetch options.
+   * @returns {Promise<Object>} See netUtil.request() for response shape.
    */
   list(
     resourceType,
@@ -181,6 +193,7 @@ export class ResourceClient {
    * @param {string} resourceType
    * @param {Object} [options]
    * @param {number} [options.limit] To limit the number of items fetched.
+   * @returns {Promise<Object>} See netUtil.request() for response shape.
    */
   listAll(resourceType, { limit } = {}) {
     const paramStr = buildQueryString({ limit });
@@ -189,6 +202,12 @@ export class ResourceClient {
     });
   }
 
+  /**
+   * @param {string} resourceType
+   * @param {Object} options
+   * @param {string} options.spec JSON payload.
+   * @param {string} [options.namespaceName]
+   */
   create(resourceType, { namespaceName, spec } = {}) {
     return this.request(
       `${namespacePrefix(namespaceName)}${resourceType}/create`,
@@ -200,18 +219,13 @@ export class ResourceClient {
     );
   }
 
-  delete(resourceType, { namespaceName, name } = {}) {
-    return this.request(
-      `${namespacePrefix(namespaceName)}${resourceType}/${name}`,
-      {
-        options: { method: 'DELETE' },
-        errorMessage: strings.apiClient.error.failedToDelete(
-          `${logValue(resourceType)} ${logValue(name)}`
-        ),
-      }
-    );
-  }
-
+  /**
+   * @param {string} resourceType
+   * @param {Object} options
+   * @param {string} options.name
+   * @param {Object} options.patch JSON payload.
+   * @param {string} [options.namespaceName]
+   */
   update(resourceType, { namespaceName, name, patch } = {}) {
     return this.request(
       `${namespacePrefix(namespaceName)}${resourceType}/${name}`,
@@ -226,5 +240,41 @@ export class ResourceClient {
         ),
       }
     );
+  }
+
+  /**
+   * @param {string} resourceType
+   * @param {Object} options
+   * @param {string} options.name
+   * @param {string} [options.namespaceName]
+   */
+  delete(resourceType, { namespaceName, name } = {}) {
+    return this.request(
+      `${namespacePrefix(namespaceName)}${resourceType}/${name}`,
+      {
+        options: { method: 'DELETE' },
+        errorMessage: strings.apiClient.error.failedToDelete(
+          `${logValue(resourceType)} ${logValue(name)}`
+        ),
+      }
+    );
+  }
+
+  reviewRules() {
+    return Promise.resolve({
+      error: 'Method "reviewRules" not supported on ResourceClient',
+      response: undefined,
+      expectedStatuses: [],
+      body: undefined,
+    });
+  }
+
+  nsAccess() {
+    return Promise.resolve({
+      error: 'Method "nsAccess" not supported on ResourceClient',
+      response: undefined,
+      expectedStatuses: [],
+      body: undefined,
+    });
   }
 }

--- a/src/api/types/ClusterDeployment.js
+++ b/src/api/types/ClusterDeployment.js
@@ -25,12 +25,12 @@ export class ClusterDeployment extends ResourceUpdate {
   /**
    * @constructor
    * @param {Object} params
-   * @param {Object} params.data Raw data payload from the API.
+   * @param {Object} params.kube Raw kube object payload from the API.
    * @param {Namespace} params.namespace Namespace to which the object belongs.
-   * @param {Cloud} params.cloud Reference to the Cloud used to get the data.
+   * @param {DataCloud} params.dataCloud Reference to the DataCloud used to get the data.
    */
-  constructor({ data, namespace, cloud }) {
-    super({ data, cloud, namespace, typeset: clusterDeploymentTs });
+  constructor({ kube, namespace, dataCloud }) {
+    super({ kube, namespace, dataCloud, typeset: clusterDeploymentTs });
 
     /**
      * @readonly
@@ -40,7 +40,7 @@ export class ClusterDeployment extends ResourceUpdate {
     Object.defineProperty(this, 'release', {
       enumerable: true,
       get() {
-        return data.release || '-1.0.0'; // TODO[cluster-history]: remove '-1.0.0' fallback
+        return kube.release || '-1.0.0'; // TODO[cluster-history]: remove '-1.0.0' fallback
       },
     });
   }

--- a/src/api/types/ClusterEvent.js
+++ b/src/api/types/ClusterEvent.js
@@ -23,12 +23,12 @@ export class ClusterEvent extends ResourceEvent {
   /**
    * @constructor
    * @param {Object} params
-   * @param {Object} params.data Raw data payload from the API.
+   * @param {Object} params.kube Raw kube object payload from the API.
    * @param {Namespace} params.namespace Namespace to which the object belongs.
-   * @param {Cloud} params.cloud Reference to the Cloud used to get the data.
+   * @param {DataCloud} params.dataCloud Reference to the DataCloud used to get the data.
    */
-  constructor({ data, namespace, cloud }) {
-    super({ data, cloud, namespace, typeset: clusterEventTs });
+  constructor({ kube, namespace, dataCloud }) {
+    super({ kube, namespace, dataCloud, typeset: clusterEventTs });
   }
 
   // NOTE: we don't have toEntity() because we don't show ClusterEvents in the Catalog at

--- a/src/api/types/ClusterUpgrade.js
+++ b/src/api/types/ClusterUpgrade.js
@@ -25,12 +25,12 @@ export class ClusterUpgrade extends ResourceUpdate {
   /**
    * @constructor
    * @param {Object} params
-   * @param {Object} params.data Raw data payload from the API.
+   * @param {Object} params.kube Raw kube object payload from the API.
    * @param {Namespace} params.namespace Namespace to which the object belongs.
-   * @param {Cloud} params.cloud Reference to the Cloud used to get the data.
+   * @param {DataCloud} params.dataCloud Reference to the DataCloud used to get the data.
    */
-  constructor({ data, namespace, cloud }) {
-    super({ data, cloud, namespace, typeset: clusterUpgradeTs });
+  constructor({ kube, namespace, dataCloud }) {
+    super({ kube, namespace, dataCloud, typeset: clusterUpgradeTs });
 
     /**
      * @readonly
@@ -39,7 +39,7 @@ export class ClusterUpgrade extends ResourceUpdate {
     Object.defineProperty(this, 'fromRelease', {
       enumerable: true,
       get() {
-        return data.fromRelease;
+        return kube.fromRelease;
       },
     });
 
@@ -50,7 +50,7 @@ export class ClusterUpgrade extends ResourceUpdate {
     Object.defineProperty(this, 'release', {
       enumerable: true,
       get() {
-        return data.toRelease; // TODO[cluster-history] change to 'release' per PRODX-28727
+        return kube.toRelease; // TODO[cluster-history] change to 'release' per PRODX-28727
       },
     });
   }

--- a/src/api/types/Credential.js
+++ b/src/api/types/Credential.js
@@ -43,15 +43,15 @@ export class Credential extends NamedResource {
   /**
    * @constructor
    * @param {Object} params
-   * @param {Object} params.data Raw data payload from the API.
+   * @param {Object} params.kube Raw kube object payload from the API.
    * @param {Namespace} params.namespace Namespace to which the object belongs.
-   * @param {Cloud} params.cloud Reference to the Cloud used to get the data.
+   * @param {DataCloud} params.dataCloud Reference to the DataCloud used to get the data.
    */
-  constructor({ data, namespace, cloud }) {
+  constructor({ kube, namespace, dataCloud }) {
     super({
-      data,
+      kube,
       namespace,
-      cloud,
+      dataCloud,
       typeset: credentialTs,
     });
 
@@ -59,7 +59,7 @@ export class Credential extends NamedResource {
     Object.defineProperty(this, 'region', {
       enumerable: true,
       get() {
-        return data.metadata.labels?.[apiLabels.KAAS_REGION] || null;
+        return kube.metadata.labels?.[apiLabels.KAAS_REGION] || null;
       },
     });
 
@@ -67,7 +67,7 @@ export class Credential extends NamedResource {
     Object.defineProperty(this, 'provider', {
       enumerable: true,
       get() {
-        return data.metadata.labels?.[apiLabels.KAAS_PROVIDER] || null;
+        return kube.metadata.labels?.[apiLabels.KAAS_PROVIDER] || null;
       },
     });
 
@@ -76,7 +76,7 @@ export class Credential extends NamedResource {
       enumerable: true,
       get() {
         // NOTE: BYOCredential objects do not have a `status` for some reason
-        return !!data.status?.valid;
+        return !!kube.status?.valid;
       },
     });
   }
@@ -93,7 +93,7 @@ export class Credential extends NamedResource {
     return merge({}, model, {
       metadata: {
         labels: {
-          [entityLabels.CLOUD]: this.cloud.name,
+          [entityLabels.CLOUD]: this.dataCloud.name,
           [entityLabels.NAMESPACE]: this.namespace.name,
         },
       },

--- a/src/api/types/License.js
+++ b/src/api/types/License.js
@@ -27,12 +27,12 @@ export class License extends NamedResource {
   /**
    * @constructor
    * @param {Object} params
-   * @param {Object} params.data Raw data payload from the API.
+   * @param {Object} params.kube Raw kube object payload from the API.
    * @param {Namespace} params.namespace Namespace to which the object belongs.
-   * @param {Cloud} params.cloud Reference to the Cloud used to get the data.
+   * @param {DataCloud} params.dataCloud Reference to the DataCloud used to get the data.
    */
-  constructor({ data, namespace, cloud }) {
-    super({ data, namespace, cloud, typeset: licenseTs });
+  constructor({ kube, namespace, dataCloud }) {
+    super({ kube, namespace, dataCloud, typeset: licenseTs });
   }
 
   /**
@@ -47,7 +47,7 @@ export class License extends NamedResource {
     return merge({}, model, {
       metadata: {
         labels: {
-          [entityLabels.CLOUD]: this.cloud.name,
+          [entityLabels.CLOUD]: this.dataCloud.name,
           [entityLabels.NAMESPACE]: this.namespace.name,
         },
       },

--- a/src/api/types/Machine.js
+++ b/src/api/types/Machine.js
@@ -57,16 +57,16 @@ export class Machine extends Node {
   /**
    * @constructor
    * @param {Object} params
-   * @param {Object} params.data Raw data payload from the API.
+   * @param {Object} params.kube Raw kube object payload from the API.
    * @param {Namespace} params.namespace Namespace to which the object belongs.
    *
    *  NOTE: The namespace is expected to already contain all known Licenses that
    *   this Machine might reference.
    *
-   * @param {Cloud} params.cloud Reference to the Cloud used to get the data.
+   * @param {DataCloud} params.dataCloud Reference to the DataCloud used to get the data.
    */
-  constructor({ data, namespace, cloud }) {
-    super({ data, cloud, namespace, typeset: machineTs });
+  constructor({ kube, namespace, dataCloud }) {
+    super({ kube, namespace, dataCloud, typeset: machineTs });
 
     let _license = null;
 
@@ -77,7 +77,7 @@ export class Machine extends Node {
     Object.defineProperty(this, 'clusterName', {
       enumerable: true,
       get() {
-        return data.metadata.labels?.[apiLabels.CLUSTER_NAME] || null;
+        return kube.metadata.labels?.[apiLabels.CLUSTER_NAME] || null;
       },
     });
 
@@ -88,7 +88,7 @@ export class Machine extends Node {
     Object.defineProperty(this, 'isController', {
       enumerable: true,
       get() {
-        return !!data.metadata.labels?.[apiLabels.CLUSTER_CONTROLLER];
+        return !!kube.metadata.labels?.[apiLabels.CLUSTER_CONTROLLER];
       },
     });
 
@@ -104,8 +104,8 @@ export class Machine extends Node {
 
     //// Initialize
 
-    if (data.spec.providerSpec.value.rhelLicense) {
-      const licenseName = data.spec.providerSpec.value.rhelLicense;
+    if (kube.spec.providerSpec.value.rhelLicense) {
+      const licenseName = kube.spec.providerSpec.value.rhelLicense;
       _license =
         this.namespace.licenses.find((li) => li.name === licenseName) || null;
       if (!_license) {

--- a/src/api/types/MachineDeployment.js
+++ b/src/api/types/MachineDeployment.js
@@ -25,12 +25,12 @@ export class MachineDeployment extends ResourceUpdate {
   /**
    * @constructor
    * @param {Object} params
-   * @param {Object} params.data Raw data payload from the API.
+   * @param {Object} params.kube Raw kube object payload from the API.
    * @param {Namespace} params.namespace Namespace to which the object belongs.
-   * @param {Cloud} params.cloud Reference to the Cloud used to get the data.
+   * @param {DataCloud} params.dataCloud Reference to the DataCloud used to get the data.
    */
-  constructor({ data, namespace, cloud }) {
-    super({ data, cloud, namespace, typeset: machineDeploymentTs });
+  constructor({ kube, namespace, dataCloud }) {
+    super({ kube, namespace, dataCloud, typeset: machineDeploymentTs });
 
     /**
      * @readonly
@@ -40,7 +40,7 @@ export class MachineDeployment extends ResourceUpdate {
     Object.defineProperty(this, 'release', {
       enumerable: true,
       get() {
-        return data.release || '-1.0.0'; // TODO[cluster-history]: remove '-1.0.0' fallback
+        return kube.release || '-1.0.0'; // TODO[cluster-history]: remove '-1.0.0' fallback
       },
     });
   }

--- a/src/api/types/MachineEvent.js
+++ b/src/api/types/MachineEvent.js
@@ -23,12 +23,12 @@ export class MachineEvent extends ResourceEvent {
   /**
    * @constructor
    * @param {Object} params
-   * @param {Object} params.data Raw data payload from the API.
+   * @param {Object} params.kube Raw kube object payload from the API.
    * @param {Namespace} params.namespace Namespace to which the object belongs.
-   * @param {Cloud} params.cloud Reference to the Cloud used to get the data.
+   * @param {DataCloud} params.dataCloud Reference to the DataCloud used to get the data.
    */
-  constructor({ data, namespace, cloud }) {
-    super({ data, cloud, namespace, typeset: machineEventTs });
+  constructor({ kube, namespace, dataCloud }) {
+    super({ kube, namespace, dataCloud, typeset: machineEventTs });
   }
 
   // NOTE: we don't have toEntity() because we don't show MachineEvents in the Catalog at

--- a/src/api/types/MachineUpgrade.js
+++ b/src/api/types/MachineUpgrade.js
@@ -25,12 +25,12 @@ export class MachineUpgrade extends ResourceUpdate {
   /**
    * @constructor
    * @param {Object} params
-   * @param {Object} params.data Raw data payload from the API.
+   * @param {Object} params.kube Raw kube object payload from the API.
    * @param {Namespace} params.namespace Namespace to which the object belongs.
-   * @param {Cloud} params.cloud Reference to the Cloud used to get the data.
+   * @param {DataCloud} params.dataCloud Reference to the DataCloud used to get the data.
    */
-  constructor({ data, namespace, cloud }) {
-    super({ data, cloud, namespace, typeset: machineUpgradeTs });
+  constructor({ kube, namespace, dataCloud }) {
+    super({ kube, namespace, dataCloud, typeset: machineUpgradeTs });
 
     /**
      * @readonly
@@ -39,7 +39,7 @@ export class MachineUpgrade extends ResourceUpdate {
     Object.defineProperty(this, 'fromRelease', {
       enumerable: true,
       get() {
-        return data.fromRelease;
+        return kube.fromRelease;
       },
     });
 
@@ -50,7 +50,7 @@ export class MachineUpgrade extends ResourceUpdate {
     Object.defineProperty(this, 'release', {
       enumerable: true,
       get() {
-        return data.toRelease; // TODO[cluster-history] change to 'release' per PRODX-28727
+        return kube.toRelease; // TODO[cluster-history] change to 'release' per PRODX-28727
       },
     });
   }

--- a/src/api/types/NamedResource.js
+++ b/src/api/types/NamedResource.js
@@ -23,13 +23,13 @@ export class NamedResource extends Resource {
   /**
    * @constructor
    * @param {Object} params
-   * @param {Object} params.data Raw data payload from the API.
+   * @param {Object} params.kube Raw kube object payload from the API.
    * @param {Namespace} params.namespace Namespace to which the object belongs.
-   * @param {Cloud} params.cloud Reference to the Cloud used to get the data.
+   * @param {DataCloud} params.dataCloud Reference to the DataCloud used to get the data.
    * @param {rtv.Typeset} params.typeset Typeset for verifying the data.
    */
-  constructor({ data, namespace, cloud, typeset }) {
-    super({ data, cloud, typeset });
+  constructor({ kube, namespace, dataCloud, typeset }) {
+    super({ kube, dataCloud, typeset });
 
     DEV_ENV &&
       rtv.verify(

--- a/src/api/types/Namespace.js
+++ b/src/api/types/Namespace.js
@@ -32,13 +32,13 @@ export class Namespace extends Resource {
   /**
    * @constructor
    * @param {Object} params
-   * @param {Object} params.data Raw data payload from the API.
-   * @param {Cloud} params.cloud Reference to the Cloud used to get the data.
+   * @param {Object} params.kube Raw kube object payload from the API.
+   * @param {DataCloud} params.dataCloud Reference to the DataCloud used to get the data.
    * @param {boolean} [params.preview] True if this Namespace is for preview
    *  purposes only, and so only the __count__ properties will be valid.
    */
-  constructor({ data, cloud, preview = false }) {
-    super({ data, cloud, typeset: namespaceTs });
+  constructor({ kube, dataCloud, preview = false }) {
+    super({ kube, dataCloud, typeset: namespaceTs });
 
     let _clusters = [];
     let _events = [];
@@ -64,7 +64,7 @@ export class Namespace extends Resource {
     Object.defineProperty(this, 'phase', {
       enumerable: true,
       get() {
-        return data.status.phase;
+        return kube.status.phase;
       },
     });
 

--- a/src/api/types/Node.js
+++ b/src/api/types/Node.js
@@ -22,13 +22,13 @@ export class Node extends NamedResource {
   /**
    * @constructor
    * @param {Object} params
-   * @param {Object} params.data Raw data payload from the API.
+   * @param {Object} params.kube Raw kube object payload from the API.
    * @param {Namespace} params.namespace Namespace to which the object belongs.
-   * @param {Cloud} params.cloud Reference to the Cloud used to get the data.
+   * @param {DataCloud} params.dataCloud Reference to the DataCloud used to get the data.
    * @param {rtv.Typeset} params.typeset Typeset for verifying the data.
    */
-  constructor({ data, namespace, cloud, typeset }) {
-    super({ data, namespace, cloud, typeset });
+  constructor({ kube, namespace, dataCloud, typeset }) {
+    super({ kube, namespace, dataCloud, typeset });
 
     /**
      * @readonly
@@ -38,14 +38,14 @@ export class Node extends NamedResource {
       enumerable: true,
       get() {
         // NOTE: AWS clusters, while they have a 'region' label like all other cluster
-        //  types, also have a `data.spec?.providerSpec?.value?.region` which provides
+        //  types, also have a `kube.spec?.providerSpec?.value?.region` which provides
         //  a better value (i.e. the label will always be 'aws' while the provider
         //  region will be what we want, like 'us-west-2'); we assume here that if
         //  there's a provider-specific region, that will always be more precise than
         //  the label, regardless of cluster provider type
         return (
-          data.spec?.providerSpec?.value?.region ||
-          data.metadata.labels?.[apiLabels.KAAS_REGION] ||
+          kube.spec?.providerSpec?.value?.region ||
+          kube.metadata.labels?.[apiLabels.KAAS_REGION] ||
           null
         );
       },
@@ -58,7 +58,7 @@ export class Node extends NamedResource {
     Object.defineProperty(this, 'provider', {
       enumerable: true,
       get() {
-        return data.metadata.labels?.[apiLabels.KAAS_PROVIDER] || null;
+        return kube.metadata.labels?.[apiLabels.KAAS_PROVIDER] || null;
       },
     });
 
@@ -70,7 +70,7 @@ export class Node extends NamedResource {
     Object.defineProperty(this, 'conditions', {
       enumerable: true,
       get() {
-        return data.status?.providerStatus?.conditions || [];
+        return kube.status?.providerStatus?.conditions || [];
       },
     });
 
@@ -83,7 +83,7 @@ export class Node extends NamedResource {
     Object.defineProperty(this, 'status', {
       enumerable: true,
       get() {
-        const { providerStatus } = data.status || {};
+        const { providerStatus } = kube.status || {};
 
         if (!providerStatus) {
           // we don't have any status-related info yet
@@ -135,7 +135,7 @@ export class Node extends NamedResource {
     Object.defineProperty(this, 'ready', {
       enumerable: true,
       get() {
-        return !!data.status?.providerStatus?.ready;
+        return !!kube.status?.providerStatus?.ready;
       },
     });
   }

--- a/src/api/types/Proxy.js
+++ b/src/api/types/Proxy.js
@@ -37,18 +37,18 @@ export class Proxy extends NamedResource {
   /**
    * @constructor
    * @param {Object} params
-   * @param {Object} params.data Raw data payload from the API.
+   * @param {Object} params.kube Raw kube object payload from the API.
    * @param {Namespace} params.namespace Namespace to which the object belongs.
-   * @param {Cloud} params.cloud Reference to the Cloud used to get the data.
+   * @param {DataCloud} params.dataCloud Reference to the DataCloud used to get the data.
    */
-  constructor({ data, namespace, cloud }) {
-    super({ data, namespace, cloud, typeset: proxyTs });
+  constructor({ kube, namespace, dataCloud }) {
+    super({ kube, namespace, dataCloud, typeset: proxyTs });
 
     /** @member {string} region */
     Object.defineProperty(this, 'region', {
       enumerable: true,
       get() {
-        return data.metadata.labels?.[apiLabels.KAAS_REGION] || null;
+        return kube.metadata.labels?.[apiLabels.KAAS_REGION] || null;
       },
     });
 
@@ -56,7 +56,7 @@ export class Proxy extends NamedResource {
     Object.defineProperty(this, 'httpProxy', {
       enumerable: true,
       get() {
-        return data.spec.httpProxy;
+        return kube.spec.httpProxy;
       },
     });
 
@@ -64,7 +64,7 @@ export class Proxy extends NamedResource {
     Object.defineProperty(this, 'httpsProxy', {
       enumerable: true,
       get() {
-        return data.spec.httpsProxy;
+        return kube.spec.httpsProxy;
       },
     });
   }
@@ -81,7 +81,7 @@ export class Proxy extends NamedResource {
     return merge({}, model, {
       metadata: {
         labels: {
-          [entityLabels.CLOUD]: this.cloud.name,
+          [entityLabels.CLOUD]: this.dataCloud.name,
           [entityLabels.NAMESPACE]: this.namespace.name,
         },
       },

--- a/src/api/types/Release.js
+++ b/src/api/types/Release.js
@@ -1,0 +1,180 @@
+import * as rtv from 'rtvjs';
+import { merge } from 'lodash';
+import * as semver from 'semver';
+import { mergeRtvShapes } from '../../util/mergeRtvShapes';
+import { Resource, resourceTs } from './Resource';
+import { entityLabels } from '../../catalog/catalogEntities';
+import { apiKinds } from '../apiConstants';
+import { logValue } from '../../util/logger';
+
+/**
+ * Typeset for an MCC Release API resource.
+ */
+export const releaseTs = mergeRtvShapes({}, resourceTs, {
+  // NOTE: this is not intended to be fully-representative; we only list the properties
+  //  related to what we expect to find in order to create a `Release` class instance
+
+  kind: [rtv.STRING, { oneOf: apiKinds.KAAS_RELEASE }],
+
+  metadata: {
+    labels: [rtv.OPTIONAL, rtv.HASH_MAP, { $values: rtv.JSON }],
+  },
+
+  spec: {
+    version: rtv.STRING,
+  },
+});
+
+/**
+ * MCC license API resource.
+ * @class Release
+ */
+export class Release extends Resource {
+  /**
+   * @constructor
+   * @param {Object} params
+   * @param {Object} params.kube Raw kube object payload from the API.
+   * @param {Namespace} params.namespace Namespace to which the object belongs.
+   * @param {DataCloud} params.dataCloud Reference to the DataCloud used to get the data.
+   */
+  constructor({ kube, namespace, dataCloud }) {
+    super({ kube, namespace, dataCloud, typeset: releaseTs });
+
+    // make sure it's 'x.y.z' format (should be, but just in case) since other semver APIs
+    //  require it to be in order to either not throw, or behave properly
+    const _version = semver.valid(semver.coerce(kube.spec.version));
+
+    /**
+     * @readonly
+     * @member {boolean} active True if it's the active (current) release; false otherwise.
+     */
+    Object.defineProperty(this, 'active', {
+      enumerable: true,
+      get() {
+        return kube.metadata.labels?.['kaas.mirantis.com/active'] === 'true';
+      },
+    });
+
+    /**
+     * @readonly
+     * @member {string} version Semantic version.
+     */
+    Object.defineProperty(this, 'version', {
+      enumerable: true,
+      get() {
+        return _version;
+      },
+    });
+  }
+
+  /**
+   * Checks if the release's version satisfies a given semantic version range.
+   * @param {string} range A valid range per https://www.npmjs.com/package/semver#ranges rules.
+   *
+   *  Note: A single version, e.g. '1.2.3', is also considered a valid range. Therefore, it's
+   *   possible to check for a specific release like `satisfies('2.22')`.
+   *
+   * @returns {boolean} True if satisfied; false if not.
+   */
+  satisfies(range) {
+    return semver.satisfies(this.version, range);
+  }
+
+  /**
+   * Checks if the release's version is greater-than a given `x.y.z` version.
+   * @param {string} version Must have all three components, `x.y.z`.
+   * @returns {boolean} True if greater than this release; false otherwise.
+   * @throws {TypeError} If `version` is not fully specified as `x.y.z`.
+   */
+  isGT(version) {
+    if (semver.valid(version)) {
+      return this.satisfies(`>${version}`);
+    }
+
+    throw new TypeError(`"${version}" is not in valid "x.y.z" format`);
+  }
+
+  /**
+   * Checks if the release's version is greater-than-or-equal to a given `x.y.z` version.
+   * @param {string} version Must have all three components, `x.y.z`.
+   * @returns {boolean} True if greater than or equal to this release; false otherwise.
+   * @throws {TypeError} If `version` is not fully specified as `x.y.z`.
+   */
+  isGTE(version) {
+    if (semver.valid(version)) {
+      return this.satisfies(`>=${version}`);
+    }
+
+    throw new TypeError(`"${version}" is not in valid "x.y.z" format`);
+  }
+
+  /**
+   * Checks if the release's version is less-than a given `x.y.z` version.
+   * @param {string} version Must have all three components, `x.y.z`.
+   * @returns {boolean} True if less than this release; false otherwise.
+   * @throws {TypeError} If `version` is not fully specified as `x.y.z`.
+   */
+  isLT(version) {
+    if (semver.valid(version)) {
+      return this.satisfies(`<${version}`);
+    }
+
+    throw new TypeError(`"${version}" is not in valid "x.y.z" format`);
+  }
+
+  /**
+   * Checks if the release's version is less-than-or-equal to a given `x.y.z` version.
+   * @param {string} version Must have all three components, `x.y.z`.
+   * @returns {boolean} True if less than or equal to this release; false otherwise.
+   * @throws {TypeError} If `version` is not fully specified as `x.y.z`.
+   */
+  isLTE(version) {
+    if (semver.valid(version)) {
+      return this.satisfies(`<=${version}`);
+    }
+
+    throw new TypeError(`"${version}" is not in valid "x.y.z" format`);
+  }
+
+  // NOTE: we don't have toEntity() because we don't show Releases in the Catalog at
+  //  the moment (so we don't have a ReleaseEntity class for them either)
+
+  /**
+   * Converts this API Object into a Catalog Entity Model.
+   * @returns {{ metadata: Object, spec: Object, status: Object }} Catalog Entity Model
+   *  (use to create new Catalog Entity).
+   * @override
+   */
+  toModel() {
+    const model = super.toModel();
+
+    return merge({}, model, {
+      metadata: {
+        labels: {
+          [entityLabels.CLOUD]: this.dataCloud.name,
+        },
+      },
+      spec: {
+        active: this.active,
+        version: this.version,
+      },
+      status: {
+        phase: 'available',
+      },
+    });
+  }
+
+  /** @returns {string} A string representation of this instance for logging/debugging. */
+  toString() {
+    const propStr = `${super.toString()}, version: ${logValue(
+      this.version
+    )}, active: ${this.active}`;
+
+    if (Object.getPrototypeOf(this).constructor === Release) {
+      return `{Release ${propStr}}`;
+    }
+
+    // this is actually an extended class instance, so return only the properties
+    return propStr;
+  }
+}

--- a/src/api/types/ResourceEvent.js
+++ b/src/api/types/ResourceEvent.js
@@ -2,6 +2,7 @@ import { merge } from 'lodash';
 import * as rtv from 'rtvjs';
 import { mergeRtvShapes } from '../../util/mergeRtvShapes';
 import { NamedResource, namedResourceTs } from './NamedResource';
+import { entityLabels } from '../../catalog/catalogEntities';
 import { apiEventTypes } from '../apiConstants';
 import { logValue } from '../../util/logger';
 
@@ -40,13 +41,13 @@ export class ResourceEvent extends NamedResource {
   /**
    * @constructor
    * @param {Object} params
-   * @param {Object} params.data Raw data payload from the API.
+   * @param {Object} params.kube Raw kube object payload from the API.
    * @param {Namespace} params.namespace Namespace to which the object belongs.
-   * @param {Cloud} params.cloud Reference to the Cloud used to get the data.
+   * @param {DataCloud} params.dataCloud Reference to the DataCloud used to get the data.
    * @param {rtv.Typeset} params.typeset Typeset for verifying the data.
    */
-  constructor({ data, namespace, cloud, typeset = resourceEventTs }) {
-    super({ data, cloud, namespace, typeset });
+  constructor({ kube, namespace, dataCloud, typeset = resourceEventTs }) {
+    super({ kube, namespace, dataCloud, typeset });
 
     /**
      * @readonly
@@ -55,7 +56,7 @@ export class ResourceEvent extends NamedResource {
     Object.defineProperty(this, 'type', {
       enumerable: true,
       get() {
-        return data.type;
+        return kube.type;
       },
     });
 
@@ -66,7 +67,7 @@ export class ResourceEvent extends NamedResource {
     Object.defineProperty(this, 'lastDate', {
       enumerable: true,
       get() {
-        return new Date(data.lastTimestamp);
+        return new Date(kube.lastTimestamp);
       },
     });
 
@@ -77,7 +78,7 @@ export class ResourceEvent extends NamedResource {
     Object.defineProperty(this, 'count', {
       enumerable: true,
       get() {
-        return data.count;
+        return kube.count;
       },
     });
 
@@ -88,7 +89,7 @@ export class ResourceEvent extends NamedResource {
     Object.defineProperty(this, 'sourceComponent', {
       enumerable: true,
       get() {
-        return data.source.component;
+        return kube.source.component;
       },
     });
 
@@ -100,7 +101,7 @@ export class ResourceEvent extends NamedResource {
     Object.defineProperty(this, 'targetKind', {
       enumerable: true,
       get() {
-        return data.involvedObject.kind;
+        return kube.involvedObject.kind;
       },
     });
 
@@ -112,7 +113,7 @@ export class ResourceEvent extends NamedResource {
     Object.defineProperty(this, 'targetUid', {
       enumerable: true,
       get() {
-        return data.involvedObject.uid || null;
+        return kube.involvedObject.uid || null;
       },
     });
 
@@ -123,7 +124,7 @@ export class ResourceEvent extends NamedResource {
     Object.defineProperty(this, 'targetName', {
       enumerable: true,
       get() {
-        return data.involvedObject.name;
+        return kube.involvedObject.name;
       },
     });
 
@@ -134,7 +135,7 @@ export class ResourceEvent extends NamedResource {
     Object.defineProperty(this, 'reason', {
       enumerable: true,
       get() {
-        return data.reason;
+        return kube.reason;
       },
     });
 
@@ -145,7 +146,7 @@ export class ResourceEvent extends NamedResource {
     Object.defineProperty(this, 'message', {
       enumerable: true,
       get() {
-        return data.message;
+        return kube.message;
       },
     });
   }
@@ -159,6 +160,12 @@ export class ResourceEvent extends NamedResource {
     const model = super.toModel();
 
     return merge({}, model, {
+      metadata: {
+        labels: {
+          [entityLabels.CLOUD]: this.dataCloud.name,
+          [entityLabels.NAMESPACE]: this.namespace.name,
+        },
+      },
       spec: {
         type: this.type,
         lastTimeAt: this.lastDate.toISOString(),

--- a/src/api/types/SshKey.js
+++ b/src/api/types/SshKey.js
@@ -27,18 +27,18 @@ export class SshKey extends NamedResource {
   /**
    * @constructor
    * @param {Object} params
-   * @param {Object} params.data Raw data payload from the API.
+   * @param {Object} params.kube Raw kube object payload from the API.
    * @param {Namespace} params.namespace Namespace to which the object belongs.
-   * @param {Cloud} params.cloud Reference to the Cloud used to get the data.
+   * @param {DataCloud} params.dataCloud Reference to the DataCloud used to get the data.
    */
-  constructor({ data, namespace, cloud }) {
-    super({ data, namespace, cloud, typeset: sshKeyTs });
+  constructor({ kube, namespace, dataCloud }) {
+    super({ kube, namespace, dataCloud, typeset: sshKeyTs });
 
     /** @member {string} publicKey */
     Object.defineProperty(this, 'publicKey', {
       enumerable: true,
       get() {
-        return data.spec.publicKey;
+        return kube.spec.publicKey;
       },
     });
   }
@@ -55,7 +55,7 @@ export class SshKey extends NamedResource {
     return merge({}, model, {
       metadata: {
         labels: {
-          [entityLabels.CLOUD]: this.cloud.name,
+          [entityLabels.CLOUD]: this.dataCloud.name,
           [entityLabels.NAMESPACE]: this.namespace.name,
         },
       },

--- a/src/catalog/catalogEntities.js
+++ b/src/catalog/catalogEntities.js
@@ -81,6 +81,17 @@ export const catalogEntityModelTs = {
 
     kind: apiKindTs,
     resourceVersion: rtv.STRING,
+    syncedAt: rtv.STRING,
+
+    // optional for backward compatibility
+    // `null` if release is unknown
+    cloudRelease: [
+      rtv.OPTIONAL,
+      {
+        active: rtv.BOOLEAN,
+        version: rtv.STRING,
+      },
+    ],
 
     // this is a string that essentially identifies the version of the extension which
     //  created the entity; it should be treated as an opaque value at the entity level
@@ -90,7 +101,6 @@ export const catalogEntityModelTs = {
     //  if necessary
     namespace: rtv.STRING,
     cloudUrl: [rtv.STRING, (v) => !v.endsWith('/')], // no trailing slash
-    syncedAt: rtv.STRING,
   },
 
   // spec is specific to the type of entity being added to the Catalog; e.g. for a cluster,

--- a/src/main/SyncManager.js
+++ b/src/main/SyncManager.js
@@ -1331,7 +1331,12 @@ export class SyncManager extends Singleton {
     // ALL resources of each type across ALL __synced__ namespaces since we don't
     //  know what changed
     const resources = types.reduce((acc, type) => {
-      acc[type] = dataCloud.syncedNamespaces.flatMap((ns) => ns[type]);
+      // NOTE: due to event dispatch timings, it's somewhat possible we get here with
+      //  `syncedNamespaces` being an array of unfilled slots, in which case we need
+      //  to filter those out and deal only with what we actually got (if anything)
+      acc[type] = dataCloud.syncedNamespaces
+        .filter((ns) => !!ns)
+        .flatMap((ns) => ns[type]);
       return acc;
     }, {});
 

--- a/src/store/CloudStore.js
+++ b/src/store/CloudStore.js
@@ -335,7 +335,7 @@ export class CloudStore extends Common.Store.ExtensionStore {
       );
       eventNames = [
         CLOUD_EVENTS.SYNC_CHANGE, // selective sync changes only happen on RENDERER
-        CLOUD_EVENTS.PROP_CHANGE, // may change on RENDERER if we allow editing name
+        CLOUD_EVENTS.PROP_CHANGE, // may change on RENDERER (e.g. if we allow editing name)
       ];
     }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -44,17 +44,21 @@ const plugins = [
   new DefinePlugin({
     DEV_ENV: JSON.stringify(buildTarget !== 'production'),
     TEST_ENV: JSON.stringify(false), // always false (Jest configures it true always for tests)
+    'process.env.TARGET': JSON.stringify(buildTarget),
+
+    // automatic cache-break when publish new package version or new build of same version
     ENTITY_CACHE_VERSION:
       (process.env.ENTITY_CACHE_VERSION &&
         JSON.stringify(process.env.ENTITY_CACHE_VERSION)) ||
       JSON.stringify(`v${pkg.version}:${Date.now()}`),
+
     FEAT_CLUSTER_PAGE_HISTORY_ENABLED: JSON.stringify(
       !!Number(process.env.FEAT_CLUSTER_PAGE_HISTORY_ENABLED)
     ),
+
     FEAT_CLUSTER_PAGE_HEALTH_ENABLED: JSON.stringify(
       !!Number(process.env.FEAT_CLUSTER_PAGE_HEALTH_ENABLED)
     ),
-    'process.env.TARGET': JSON.stringify(buildTarget),
   }),
 ];
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6126,6 +6126,13 @@ semver@^7.2.1, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7:
   dependencies:
     lru-cache "^6.0.0"
 
+semver@^7.3.8:
+  version "7.3.8"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.8.tgz#07a78feafb3f7b32347d725e33de7e2a2df67798"
+  integrity sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==
+  dependencies:
+    lru-cache "^6.0.0"
+
 serialize-error@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/serialize-error/-/serialize-error-7.0.1.tgz#f1360b0447f61ffb483ec4157c737fab7d778e18"


### PR DESCRIPTION
First, the active KAAS_RELEASE object had to be fetched, which led to some refactoring of the API Client classes.

Then it had to be used to compare the active version with a sought version, hence the new `Release` API resource type class.

Then it had to get all the down into Catalog entities. But since the release is fetched on every sync (since it could change from one sync to another), the release is DataCloud-related data, not Cloud-related data, and all API resource type classes were requiring Cloud instances, not DataCloud instances. So they all had to be refactored to accept a DataCloud instead.

At this point, everything works again like it used to. There are no functional changes other than:

1. The release is always fetched.
2. Instead of looking at the `FEAT_CLUSTER_PAGE_HISTORY_ENABLED` Webpack flag during DataCloud fetch to determine if we should fetch resource updates, now we use the Release instance and fetch resource updates if the active release is `>=2.22`. The rest of the history-related code still uses the Webpack flag.
3. The release info is included in all Catalog entities.

Finally, the `semver` dependency was added to do the semver comparisons with the release version.

### PR Checklist

n/a (no tangible changes)
