### PR TITLE
[CCLEX-178] Attempt to make this work, but still blocked

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -78,7 +78,6 @@ const globals = {
   DEV_ENV: 'readonly',
   TEST_ENV: 'readonly',
   ENTITY_CACHE_VERSION: 'readonly',
-  FEAT_CLUSTER_PAGE_HEALTH_ENABLED: 'readonly',
   fetchMock: 'readonly', // from 'jest-fetch-mock' package
 };
 

--- a/src/api/apiConstants.js
+++ b/src/api/apiConstants.js
@@ -171,12 +171,3 @@ export const apiUpdateStatuses = Object.freeze({
   NOT_STARTED: 'NotStarted',
   FAILURE: 'Fail',
 });
-
-/**
- * Possible Cloud connection error types.
- * @type {Record<string, string>}
- */
-export const apiCloudErrorTypes = Object.freeze({
-  HOST_NOT_FOUND: 'HostNotFound',
-  CERT_VERIFICATION: 'CertificateVerification',
-});

--- a/src/api/apiUtil.js
+++ b/src/api/apiUtil.js
@@ -8,7 +8,7 @@ import { AuthorizationClient } from './clients/AuthorizationClient';
 import { KubernetesClient } from './clients/KubernetesClient';
 import { ResourceClient } from './clients/ResourceClient';
 import { logger, logValue } from '../util/logger';
-import { apiCloudErrorTypes, apiResourceTypes } from './apiConstants';
+import { apiResourceTypes } from './apiConstants';
 import { Cloud } from '../common/Cloud';
 
 /**
@@ -264,21 +264,3 @@ export async function cloudRequest({
     path,
   };
 }
-
-/**
- * Determines if a given error is a known Cloud error.
- * @param {Error|string} error Object or message.
- * @returns {string|undefined} One of `apiCloudErrorTypes` enum identifying the type if known;
- *  `undefined` if the error couldn't be identified.
- */
-export const getCloudErrorType = function (error) {
-  const msg = (typeof error === 'string' ? error : error?.message) || '';
-
-  if (msg.match(/unable to verify.+certificate/i)) {
-    return apiCloudErrorTypes.CERT_VERIFICATION;
-  } else if (msg.match(/getaddrinfo.+ENOTFOUND/i)) {
-    return apiCloudErrorTypes.HOST_NOT_FOUND;
-  }
-
-  return undefined;
-};

--- a/src/common/DataCloud.js
+++ b/src/common/DataCloud.js
@@ -16,10 +16,13 @@ import {
 } from '../api/apiFetch';
 import { logger, logValue } from '../util/logger';
 import { EventDispatcher } from './EventDispatcher';
-import { ipcEvents, mccCodeName, historyCloudVersion } from '../constants';
+import {
+  ipcEvents,
+  mccCodeName,
+  clusterHistoryCloudVersion,
+} from '../constants';
 import * as strings from '../strings';
