### PR TITLE
ExtensionStore is no longer a Singleton in Lens since some 6.4.x release

### DIFF
--- a/__mocks__/@k8slens/extensions.js
+++ b/__mocks__/@k8slens/extensions.js
@@ -117,7 +117,7 @@ class Singleton {
     //  set in the prototype chain directly off the Singleton constructor function (when this
     //  code is distilled down to ES5) and then called as `ExtendingSingletonClass.createInstance()`,
     //  it will be a reference to the constructor function of the class extending from
-    //  Singleton (e.g. the `ExtendingSingleClass` function in this case, which we can "new"
+    //  Singleton (e.g. the `ExtendingSingletonClass` function in this case, which we can "new"
     //  because it's a function).
     // NOTE: The prototype chain will be like this, `ExtendingSingletonClass.__proto__ -> Singleton`
     //  (the Singleton function itself, setup as the "prototype of" the ExtendingSingletonClass
@@ -413,51 +413,19 @@ MenuActions.proptypes = {
 
 // NOTE: in reality, ExtensionStore extends BaseStore, but we don't need to access BaseStore
 //  separately anywhere in our code, so the mock just fakes everything in ExtensionStore
-class ExtensionStore extends Singleton {
-  /**
-   * __MOCK ONLY__
-   * @type {{ [index: string]: { created: boolean, json: Object } }} map of store name to
-   *  object with `created` true if store has been constructed, and `json` being the current
-   *  state of the store from "disk"
-   */
-  static stores = {};
-
-  /**
-   * __MOCK ONLY__
-   *
-   * Initializes a store before it gets created.
-   * @param {string} name Store name.
-   * @param {Object} json Store state as it would be read from disk by Lens in reality.
-   */
-  static initStore(name, json) {
-    ExtensionStore.stores[name] = { created: false, json };
-  }
-
+class ExtensionStore {
   constructor({ configName, defaults }) {
-    super();
-
     this.configName = configName;
     this.defaults = defaults;
   }
 
   loadExtension(extension) {
-    if (!ExtensionStore.stores[this.configName]?.created) {
-      if (!ExtensionStore.stores[this.configName]) {
-        // create store state
-        ExtensionStore.stores[this.configName] = {
-          created: false,
-          json: this.defaults,
-        };
-      }
-    }
-
-    const state = ExtensionStore.stores[this.configName];
-    state.created = true;
-
-    // real impl doesn't appear to have any async behavior in it: calls fromStore() immediately
-    this.fromStore(state.json);
+    this.fromStore(this.defaults);
   }
 
+  // NOTE: in unit tests, call this method directly on the instance (it won't be abstract)
+  //  in order to load the store with some seed data if you're doing on an instance that
+  //  already exists (like the `globalCloudStore` or `globalSyncStore`)
   fromStore(store) {
     throw new Error('abstract');
   }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1,7 +1,7 @@
 import { Main } from '@k8slens/extensions';
 import { observable } from 'mobx';
-import { cloudStore } from '../store/CloudStore';
-import { syncStore } from '../store/SyncStore';
+import { globalCloudStore } from '../store/CloudStore';
+import { globalSyncStore } from '../store/SyncStore';
 import { IpcMain } from './IpcMain';
 import { logger as loggerUtil } from '../util/logger';
 import { SyncManager } from './SyncManager';
@@ -46,8 +46,8 @@ export default class ExtensionMain extends Main.LensExtension {
 
     const ipcMain = IpcMain.createInstance(this);
 
-    cloudStore.loadExtension(this, { ipcMain });
-    syncStore.loadExtension(this, { ipcMain });
+    globalCloudStore.loadExtension(this, { ipcMain });
+    globalSyncStore.loadExtension(this, { ipcMain });
 
     // AFTER load stores
     SyncManager.createInstance({

--- a/src/renderer/components/GlobalSyncPage/EnhancedTable/__tests__/EnhancedTable.spec.js
+++ b/src/renderer/components/GlobalSyncPage/EnhancedTable/__tests__/EnhancedTable.spec.js
@@ -5,7 +5,7 @@ import { EnhancedTable } from '../EnhancedTable';
 import { Cloud } from '../../../../../common/Cloud'; // MOCKED
 import { CloudProvider } from '../../../../store/CloudProvider';
 import { IpcRenderer } from '../../../../IpcRenderer';
-import { CloudStore } from '../../../../../store/CloudStore';
+import { globalCloudStore } from '../../../../../store/CloudStore';
 
 jest.mock('../../../../../common/Cloud');
 
@@ -14,6 +14,7 @@ describe('/renderer/components/GlobalSyncPage/EnhancedTable/EnhancedTable', () =
   let fakeCloudFoo;
   let fakeCloudBar;
   let user;
+  let ipcRenderer;
 
   beforeEach(() => {
     user = userEvent.setup();
@@ -55,8 +56,8 @@ describe('/renderer/components/GlobalSyncPage/EnhancedTable/EnhancedTable', () =
       ],
     });
 
-    const ipcRenderer = IpcRenderer.createInstance(extension);
-    CloudStore.createInstance().loadExtension(extension, { ipcRenderer });
+    ipcRenderer = IpcRenderer.createInstance(extension);
+    globalCloudStore.loadExtension(extension, { ipcRenderer });
   });
 
   [true, false].forEach((isSelectiveSyncView) => {

--- a/src/renderer/components/GlobalSyncPage/EnhancedTable/__tests__/EnhancedTableRow.spec.js
+++ b/src/renderer/components/GlobalSyncPage/EnhancedTable/__tests__/EnhancedTableRow.spec.js
@@ -5,7 +5,7 @@ import { EnhancedTableRow } from '../EnhancedTableRow';
 import { Cloud, CONNECTION_STATUSES } from '../../../../../common/Cloud'; // MOCKED
 import { CloudProvider } from '../../../../store/CloudProvider';
 import { IpcRenderer } from '../../../../IpcRenderer';
-import { CloudStore } from '../../../../../store/CloudStore';
+import { globalCloudStore } from '../../../../../store/CloudStore';
 import * as strings from '../../../../../strings';
 
 jest.mock('../../../../../common/Cloud');
@@ -13,6 +13,7 @@ jest.mock('../../../../../common/Cloud');
 describe('/renderer/components/GlobalSyncPage/EnhancedTable/EnhancedTable', () => {
   const extension = {};
   let user;
+  let ipcRenderer;
 
   const colorGreen = {
     color: 'var(--colorSuccess)',
@@ -22,13 +23,12 @@ describe('/renderer/components/GlobalSyncPage/EnhancedTable/EnhancedTable', () =
     color: 'var(--halfGray)',
   };
 
-  let ipcRenderer;
-
   beforeEach(() => {
     user = userEvent.setup();
     mockConsole(['log', 'info', 'warn']); // automatically restored after each test
 
     ipcRenderer = IpcRenderer.createInstance(extension);
+    globalCloudStore.loadExtension(extension, { ipcRenderer });
   });
 
   describe('render', () => {
@@ -60,8 +60,6 @@ describe('/renderer/components/GlobalSyncPage/EnhancedTable/EnhancedTable', () =
         name: 'bar',
         cloudUrl: 'http://bar.com',
       });
-
-      CloudStore.createInstance().loadExtension(extension, { ipcRenderer });
     });
 
     [true, false].forEach((isSyncStarted) => {

--- a/src/renderer/components/GlobalSyncPage/EnhancedTable/__tests__/TableRowListenerWrapper.spec.js
+++ b/src/renderer/components/GlobalSyncPage/EnhancedTable/__tests__/TableRowListenerWrapper.spec.js
@@ -9,7 +9,7 @@ import {
 } from '../../../../../common/Cloud'; // MOCKED
 import { CloudProvider } from '../../../../store/CloudProvider';
 import { IpcRenderer } from '../../../../IpcRenderer';
-import { CloudStore } from '../../../../../store/CloudStore';
+import { globalCloudStore } from '../../../../../store/CloudStore';
 import * as strings from '../../../../../strings';
 
 jest.mock('../../../../../common/Cloud');
@@ -17,13 +17,14 @@ jest.mock('../../../../../common/Cloud');
 describe('/renderer/components/GlobalSyncPage/EnhancedTable/TableRowListenerWrapper', () => {
   const extension = {};
   let user;
+  let ipcRenderer;
 
   beforeEach(() => {
     user = userEvent.setup();
     mockConsole(['log', 'info', 'warn']); // automatically restored after each test
 
-    const ipcRenderer = IpcRenderer.createInstance(extension);
-    CloudStore.createInstance().loadExtension(extension, { ipcRenderer });
+    ipcRenderer = IpcRenderer.createInstance(extension);
+    globalCloudStore.loadExtension(extension, { ipcRenderer });
   });
 
   (function () {

--- a/src/renderer/components/GlobalSyncPage/__tests__/AddCloudInstance.spec.js
+++ b/src/renderer/components/GlobalSyncPage/__tests__/AddCloudInstance.spec.js
@@ -5,7 +5,7 @@ import { AddCloudInstance } from '../AddCloudInstance';
 import { MOCK_CONNECT_FAILURE_CLOUD_NAME } from '../../../../common/Cloud'; // MOCKED
 import { CloudProvider } from '../../../store/CloudProvider';
 import { IpcRenderer } from '../../../IpcRenderer';
-import { CloudStore } from '../../../../store/CloudStore';
+import { globalCloudStore } from '../../../../store/CloudStore';
 import * as strings from '../../../../strings';
 
 jest.mock('../../../../common/Cloud');
@@ -76,7 +76,7 @@ describe('/renderer/components/GlobalSyncPage/AddCloudInstance', () => {
     mockConsole(['log', 'info', 'warn']); // automatically restored after each test
 
     const ipcRenderer = IpcRenderer.createInstance(extension);
-    CloudStore.createInstance().loadExtension(extension, { ipcRenderer });
+    globalCloudStore.loadExtension(extension, { ipcRenderer });
   });
 
   describe('render', () => {

--- a/src/renderer/components/GlobalSyncPage/__tests__/GlobalSyncPage.spec.js
+++ b/src/renderer/components/GlobalSyncPage/__tests__/GlobalSyncPage.spec.js
@@ -3,18 +3,19 @@ import { render, screen } from 'testingUtility';
 import { GlobalSyncPage } from '../GlobalSyncPage';
 import { CloudProvider } from '../../../store/CloudProvider';
 import { IpcRenderer } from '../../../IpcRenderer';
-import { CloudStore } from '../../../../store/CloudStore';
+import { globalCloudStore } from '../../../../store/CloudStore';
 import { themeModes } from '../../theme';
 import * as strings from '../../../../strings';
 
 describe('/renderer/components/GlobalSyncPage/GlobalSyncPage', () => {
   const extension = {};
+  let ipcRenderer;
 
   beforeEach(() => {
     mockConsole(['log', 'info', 'warn']); // automatically restored after each test
 
-    const ipcRenderer = IpcRenderer.createInstance(extension);
-    CloudStore.createInstance().loadExtension(extension, { ipcRenderer });
+    ipcRenderer = IpcRenderer.createInstance(extension);
+    globalCloudStore.loadExtension(extension, { ipcRenderer });
   });
 
   [themeModes.LIGHT, themeModes.DARK].forEach((themeMode) => {

--- a/src/renderer/components/GlobalSyncPage/__tests__/SyncView-contextMenus.spec.js
+++ b/src/renderer/components/GlobalSyncPage/__tests__/SyncView-contextMenus.spec.js
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { Renderer } from '@k8slens/extensions';
 import { CloudProvider } from '../../../store/CloudProvider';
 import { IpcRenderer } from '../../../IpcRenderer';
-import { CloudStore } from '../../../../store/CloudStore';
+import { globalCloudStore } from '../../../../store/CloudStore';
 import { mkCloudJson, CONNECTION_STATUSES } from '../../../../common/Cloud'; // MOCKED
 import { SyncView } from '../SyncView';
 
@@ -24,6 +24,7 @@ describe('/renderer/components/GlobalSyncPage/SyncView', () => {
     mockConsole(['log', 'info', 'warn']); // automatically restored after each test
 
     ipcRenderer = IpcRenderer.createInstance(extension);
+    globalCloudStore.loadExtension(extension, { ipcRenderer });
   });
 
   describe('getCloudMenuItems()', () => {
@@ -78,12 +79,11 @@ describe('/renderer/components/GlobalSyncPage/SyncView', () => {
     });
 
     it('triggers reconnect cloud action by clicking on "Reconnect" button', async () => {
-      CloudStore.initStore('cloud-store', {
+      globalCloudStore.fromStore({
         clouds: {
           'http://foo.com': disconnectedFakeCloudJson,
         },
       });
-      CloudStore.createInstance().loadExtension(extension, { ipcRenderer });
 
       render(
         <CloudProvider>
@@ -98,12 +98,11 @@ describe('/renderer/components/GlobalSyncPage/SyncView', () => {
     });
 
     it('cloud |without| namespaces: triggers remove cloud action by clicking on "Remove" button', async () => {
-      CloudStore.initStore('cloud-store', {
+      globalCloudStore.fromStore({
         clouds: {
           'http://bar.com': fakeCloudWithoutNamespacesJson,
         },
       });
-      CloudStore.createInstance().loadExtension(extension, { ipcRenderer });
 
       render(
         <CloudProvider>
@@ -118,12 +117,11 @@ describe('/renderer/components/GlobalSyncPage/SyncView', () => {
     });
 
     it('cloud |with| namespaces: triggers remove cloud action by clicking on "Remove" button', async () => {
-      CloudStore.initStore('cloud-store', {
+      globalCloudStore.fromStore({
         clouds: {
           'http://bar.com': fakeCloudJson,
         },
       });
-      CloudStore.createInstance().loadExtension(extension, { ipcRenderer });
 
       render(
         <CloudProvider>
@@ -145,12 +143,11 @@ describe('/renderer/components/GlobalSyncPage/SyncView', () => {
     it('triggers open in browser action by clicking on "Open in browser" button', async () => {
       const logSpy = jest.spyOn(console, 'log');
 
-      CloudStore.initStore('cloud-store', {
+      globalCloudStore.fromStore({
         clouds: {
           'http://bar.com': fakeCloudJson,
         },
       });
-      CloudStore.createInstance().loadExtension(extension, { ipcRenderer });
 
       render(
         <CloudProvider>

--- a/src/renderer/components/GlobalSyncPage/__tests__/SyncView.spec.js
+++ b/src/renderer/components/GlobalSyncPage/__tests__/SyncView.spec.js
@@ -3,7 +3,7 @@ import { render, screen, act } from 'testingUtility';
 import userEvent from '@testing-library/user-event';
 import { CloudProvider } from '../../../store/CloudProvider';
 import { IpcRenderer } from '../../../IpcRenderer';
-import { CloudStore } from '../../../../store/CloudStore';
+import { globalCloudStore } from '../../../../store/CloudStore';
 import * as strings from '../../../../strings';
 import { SyncView } from '../SyncView';
 
@@ -17,12 +17,11 @@ describe('/renderer/components/GlobalSyncPage/SyncView', () => {
     mockConsole(['log', 'info', 'warn']); // automatically restored after each test
 
     ipcRenderer = IpcRenderer.createInstance(extension);
+    globalCloudStore.loadExtension(extension, { ipcRenderer });
   });
 
   describe('clouds do not exist', () => {
-    beforeEach(() => {
-      CloudStore.createInstance().loadExtension(extension, { ipcRenderer });
-    });
+    beforeEach(() => {});
 
     it('renders WelcomeView component instead of dataClouds table', () => {
       render(
@@ -39,7 +38,7 @@ describe('/renderer/components/GlobalSyncPage/SyncView', () => {
 
   describe('clouds exist', () => {
     beforeEach(() => {
-      CloudStore.initStore('cloud-store', {
+      globalCloudStore.fromStore({
         clouds: {
           'https://foo.com': {
             cloudUrl: 'https://foo.com',
@@ -114,7 +113,6 @@ describe('/renderer/components/GlobalSyncPage/SyncView', () => {
           },
         },
       });
-      CloudStore.createInstance().loadExtension(extension, { ipcRenderer });
     });
 
     it('renders SyncView component', () => {

--- a/src/renderer/components/GlobalSyncPage/__tests__/SynchronizeBlock.spec.js
+++ b/src/renderer/components/GlobalSyncPage/__tests__/SynchronizeBlock.spec.js
@@ -5,13 +5,14 @@ import { SynchronizeBlock } from '../SynchronizeBlock';
 import { Cloud } from '../../../../common/Cloud'; // MOCKED
 import { CloudProvider } from '../../../store/CloudProvider';
 import { IpcRenderer } from '../../../IpcRenderer';
-import { CloudStore } from '../../../../store/CloudStore';
+import { globalCloudStore } from '../../../../store/CloudStore';
 import * as strings from '../../../../strings';
 
 jest.mock('../../../../common/Cloud');
 
 describe('/renderer/components/GlobalSyncPage/AddCloudInstance', () => {
   const extension = {};
+  let ipcRenderer;
   let user;
   let fakeCloud;
   let fakeCloudWithoutNamespaces;
@@ -94,8 +95,8 @@ describe('/renderer/components/GlobalSyncPage/AddCloudInstance', () => {
       namespaces: [],
     };
 
-    const ipcRenderer = IpcRenderer.createInstance(extension);
-    CloudStore.createInstance().loadExtension(extension, { ipcRenderer });
+    ipcRenderer = IpcRenderer.createInstance(extension);
+    globalCloudStore.loadExtension(extension, { ipcRenderer });
   });
 
   it('renders component', () => {

--- a/src/renderer/renderer.tsx
+++ b/src/renderer/renderer.tsx
@@ -22,8 +22,8 @@ import {
   EXT_EVENT_ACTIVATE_CLUSTER,
   dispatchExtEvent,
 } from '../common/eventBus';
-import { cloudStore } from '../store/CloudStore';
-import { syncStore } from '../store/SyncStore';
+import { globalCloudStore } from '../store/CloudStore';
+import { globalSyncStore } from '../store/SyncStore';
 import { logger as loggerUtil } from '../util/logger';
 import { IpcRenderer } from './IpcRenderer';
 import { getLensClusters } from './rendererUtil';
@@ -287,8 +287,8 @@ export default class ExtensionRenderer extends LensExtension {
 
     const ipcRenderer = IpcRenderer.createInstance(this);
 
-    cloudStore.loadExtension(this, { ipcRenderer });
-    syncStore.loadExtension(this, { ipcRenderer });
+    globalCloudStore.loadExtension(this, { ipcRenderer });
+    globalSyncStore.loadExtension(this, { ipcRenderer });
 
     const category = catalogCategories.getForGroupKind(
       consts.catalog.entities.kubeCluster.group,

--- a/src/renderer/store/CloudProvider.js
+++ b/src/renderer/store/CloudProvider.js
@@ -3,7 +3,7 @@ import * as rtv from 'rtvjs';
 import { autorun } from 'mobx';
 import { ProviderStore } from './ProviderStore';
 import { cloneDeepWith } from 'lodash';
-import { cloudStore } from '../../store/CloudStore';
+import { globalCloudStore } from '../../store/CloudStore';
 import { Cloud } from '../../common/Cloud';
 import { IpcRenderer } from '../IpcRenderer';
 import { ipcEvents } from '../../constants';
@@ -62,7 +62,7 @@ const _handleAutoRun = function () {
   let storeChanged = false;
 
   // add any new Clouds added to the CloudStore
-  Object.entries(cloudStore.clouds).forEach(([cloudUrl, cloud]) => {
+  Object.entries(globalCloudStore.clouds).forEach(([cloudUrl, cloud]) => {
     if (!pr.store.clouds[cloudUrl]) {
       pr.store.clouds[cloudUrl] = cloud;
       storeChanged = true;
@@ -71,7 +71,7 @@ const _handleAutoRun = function () {
 
   // filter out updated Clouds
   Object.keys(oldStoreClouds).forEach((cloudUrl) => {
-    if (cloudStore.clouds[cloudUrl]) {
+    if (globalCloudStore.clouds[cloudUrl]) {
       // still exists so remove from the old list so we don't destroy it
       // NOTE: the CloudStore is careful to update existing Cloud instances when
       //  they change in the cloud-store.json file, and those updates will cause
@@ -184,7 +184,7 @@ export const useClouds = function () {
        * @param {Cloud} cloud
        */
       addCloud(cloud) {
-        cloudStore.addCloud(cloud);
+        globalCloudStore.addCloud(cloud);
       },
 
       /**
@@ -192,7 +192,7 @@ export const useClouds = function () {
        * @param {string} cloudUrl URL of the Cloud to remove.
        */
       removeCloud(cloudUrl) {
-        cloudStore.removeCloud(cloudUrl);
+        globalCloudStore.removeCloud(cloudUrl);
       },
     },
   };

--- a/src/renderer/store/__tests__/CloudProvider.spec.js
+++ b/src/renderer/store/__tests__/CloudProvider.spec.js
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event';
 import mockConsole from 'jest-mock-console';
 import { expectErrorBoundary } from '../../../../tools/tests/testTools';
 import { useClouds, CloudProvider } from '../CloudProvider';
-import { CloudStore } from '../../../store/CloudStore';
+import { globalCloudStore } from '../../../store/CloudStore';
 import { Cloud, mkCloudJson, CONNECTION_STATUSES } from '../../../common/Cloud'; // MOCKED
 import { IpcRenderer } from '../../IpcRenderer';
 
@@ -12,6 +12,7 @@ jest.mock('../../../common/Cloud');
 describe('/renderer/store/CloudProvider', () => {
   const extension = {};
   let user;
+  let ipcRenderer;
 
   beforeEach(() => {
     user = userEvent.setup();
@@ -96,14 +97,13 @@ describe('/renderer/store/CloudProvider', () => {
           ],
         });
 
-        CloudStore.initStore('cloud-store', {
+        ipcRenderer = IpcRenderer.createInstance(extension);
+        globalCloudStore.loadExtension(extension, { ipcRenderer });
+        globalCloudStore.fromStore({
           clouds: {
             'http://foo.com': fakeFooCloudJson,
           },
         });
-
-        const ipcRenderer = IpcRenderer.createInstance(extension);
-        CloudStore.createInstance().loadExtension(extension, { ipcRenderer });
       });
 
       describe('cloudActions.removeCloud()', () => {


### PR DESCRIPTION
- https://github.com/lensapp/lens/blob/master/packages/core/src/extensions/extension-store.ts
- https://github.com/lensapp/lens/pull/6690 ("Make base store non Singleton")
- https://github.com/lensapp/lens/issues/4573 ("Elimination of global shared state")

The `createInstance()` and `getInstance()` methods had been deprecated in the Lens Extensions API, so they have been eliminated from our code base also. But we're still using "global shared state" Cloud and Sync store instances. It's just that Lens isn't the one creating and holding the instance anymore, we are.


### PR Checklist

n/a