-import { getCloudErrorType } from '../api/apiUtil';
-import { apiCloudErrorTypes } from '../api/apiConstants';
+import { netErrorTypes, getNetErrorType } from '../util/netUtil';
 
 export const DATA_CLOUD_EVENTS = Object.freeze({
   /**
@@ -572,10 +575,10 @@ export class DataCloud extends EventDispatcher {
     if (nsResults.error) {
       this.fetching = false;
 
-      const errorType = getCloudErrorType(nsResults.error);
+      const errorType = getNetErrorType(nsResults.error);
       const disconnected =
-        errorType === apiCloudErrorTypes.CERT_VERIFICATION ||
-        errorType === apiCloudErrorTypes.HOST_NOT_FOUND;
+        errorType === netErrorTypes.CERT_VERIFICATION ||
+        errorType === netErrorTypes.HOST_NOT_FOUND;
 
       this.error = nsResults.error.message;
       logger.error(
@@ -641,12 +644,12 @@ export class DataCloud extends EventDispatcher {
         errorsOccurred: false,
       };
 
-      if (release?.isGTE(historyCloudVersion)) {
+      if (release?.isGTE(clusterHistoryCloudVersion)) {
         resUpdateResults = await fetchResourceUpdates(this, fetchedNamespaces);
       } else {
         logger.warn(
           'DataCloud.fetchData()',
-          `Skipping ResourceUpdate objects fetch: ${mccCodeName} >=${historyCloudVersion} is required; release=${logValue(
+          `Skipping ResourceUpdate objects fetch: ${mccCodeName} >=${clusterHistoryCloudVersion} is required; release=${logValue(
             release
           )}`
         );

--- a/src/common/__mocks__/Cloud.js
+++ b/src/common/__mocks__/Cloud.js
@@ -305,7 +305,10 @@ export class Cloud extends EventDispatcher {
     });
   }
 
-  async loadConfig() {
+  async loadConfig(later = false) {
+    if (later) {
+      this.config = undefined; // indicate loading
+    }
     return new Promise((resolve) => {
       setTimeout(() => {
         this.config = {};

--- a/src/constants.js
+++ b/src/constants.js
@@ -3,14 +3,27 @@ import { deepFreeze } from './util/deepFreeze';
 /**
  * __Semantic version (`x.y.z` format)__
  *
- * Minimum mgmt cluster release version required to enable History features.
+ * Minimum mgmt cluster release version required to enable cluster History features.
  *
  * History features require MCC v2.22+ which adds the `status` field to cluster/machine
  *  deployment/upgrade status stage objects (see `ResourceUpdate` API resource type class
  *  which looks for this). v2.22 also adds the `release` field to cluster/machine deployment
  *  objects (see `ClusterDeployment` and `MachineDeployment` resource types).
  */
-export const historyCloudVersion = '2.22.0';
+export const clusterHistoryCloudVersion = '2.22.0';
+
+/**
+ * __Semantic version (`x.y.z` format)__
+ *
+ * Minimum mgmt cluster release version required to enable cluster Health features.
+ *
+ * Health features require MCC v2.23+ which makes it possible to reach StackLight Prometheus
+ *  APIs using the same SSO AuthN used to access the MCC API. Without this, we'd have to re-auth
+ *  other SSO to the Prometheus or StackLight endpoint to obtain a token with a different role,
+ *  which would require opening the external browser, etc. (same as we do when reconnecting to a
+ *  disconnected mgmt cluster).
+ */
+export const clusterHealthCloudVersion = null; // TODO[metrics]: specify minimum version like '2.24.0';
 
 /**
  * Name of the sub directory in the Lens-designated "extension storage" directory

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -7,4 +7,3 @@
 
 // Declared by Webpack
 declare const DEV_ENV: boolean;
-declare const FEAT_CLUSTER_PAGE_HEALTH_ENABLED: boolean;

--- a/src/renderer/components/ClusterPage/Overview/ClusterOverviewView.js
+++ b/src/renderer/components/ClusterPage/Overview/ClusterOverviewView.js
@@ -11,6 +11,9 @@ import {
   PanelsWrapper,
   PanelItem,
 } from '../clusterPageComponents';
+// TODO[metrics]: Enable this code
+// import { cloudVersionIsGTE } from '../../../../catalog/catalogEntities';
+// import { clusterHealthCloudVersion } from '../../../../constants';
 
 //
 // MAIN COMPONENT
@@ -21,13 +24,15 @@ export const ClusterOverviewView = function ({ clusterEntity }) {
   // RENDER
   //
 
+  const showHealth = false; // TODO[metrics]: Use this instead: `cloudVersionIsGTE(clusterEntity, clusterHealthCloudVersion);`
+
   return (
     <PageContainer>
       <PanelsWrapper>
-        <PanelItem isHalfWidth={FEAT_CLUSTER_PAGE_HEALTH_ENABLED || false}>
+        <PanelItem isHalfWidth={showHealth}>
           <SummaryPanel clusterEntity={clusterEntity} />
         </PanelItem>
-        {FEAT_CLUSTER_PAGE_HEALTH_ENABLED ? (
+        {showHealth ? (
           <PanelItem isHalfWidth>
             <HealthPanel clusterEntity={clusterEntity} />
           </PanelItem>

--- a/src/renderer/renderer.tsx
+++ b/src/renderer/renderer.tsx
@@ -367,7 +367,8 @@ export default class ExtensionRenderer extends LensExtension {
           if (showClusterPage()) {
             const entity = this.getActiveClusterEntity();
             return (
-              entity && cloudVersionIsGTE(entity, consts.historyCloudVersion)
+              entity &&
+              cloudVersionIsGTE(entity, consts.clusterHistoryCloudVersion)
             );
           }
           return false;

--- a/src/renderer/rendererUtil.js
+++ b/src/renderer/rendererUtil.js
@@ -5,8 +5,7 @@
 import { Renderer } from '@k8slens/extensions';
 import dayjs from 'dayjs';
 import dayjsRelativeTimePlugin from 'dayjs/plugin/relativeTime';
-import { getCloudErrorType } from '../api/apiUtil';
-import { apiCloudErrorTypes } from '../api/apiConstants';
+import { netErrorTypes, getNetErrorType } from '../util/netUtil';
 import * as consts from '../constants';
 import * as strings from '../strings';
 
@@ -64,10 +63,10 @@ export const getCloudConnectionError = function (cloud) {
   let message;
   if (cloud.connectError) {
     message = strings.cloudConnectionErrors.connectionError(); // generic error/reconnect message
-    const errorType = getCloudErrorType(cloud.connectError);
-    if (errorType === apiCloudErrorTypes.CERT_VERIFICATION) {
+    const errorType = getNetErrorType(cloud.connectError);
+    if (errorType === netErrorTypes.CERT_VERIFICATION) {
       message = strings.cloudConnectionErrors.untrustedCertificate();
-    } else if (errorType === apiCloudErrorTypes.HOST_NOT_FOUND) {
+    } else if (errorType === netErrorTypes.HOST_NOT_FOUND) {
       message = strings.cloudConnectionErrors.hostNotFound();
     }
   }

--- a/src/strings.ts
+++ b/src/strings.ts
@@ -421,6 +421,8 @@ export const clusterPage: Dict = {
       },
       health: {
         title: () => 'Health',
+        showMore: () => '(Show more)',
+        showLess: () => '(Show less)',
         metrics: {
           error: {
             disconnectedManagementCluster: {
@@ -435,6 +437,21 @@ export const clusterPage: Dict = {
                 'Stacklight is disabled.',
                 'Stacklight service is not available.',
               ],
+            },
+            hostNotFound: {
+              title: (url) => `The Prometheus API (${url}) cannot be reached.`,
+              more: () =>
+                'Check your network connection, make sure your VPN is active (if it is required to access the host), make sure the service is enabled via StackLight, and re-open this cluster page.',
+            },
+            untrustedCertificate: {
+              title: (url) =>
+                `The Prometheus API (${url}) appears to be using a self-signed certificate which cannot be verified.`,
+              more: (cloudName) =>
+                `If you trust the host, the management cluster (${cloudName}) itself must be trusted. Remove it from the extension and then re-add it, making sure the "Trust this host" option is enabled when you do (and syncing the same projects as before). Then try re-opening this cluster page.`,
+            },
+            unknownError: {
+              title: () =>
+                'An unknown network error occurred while fetching metrics. Try re-opening this cluster page again.',
             },
           },
           cpu: {

--- a/tools/scripts/test/testConfigs.mjs
+++ b/tools/scripts/test/testConfigs.mjs
@@ -169,7 +169,6 @@ export const baseConfig = function ({
       globals: {
         DEV_ENV: 'true',
         TEST_ENV: 'true',
-        FEAT_CLUSTER_PAGE_HEALTH_ENABLED: true,
       },
       transform: {
         '^.+\\.(t|j)sx?$': 'babel-jest',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,8 +3,6 @@
 //
 // Environment Variables:
 // - TARGET: Either 'development' or 'production' (default).
-// - FEAT_CLUSTER_PAGE_HEALTH_ENABLED: Set to 1 to enable the "Cluster Page > Overview > Health" panel.
-//     Disabled by default.
 // - ENTITY_CACHE_VERSION: Version to use when caching entities via the SyncManager to disk with the
 //     SyncStore. Changing this version will result in a forced update of all synced resources
 //     the next time a DataCloud connects and syncs from MCC. Defaults to the
@@ -49,10 +47,6 @@ const plugins = [
       (process.env.ENTITY_CACHE_VERSION &&
         JSON.stringify(process.env.ENTITY_CACHE_VERSION)) ||
       JSON.stringify(`v${pkg.version}:${Date.now()}`),
-
-    FEAT_CLUSTER_PAGE_HEALTH_ENABLED: JSON.stringify(
-      !!Number(process.env.FEAT_CLUSTER_PAGE_HEALTH_ENABLED)
-    ),
   }),
 ];
 


### PR DESCRIPTION
Basically, even after PRODX-28459 and MCC v2.23 with the fix, we still have 2 problems:

1. The Prometheus host uses a self-signed cert which requires the host to be trusted, which requires removing the Cloud entirely and re-adding it with "trust this host" enabled... Bad UX.
2. If the host is trusted, then we still hit a `401 Unauthorized` response from the Prometheus endpoint in spite of using brand new, certainly not expired, tokens.

Nonetheless, I was still able to move things forward a bit:

- Webpack command line switch is replaced with a soft version check, which remains disabled for now (so the Health panel will not show up unless `const showHealth = false` is set to `true` in ClusterOverview.js
- New bits and bobs added to enable the MCC version check later on (see new `// TODO[metrics]` comments).
- Fixed a bug where the Cloud instances on the RENDERER thread were missing their config objects (because Clouds on that thread are essentially slaves to their copies on the MAIN thread).
- Added some friendly network error handling to the Health panel for errors like self-signed certs, unreacheable host, and generic unknown errors.

The needle has been moved forward, but we're now blocked on new MCC bug PRODX-31468


### PR Checklist

n/a (outward behavior has not changed)
